### PR TITLE
Add distinct connections over Io

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,7 +24,7 @@ rand_distr = "0.4.3"
 scoped-tls = "1.0.0"
 serde = { version = "1.0.143", features = ["derive"] }
 serde_json = "1.0.83"
-tokio = { version = "1.19.2", features = ["rt", "sync", "test-util", "time"] }
+tokio = { version = "1.19.2", features = ["full"] }
 tokio-stream = "0.1.9"
 tokio-test = { version = "0.4.2" }
 unicycle = "0.9.2"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,6 +17,7 @@ keywords = ["Deterministic", "Simulation", "Testing"]
 categories = ["asynchronous", "network-programming", "simulation"]
 
 [dependencies]
+futures = "0.3"
 indexmap = "1.9"
 rand = { version = "0.8.5", features = ["small_rng"] }
 rand_distr = "0.4.3"
@@ -24,4 +25,6 @@ scoped-tls = "1.0.0"
 serde = { version = "1.0.143", features = ["derive"] }
 serde_json = "1.0.83"
 tokio = { version = "1.19.2", features = ["rt", "sync", "test-util", "time"] }
+tokio-stream = "0.1.9"
 tokio-test = { version = "0.4.2" }
+unicycle = "0.9.2"

--- a/src/connection.rs
+++ b/src/connection.rs
@@ -8,7 +8,7 @@ use tokio::sync::{mpsc, oneshot};
 use tokio_stream::wrappers::ReceiverStream;
 
 /// A connection between two hosts.
