### PR TITLE
Move Dns into Sim's shared state

### DIFF
--- a/src/builder.rs
+++ b/src/builder.rs
@@ -69,11 +69,11 @@ impl Builder {
         Sim {
             inner: Rc::new(Inner {
                 config: self.config.clone(),
+                dns: Dns::new(),
                 hosts: Default::default(),
                 topology: RefCell::new(topology),
                 rand: RefCell::new(rng),
             }),
-            dns: Dns::new(),
         }
     }
 }

--- a/src/dns.rs
+++ b/src/dns.rs
@@ -1,11 +1,9 @@
 use indexmap::IndexMap;
 use std::cell::RefCell;
 use std::net::SocketAddr;
-use std::rc::Rc;
 
-#[derive(Clone)]
 pub struct Dns {
-    inner: Rc<RefCell<Inner>>,
+    inner: RefCell<Inner>,
 }
 
 struct Inner {
@@ -20,10 +18,10 @@ pub trait ToSocketAddr {
 impl Dns {
     pub(crate) fn new() -> Dns {
         Dns {
-            inner: Rc::new(RefCell::new(Inner {
+            inner: RefCell::new(Inner {
                 next: 1,
                 names: IndexMap::new(),
-            })),
+            }),
         }
     }
 

--- a/src/host.rs
+++ b/src/host.rs
@@ -40,11 +40,7 @@ pub(crate) struct Simulated<T: Debug> {
 
 impl<T: Debug + 'static> Host<T> {
     /// Create a new simulated host in the simulated network
-    pub(crate) fn new_simulated(
-        addr: SocketAddr,
-        dns: Dns,
-        inner: &Rc<super::Inner<T>>,
-    ) -> (Host<T>, Io<T>) {
+    pub(crate) fn new_simulated(addr: SocketAddr, inner: &Rc<super::Inner<T>>) -> (Host<T>, Io<T>) {
         let rt = tokio::runtime::Builder::new_current_thread()
             .enable_time()
             .start_paused(true)
@@ -73,17 +69,12 @@ impl<T: Debug + 'static> Host<T> {
             inner: Rc::downgrade(inner),
             addr,
             inbox: rx,
-            dns,
         };
 
         (host, stream)
     }
 
-    pub(crate) fn new_client(
-        addr: SocketAddr,
-        dns: Dns,
-        inner: &Rc<super::Inner<T>>,
-    ) -> (Host<T>, Io<T>) {
+    pub(crate) fn new_client(addr: SocketAddr, inner: &Rc<super::Inner<T>>) -> (Host<T>, Io<T>) {
         let (tx, rx) = inbox::channel();
 
         let host = Host::Client {
@@ -95,7 +86,6 @@ impl<T: Debug + 'static> Host<T> {
             inner: Rc::downgrade(&inner),
             addr,
             inbox: rx,
-            dns,
         };
 
         (host, stream)

--- a/tests/hello_world.rs
+++ b/tests/hello_world.rs
@@ -1,4 +1,0 @@
-#[test]
-fn hello_world() {
-    todo!("write tests");
-}

--- a/tests/ping_pong.rs
+++ b/tests/ping_pong.rs
@@ -1,0 +1,31 @@
+use std::matches;
+use turmoil::Builder;
+
+#[derive(Debug)]
+enum Message {
+    Ping,
+    Pong,
+}
+
+#[test]
+fn ping_pong() {
+    let mut sim = Builder::new().build::<Message>();
+
+    let client = sim.client("client");
+
+    sim.register("server", |host| async move {
+        loop {
+            let (ping, src) = host.recv().await;
+            assert!(matches!(ping, Message::Ping));
+
+            host.send(src, Message::Pong);
+        }
+    });
+
+    sim.run_until(async move {
+        client.send("server", Message::Ping);
+
+        let (pong, _) = client.recv().await;
+        assert!(matches!(pong, Message::Pong));
+    });
+}


### PR DESCRIPTION
All simulation state is now housed within `Inner`.

Add a simple ping/pong test.
