### PR TITLE
Fix termination bug in Sim::run()

### DIFF
--- a/src/sim.rs
+++ b/src/sim.rs
@@ -162,7 +162,7 @@ impl Sim {
         let tick = self.config.tick;
 
         loop {
-            let mut is_finished = false;
+            let mut is_finished = true;
 
             for (&addr, rt) in self.rts.iter() {
                 // Set the current host
@@ -177,7 +177,7 @@ impl Sim {
                 world.tick(addr, now);
 
                 if let Role::Client { handle, .. } = rt {
-                    is_finished = handle.is_finished();
+                    is_finished = is_finished && handle.is_finished();
                 }
             }
 

--- a/tests/ping_pong.rs
+++ b/tests/ping_pong.rs
@@ -1,6 +1,6 @@
-use std::{matches, time::Duration};
-use tokio::time::timeout;
-use turmoil::Builder;
+use std::{matches, rc::Rc, time::Duration};
+use tokio::{sync::Semaphore, time::timeout};
+use turmoil::{Builder, Io};
 
 #[derive(Debug)]
 enum Message {
@@ -61,4 +61,34 @@ fn network_partition() {
     });
 
     sim.run();
+}
+
+#[test]
+fn multiple_clients_all_finish() {
+    let how_many = 3;
+    let tick_ms = 10;
+
+    // N = how_many runs, each with a different client finishing immediately
+    for run in 0..how_many {
+        let mut sim = Builder::new()
+            .tick_duration(Duration::from_millis(tick_ms))
+            .build();
+
+        let ct = Rc::new(Semaphore::new(how_many));
+
+        for client in 0..how_many {
+            let ct = ct.clone();
+
+            sim.client(format!("client-{}", client), |_: Io<Message>| async move {
+                let ms = if run == client { 0 } else { 2 * tick_ms };
+                tokio::time::sleep(Duration::from_millis(ms)).await;
+
+                let p = ct.acquire().await.unwrap();
+                p.forget();
+            });
+        }
+
+        sim.run();
+        assert_eq!(0, ct.available_permits());
+    }
 }


### PR DESCRIPTION
The flag for `is_finished` needs to ensure *all* clients are finished
rather than just the last one.
