### PR TITLE
Clean up `Sim` reference mutability

### DIFF
--- a/src/host.rs
+++ b/src/host.rs
@@ -7,8 +7,123 @@ use std::sync::Arc;
 use tokio::sync::Notify;
 use tokio::time::{Duration, Instant};
 
+/// A host in the simulated network.
+pub(crate) enum Host {
+    /// A lightweight client
+    Client(Inner),
+
+    /// A fully simulated host
+    Simulated(Inner),
+}
+
+impl Host {
+    pub(crate) fn client(addr: SocketAddr, now: Instant, notify: Arc<Notify>) -> Self {
+        Self::Client(Inner::new(addr, now, notify))
+    }
+
+    pub(crate) fn simulated(addr: SocketAddr, now: Instant, notify: Arc<Notify>) -> Self {
+        Self::Simulated(Inner::new(addr, now, notify))
+    }
+
+    pub(crate) fn now(&self) -> Instant {
+        self.host().now
+    }
+
+    /// Returns how long the host has been executing for in virtual time
+    pub(crate) fn elapsed(&self) -> Duration {
+        let inner = self.host();
+        inner.now - inner.epoch
+    }
+
+    /// Returns a dot for the host at its current version
+    pub(crate) fn dot(&self) -> version::Dot {
+        let inner = self.host();
+
+        version::Dot {
+            host: inner.addr,
+            version: inner.version,
+        }
+    }
+
+    pub(crate) fn send(&mut self, src: version::Dot, delay: Duration, message: Box<dyn Message>) {
+        let inner = self.host_mut();
+        let deliver_at = inner.now + delay;
+
+        inner
+            .inbox
+            .entry(src.host)
+            .or_default()
+            .push_back(Envelope {
+                src,
+                deliver_at,
+                message,
+            });
+
+        inner.notify.notify_one();
+    }
+
+    pub(crate) fn recv(&mut self) -> Option<Envelope> {
+        let inner = self.host_mut();
+        let now = Instant::now();
+
+        for deque in inner.inbox.values_mut() {
+            match deque.front() {
+                Some(Envelope { deliver_at, .. }) if *deliver_at <= now => {
+                    inner.version += 1;
+                    return deque.pop_front();
+                }
+                _ => continue,
+            }
+        }
+
+        None
+    }
+
+    pub(crate) fn recv_from(&mut self, peer: SocketAddr) -> Option<Envelope> {
+        let inner = self.host_mut();
+        let now = Instant::now();
+        let deque = inner.inbox.entry(peer).or_default();
+
+        match deque.front() {
+            Some(Envelope { deliver_at, .. }) if *deliver_at <= now => {
+                inner.version += 1;
+                deque.pop_front()
+            }
+            _ => None,
+        }
+    }
+
+    pub(crate) fn tick(&mut self, now: Instant) {
+        let inner = self.host_mut();
+        inner.now = now;
+
+        for deque in inner.inbox.values() {
+            if let Some(Envelope { deliver_at, .. }) = deque.front() {
+                if *deliver_at <= now {
+                    inner.notify.notify_one();
+                    return;
+                }
+            }
+        }
+    }
+
+    fn host(&self) -> &Inner {
+        match self {
+            Host::Client(i) => i,
+            Host::Simulated(i) => i,
+        }
+    }
+
+    fn host_mut(&mut self) -> &mut Inner {
+        match self {
+            Host::Client(i) => i,
+            Host::Simulated(i) => i,
+        }
+    }
+}
+
 /// A host in the simulated network
