### PR TITLE
remove static requirement

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,3 +24,4 @@ scoped-tls = "1.0.0"
 serde = { version = "1.0.143", features = ["derive"] }
 serde_json = "1.0.83"
 tokio = { version = "1.19.2", features = ["rt", "sync", "test-util", "time"] }
+tokio-test = { version = "0.4.2" }

--- a/src/sim.rs
+++ b/src/sim.rs
@@ -149,7 +149,6 @@ impl Sim {
         let mut task = tokio_test::task::spawn(until);
 
         let rt = Rt::new();
-        // let task = World::enter(&self.world, || rt.with(|| tokio::task::spawn_local(until)));
 
         let mut elapsed = Duration::default();
         let tick = self.config.tick;


### PR DESCRIPTION
Trying to remove the `'static` requirement while still having the `run_until` task have its own runtime.