-pub struct Connection<M: Message> {
+pub struct Connection<M> {
     /// Connection identification information
     info: ConnectionInfo,
 
@@ -19,7 +19,7 @@ pub struct Connection<M: Message> {
     tx: mpsc::Sender<(ConnectionInfo, M)>,
 }
 
-impl<M: Message> Connection<M> {
+impl<M> Connection<M> {
     /// Send a message.
     ///
     /// # Errors
@@ -90,7 +90,7 @@ struct ConnectionInfo {
     peer: SocketAddr,
 }
 
-enum Action<M: Message> {
+enum Action<M> {
     /// Accept a new connection
     Accept(ConnectionInfo),
 
@@ -251,7 +251,7 @@ impl<M: Message> Inner<M> {
 }
 
 /// Connection state management.
-struct Connections<M: Message> {
+struct Connections<M> {
     // State for each connection
     by_info: IndexMap<ConnectionInfo, ConnectionState<M>>,
 
@@ -262,7 +262,7 @@ struct Connections<M: Message> {
     receivers: unicycle::IndexedStreamsUnordered<ReceiverStream<(ConnectionInfo, M)>>,
 }
 
-enum ConnectionState<M: Message> {
+enum ConnectionState<M> {
     /// Connection initiated; awaiting syn-ack
     New {
         recv_idx: usize,
@@ -283,7 +283,7 @@ enum ConnectionState<M: Message> {
     },
 }
 
-impl<M: Message> Display for ConnectionState<M> {
+impl<M> Display for ConnectionState<M> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
             ConnectionState::New { .. } => write!(f, "New"),
@@ -293,7 +293,7 @@ impl<M: Message> Display for ConnectionState<M> {
     }
 }
 
-impl<M: Message> Connections<M> {
+impl<M> Connections<M> {
     fn new() -> Self {
         Self {
             by_info: IndexMap::new(),

--- a/src/connection.rs
+++ b/src/connection.rs
@@ -1,0 +1,430 @@
+use crate::*;
+
+use std::{fmt::Display, io, net::SocketAddr};
+
+use futures::FutureExt;
+use indexmap::IndexMap;
+use tokio::sync::{mpsc, oneshot};
+use tokio_stream::wrappers::ReceiverStream;
+
+/// A connection between two hosts.
+pub struct Connection<M: Message> {
+    /// Connection identification information
+    info: ConnectionInfo,
+
+    /// Message receiver
+    rx: mpsc::Receiver<M>,
+
+    /// Message sender; ConnectionInfo is included for routing
+    tx: mpsc::Sender<(ConnectionInfo, M)>,
+}
+
+impl<M: Message> Connection<M> {
+    /// Send a message.
+    ///
+    /// # Errors
+    ///
+    /// If the connection is reset by the peer an I/O error will be returned.
+    pub async fn send(&self, message: M) -> io::Result<()> {
+        if let Err(_) = self.tx.send((self.info, message)).await {
+            return Err(io::Error::from(io::ErrorKind::ConnectionReset));
+        }
+
+        Ok(())
+    }
+
+    /// Receive a message.
+    ///
+    /// # Errors
+    ///
+    /// If the connection is reset by the peer an I/O error will be returned.
+    pub async fn recv(&mut self) -> io::Result<M> {
+        self.rx
+            .recv()
+            .await
+            .ok_or_else(|| io::Error::from(io::ErrorKind::ConnectionReset))
+    }
+}
+
+#[derive(Debug)]
+pub enum Segment<M: Message> {
+    /// Initiate a new connection
+    Syn(u64),
+
+    /// Accept a new connection
+    SynAck(u64),
+
+    /// Send a message on an established connection
+    Data(u64, M),
+
+    /// Connection reset
+    Rst(u64),
+}
+
+impl<M: Message> Message for Segment<M> {
+    fn write_json(&self, dst: &mut dyn std::io::Write) {
+        match self {
+            Segment::Syn(_) => write!(dst, "Syn").unwrap(),
+            Segment::SynAck(_) => write!(dst, "SynAck").unwrap(),
+            Segment::Data(_, m) => m.write_json(dst),
+            Segment::Rst(_) => write!(dst, "Rst").unwrap(),
+        };
+    }
+}
+
+/// Layers distinct connections over a host's [`Io`].
+pub struct ConnectionIo<M: Message> {
+    /// Accept queue
+    queue: mpsc::Receiver<Connection<M>>,
+
+    /// Action sender
+    sender: mpsc::Sender<Action<M>>,
+}
+
+#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
+struct ConnectionInfo {
+    /// A unique identifier for each connection
+    id: u64,
+
+    /// Address of the peer on the other end
+    peer: SocketAddr,
+}
+
+enum Action<M: Message> {
+    /// Accept a new connection
+    Accept(ConnectionInfo),
+
+    /// Initiate a new connection
+    Connect {
+        dst: SocketAddr,
+        notify: oneshot::Sender<Connection<M>>,
+    },
+}
+
+impl<M: Message> ConnectionIo<M> {
+    pub fn new(io: Io<Segment<M>>) -> Self {
+        let (action_tx, action_rx) = mpsc::channel(1);
+        let (accept_tx, accept_rx) = mpsc::channel(1);
+
+        let inner = Inner {
+            ctr: 0,
+            connections: Connections::new(),
+            io,
+            queue: accept_tx,
+            receiver: action_rx,
+        };
+
+        tokio::task::spawn_local(Self::event_loop(inner));
+
+        Self {
+            queue: accept_rx,
+            sender: action_tx,
+        }
+    }
+
+    /// Accepts a new incoming connection.
+    pub async fn accept(&mut self) -> Option<Connection<M>> {
+        match self.queue.recv().await {
+            Some(c) => {
+                let _ = self.sender.send(Action::Accept(c.info.clone())).await;
+                Some(c)
+            }
+            None => None,
+        }
+    }
+
+    /// Opens a connection to a peer.
+    pub async fn connect(&self, to: impl ToSocketAddr) -> io::Result<Connection<M>> {
+        let dst = World::current(|world| world.lookup(to));
+
+        let (tx, rx) = oneshot::channel();
+        let _ = self.sender.send(Action::Connect { dst, notify: tx }).await;
+
+        rx.await
+            .map_err(|_| io::Error::from(io::ErrorKind::ConnectionRefused))
+    }
+
+    async fn event_loop(mut inner: Inner<M>) {
+        loop {
+            futures::select_biased! {
+                maybe_action = inner.receiver.recv().fuse() => match maybe_action {
+                    Some(action) => match action {
+                        Action::Accept(info) => inner.accept(info),
+                        Action::Connect { dst, notify } => inner.connect(dst, notify),
+                    },
+                    None => break,
+                },
+                recv = inner.connections.receivers.next() => {
+                    match recv {
+                        Some((idx, maybe_msg)) => match maybe_msg {
+                            Some((info, msg)) => inner.send(info, msg),
+                            None => inner.rst(idx),
+                        },
+                        None => continue,
+                    }
+                },
+                (seg, src) = inner.io.recv().fuse() => inner.route(src, seg).await,
+            }
+        }
+
+        inner.rst_all();
+    }
+}
+
+struct Inner<M: Message> {
+    /// Dense counter for connection identifiers
+    ctr: u64,
+
+    /// Active connections
+    connections: Connections<M>,
+
+    /// Underlying Io
+    io: Io<Segment<M>>,
+
+    /// Accept queue
+    queue: mpsc::Sender<Connection<M>>,
+
+    /// Action receiver
+    receiver: mpsc::Receiver<Action<M>>,
+}
+
+impl<M: Message> Inner<M> {
+    fn accept(&mut self, info: ConnectionInfo) {
+        self.connections.accept(info);
+        self.io.send(info.peer, Segment::SynAck(info.id));
+    }
+
+    fn connect(&mut self, dst: SocketAddr, notify: oneshot::Sender<Connection<M>>) {
+        self.ctr += 1;
+        let id = self.ctr;
+
+        self.connections.connect(id, dst, notify);
+        self.io.send(dst, Segment::Syn(id));
+    }
+
+    fn send(&self, info: ConnectionInfo, message: M) {
+        self.connections.check_connected(&info);
+
+        let ConnectionInfo { id, peer } = info;
+        self.io.send(peer, Segment::Data(id, message))
+    }
+
+    async fn route(&mut self, from: SocketAddr, seg: Segment<M>) {
+        match seg {
+            Segment::Syn(id) => {
+                let connection = self
+                    .connections
+                    .register_for_accept(ConnectionInfo { id, peer: from });
+                let _ = self.queue.send(connection).await;
+            }
+            Segment::SynAck(id) => self
+                .connections
+                .finish_connect(ConnectionInfo { id, peer: from }),
+            Segment::Data(id, message) => {
+                self.connections
+                    .recv(ConnectionInfo { id, peer: from }, message)
+                    .await
+            }
+            Segment::Rst(id) => {
+                let _ = self
+                    .connections
+                    .disconnect(ConnectionInfo { id, peer: from });
+            }
+        }
+    }
+
+    fn rst(&mut self, idx: usize) {
+        if let Some(info) = self.connections.deregister(idx) {
+            self.io.send(info.peer, Segment::Rst(info.id))
+        }
+    }
+
+    fn rst_all(&mut self) {
+        let Connections { by_info, .. } = &self.connections;
+
+        by_info.iter().for_each(|(info, s)| {
+            if let ConnectionState::Queued { .. } | ConnectionState::Connected { .. } = s {
+                self.io.send(info.peer, Segment::Rst(info.id))
+            }
+        });
+    }
+}
+
+/// Connection state management.
+struct Connections<M: Message> {
+    // State for each connection
+    by_info: IndexMap<ConnectionInfo, ConnectionState<M>>,
+
+    /// Receiver index to ConnectionInfo
+    by_idx: IndexMap<usize, ConnectionInfo>,
+
+    /// Connection message receivers
+    receivers: unicycle::IndexedStreamsUnordered<ReceiverStream<(ConnectionInfo, M)>>,
+}
+
+enum ConnectionState<M: Message> {
+    /// Connection initiated; awaiting syn-ack
+    New {
+        recv_idx: usize,
+        sender: mpsc::Sender<(ConnectionInfo, M)>,
+        notify: oneshot::Sender<Connection<M>>,
+    },
+
+    /// Syn received; awaiting accept
+    Queued {
+        sender: mpsc::Sender<M>,
+        receiver: mpsc::Receiver<(ConnectionInfo, M)>,
+    },
+
+    /// Connected! Data segments may flow in both directions
+    Connected {
+        recv_idx: usize,
+        sender: mpsc::Sender<M>,
+    },
+}
+
+impl<M: Message> Display for ConnectionState<M> {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            ConnectionState::New { .. } => write!(f, "New"),
+            ConnectionState::Queued { .. } => write!(f, "Queued"),
+            ConnectionState::Connected { .. } => write!(f, "Connected"),
+        }
+    }
+}
+
+impl<M: Message> Connections<M> {
+    fn new() -> Self {
+        Self {
+            by_info: IndexMap::new(),
+            by_idx: IndexMap::new(),
+            receivers: unicycle::IndexedStreamsUnordered::new(),
+        }
+    }
+
+    fn check_connected(&self, info: &ConnectionInfo) {
+        if let ConnectionState::New { .. } | ConnectionState::Queued { .. } = self.by_info[info] {
+            panic!("not connected: {:?}", info)
+        }
+    }
+
+    fn accept(&mut self, info: ConnectionInfo) {
+        let (tx, rx) = match self
+            .by_info
+            .remove(&info)
+            .expect(&format!("not registered: {:?}", info))
+        {
+            ConnectionState::Queued { sender, receiver } => (sender, receiver),
+            other => panic!("invalid state: {}, {:?}", other, info),
+        };
+
+        let idx = self.receivers.push(ReceiverStream::new(rx));
+        self.by_idx.insert(idx, info);
+
+        self.by_info.insert(
+            info,
+            ConnectionState::Connected {
+                recv_idx: idx,
+                sender: tx,
+            },
+        );
+    }
+
+    fn register_for_accept(&mut self, info: ConnectionInfo) -> Connection<M> {
+        if self.by_info.contains_key(&info) {
+            panic!("already registered: {:?}", info);
+        }
+
+        let (send_tx, send_rx) = mpsc::channel(1);
+        let (recv_tx, recv_rx) = mpsc::channel(1);
+
+        let queued = ConnectionState::Queued {
+            sender: recv_tx,
+            receiver: send_rx,
+        };
+
+        self.by_info.insert(info, queued);
+
+        Connection {
+            info,
+            rx: recv_rx,
+            tx: send_tx,
+        }
+    }
+
+    fn connect(&mut self, id: u64, dst: SocketAddr, notify: oneshot::Sender<Connection<M>>) {
+        let info = ConnectionInfo { id, peer: dst };
+
+        let (tx, rx) = mpsc::channel(1);
+        let idx = self.receivers.push(ReceiverStream::new(rx));
+        let new = ConnectionState::New {
+            recv_idx: idx,
+            sender: tx,
+            notify,
+        };
+
+        self.by_idx.insert(idx, info);
+        self.by_info.insert(info, new);
+    }
+
+    fn finish_connect(&mut self, info: ConnectionInfo) {
+        let (recv_idx, send_tx, notify) = match self
+            .by_info
+            .remove(&info)
+            .expect(&format!("not registered: {:?}", info))
+        {
+            ConnectionState::New {
+                recv_idx,
+                sender,
+                notify,
+            } => (recv_idx, sender, notify),
+            other => panic!("invalid state: {}, {:?}", other, info),
+        };
+
+        let (recv_tx, recv_rx) = mpsc::channel(1);
+        let connection = Connection {
+            info,
+            rx: recv_rx,
+            tx: send_tx,
+        };
+
+        self.by_info.insert(
+            info,
+            ConnectionState::Connected {
+                recv_idx,
+                sender: recv_tx,
+            },
+        );
+
+        let _ = notify.send(connection);
+    }
+
+    async fn recv(&self, info: ConnectionInfo, message: M) {
+        match &self.by_info[&info] {
+            ConnectionState::Connected { sender, .. } => {
+                let _ = sender.send(message).await;
+            }
+            other => panic!("invalid state: {}, {:?}", other, info),
+        }
+    }
+
+    fn deregister(&mut self, idx: usize) -> Option<ConnectionInfo> {
+        let info = self.by_idx.remove(&idx)?;
+        self.by_info.remove(&info)?;
+
+        Some(info)
+    }
+
+    fn disconnect(&mut self, info: ConnectionInfo) -> Option<()> {
+        let idx = match self.by_info.remove(&info)? {
+            ConnectionState::New { recv_idx, .. } => Some(recv_idx),
+            ConnectionState::Connected { recv_idx, .. } => Some(recv_idx),
+            _ => None,
+        }?;
+
+        let recv = self.receivers.get_mut(idx)?;
+        recv.close();
+
+        Some(())
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -5,6 +5,11 @@ pub use builder::Builder;
 mod config;
 use config::Config;
 
+mod connection;
+pub use connection::Connection;
+pub use connection::ConnectionIo;
+pub use connection::Segment;
+
 mod dns;
 use dns::Dns;
 pub use dns::ToSocketAddr;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -6,9 +6,7 @@ mod config;
 use config::Config;
 
 mod connection;
-pub use connection::Connection;
-pub use connection::ConnectionIo;
-pub use connection::Segment;
+pub use connection::{Connection, ConnectionIo, Segment};
 
 mod dns;
 use dns::Dns;

--- a/tests/connections.rs
+++ b/tests/connections.rs
@@ -1,0 +1,195 @@
+use std::sync::Arc;
+
+use tokio::sync::Notify;
+use turmoil::{Builder, ConnectionIo};
+
+#[derive(Debug, serde::Serialize)]
+enum Message {
+    Ping { how_many: u16 },
+    Pong,
+}
+
+impl turmoil::Message for Message {
+    fn write_json(&self, dst: &mut dyn std::io::Write) {
+        serde_json::to_writer_pretty(dst, self).unwrap()
+    }
+}
+
+#[test]
+#[should_panic]
+fn unknown_host() {
+    let mut sim = Builder::new().build();
+
+    sim.client("client", |io| async {
+        let io: ConnectionIo<Message> = ConnectionIo::new(io);
+        let _ = io.connect("foo").await;
+    });
+
+    sim.run();
+}
+
+#[test]
+fn n_responses() {
+    let mut sim = Builder::new().build();
+
+    sim.register("server", |io| async move {
+        let mut io: ConnectionIo<Message> = ConnectionIo::new(io);
+
+        while let Some(mut c) = io.accept().await {
+            tokio::spawn(async move {
+                while let Ok(Message::Ping { how_many }) = c.recv().await {
+                    for _ in 0..how_many {
+                        let _ = c.send(Message::Pong).await;
+                    }
+                }
+            });
+        }
+    });
+
+    sim.client("client", |io| async move {
+        let io: ConnectionIo<Message> = ConnectionIo::new(io);
+        let mut c = io.connect("server").await.unwrap();
+
+        let how_many = 3;
+        let _ = c.send(Message::Ping { how_many }).await;
+
+        for _ in 0..how_many {
+            let m = c.recv().await;
+            assert!(matches!(m, Ok(Message::Pong)));
+        }
+    });
+
+    sim.run();
+}
+
+#[test]
+fn server_concurrency() {
+    let mut sim = Builder::new().build();
+
+    sim.register("server", |io| async move {
+        let mut io: ConnectionIo<Message> = ConnectionIo::new(io);
+
+        while let Some(mut c) = io.accept().await {
+            tokio::spawn(async move {
+                while let Ok(Message::Ping { how_many }) = c.recv().await {
+                    for _ in 0..how_many {
+                        let _ = c.send(Message::Pong).await;
+                    }
+                }
+            });
+        }
+    });
+
+    let how_many = 3;
+
+    for i in 0..how_many {
+        sim.client(format!("client-{}", i), |io| async move {
+            let io: ConnectionIo<Message> = ConnectionIo::new(io);
+            let mut c = io.connect("server").await.unwrap();
+
+            let _ = c.send(Message::Ping { how_many }).await;
+
+            for _ in 0..how_many {
+                let m = c.recv().await;
+                assert!(matches!(m, Ok(Message::Pong)));
+            }
+        });
+    }
+
+    sim.run();
+}
+
+#[test]
+fn client_hangup() {
+    let mut sim = Builder::new().build();
+
+    let wait = Arc::new(Notify::new());
+    let notify = wait.clone();
+
+    sim.client("bob", |io| async move {
+        let mut io: ConnectionIo<Message> = ConnectionIo::new(io);
+        let mut c = io.accept().await.unwrap();
+
+        assert!(c.recv().await.is_err());
+        assert!(c.send(Message::Ping { how_many: 1 }).await.is_err());
+
+        notify.notify_one();
+    });
+
+    sim.client("sally", |io| async move {
+        let io: ConnectionIo<Message> = ConnectionIo::new(io);
+        let _ = io.connect("bob").await;
+
+        wait.notified().await;
+    });
+
+    sim.run();
+}
+
+#[test]
+fn server_hangup() {
+    let mut sim = Builder::new().build();
+
+    sim.register("server", |io| async move {
+        let mut io: ConnectionIo<Message> = ConnectionIo::new(io);
+
+        while let Some(c) = io.accept().await {
+            drop(c);
+        }
+    });
+
+    sim.client("client", |io| async move {
+        let io: ConnectionIo<Message> = ConnectionIo::new(io);
+
+        let mut c = io.connect("server").await.unwrap();
+
+        assert!(c.recv().await.is_err());
+        assert!(c.send(Message::Ping { how_many: 1 }).await.is_err());
+    });
+
+    sim.run();
+}
+
+#[test]
+fn drop_io() {
+    let mut sim = Builder::new().build();
+
+    let how_many = 3;
+
+    let wait = Arc::new(Notify::new());
+    let notify = wait.clone();
+
+    sim.register("server", |io| async move {
+        let mut io: ConnectionIo<Message> = ConnectionIo::new(io);
+
+        for _ in 0..how_many {
+            let mut c = io.accept().await.unwrap();
+
+            tokio::spawn(async move {
+                let _ = c.recv().await;
+            });
+        }
+
+        drop(io);
+        notify.notify_one();
+    });
+
+    sim.client("client", |io| async move {
+        let io: ConnectionIo<Message> = ConnectionIo::new(io);
+
+        let mut conns = vec![];
+
+        for _ in 0..how_many {
+            conns.push(io.connect("server").await.unwrap());
+        }
+
+        wait.notified().await;
+
+        for mut c in conns {
+            assert!(c.recv().await.is_err());
+            assert!(c.send(Message::Ping { how_many: 1 }).await.is_err());
+        }
+    });
+
+    sim.run();
+}


### PR DESCRIPTION
Real world servers often use concurrency for processing requests.
Protocols also lean on message ordering per connection, ie TCP. Neither
of these features were available with the current `Io` implementation.

This change overlays connection support on top of `Io` by multiplexing
through an actor. A simple TCP-like state machine is used to initiate and
accept connections.