-pub(crate) struct Host {
+pub(crate) struct Inner {
     /// Host address
     addr: SocketAddr,
 
@@ -20,90 +135,23 @@ pub(crate) struct Host {
     notify: Arc<Notify>,
 
     /// Current instant at the host
-    pub(crate) now: Instant,
+    now: Instant,
 
     epoch: Instant,
 
     /// Current host version. This is incremented each time a message is received.
-    pub(crate) version: u64,
+    version: u64,
 }
 
-impl Host {
-    pub(crate) fn new(addr: SocketAddr, now: Instant, notify: Arc<Notify>) -> Host {
-        Host {
+impl Inner {
+    fn new(addr: SocketAddr, now: Instant, notify: Arc<Notify>) -> Self {
+        Self {
             addr,
             inbox: IndexMap::new(),
             notify,
             now,
             epoch: now,
             version: 0,
-        }
-    }
-
-    /// Returns how long the host has been executing for in virtual time
-    pub(crate) fn elapsed(&self) -> Duration {
-        self.now - self.epoch
-    }
-
-    /// Returns a dot for the host at its current version
-    pub(crate) fn dot(&self) -> version::Dot {
-        version::Dot {
-            host: self.addr,
-            version: self.version,
-        }
-    }
-
-    pub(crate) fn send(&mut self, src: version::Dot, delay: Duration, message: Box<dyn Message>) {
-        let deliver_at = self.now + delay;
-
-        self.inbox.entry(src.host).or_default().push_back(Envelope {
-            src,
-            deliver_at,
-            message,
-        });
-
-        self.notify.notify_one();
-    }
-
-    pub(crate) fn recv(&mut self) -> Option<Envelope> {
-        let now = Instant::now();
-
-        for deque in self.inbox.values_mut() {
-            match deque.front() {
-                Some(Envelope { deliver_at, .. }) if *deliver_at <= now => {
-                    self.version += 1;
-                    return deque.pop_front();
-                }
-                _ => continue,
-            }
-        }
-
-        None
-    }
-
-    pub(crate) fn recv_from(&mut self, peer: SocketAddr) -> Option<Envelope> {
-        let now = Instant::now();
-        let deque = self.inbox.entry(peer).or_default();
-
-        match deque.front() {
-            Some(Envelope { deliver_at, .. }) if *deliver_at <= now => {
-                self.version += 1;
-                deque.pop_front()
-            }
-            _ => None,
-        }
-    }
-
-    pub(crate) fn tick(&mut self, now: Instant) {
-        self.now = now;
-
-        for deque in self.inbox.values() {
-            if let Some(Envelope { deliver_at, .. }) = deque.front() {
-                if *deliver_at <= now {
-                    self.notify.notify_one();
-                    return;
-                }
-            }
         }
     }
 }

--- a/src/world.rs
+++ b/src/world.rs
@@ -12,7 +12,7 @@ use tokio::time::Instant;
 /// Tracks all the state for the simulated world.
 pub(crate) struct World {
     /// Tracks all individual hosts
-    pub(crate) hosts: IndexMap<SocketAddr, Host>,
+    hosts: IndexMap<SocketAddr, Host>,
 
     /// Tracks how each host is connected to each other.
     pub(crate) topology: Topology,

--- a/tests/ping_pong.rs
+++ b/tests/ping_pong.rs
@@ -1,4 +1,5 @@
-use std::matches;
+use std::{matches, time::Duration};
+use tokio::time::timeout;
 use turmoil::Builder;
 
 #[derive(Debug)]
@@ -22,11 +23,37 @@ fn ping_pong() {
         }
     });
 
-    sim.run_until(async move {
+    sim.run_until(async {
         client.send("server", Message::Ping);
 
         let (pong, _) = client.recv().await;
         assert!(matches!(pong, Message::Pong));
+    });
+}
+
+#[test]
+fn network_partition() {
+    let mut sim = Builder::new().build();
+
+    let client = sim.client("client");
+
+    sim.register("server", |host| async move {
+        loop {
+            let (ping, src) = host.recv().await;
+            assert!(matches!(ping, Message::Ping));
+
+            host.send(src, Message::Pong);
+        }
+    });
+
+    sim.run_until(async {
+        // introduce the partition
+        sim.partition("client", "server");
+
+        client.send("server", Message::Ping);
+
+        let res = timeout(Duration::from_secs(1), client.recv()).await;
+        assert!(matches!(res, Err(_)));
     });
 }
 


### PR DESCRIPTION
Allows for immutable access to `Sim` from within `run_until`.
