### PR TITLE
Move io to free functions

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ turmoil = "0.2"
 Next, create a test file and add a test:
 
 ```rust
-use turmoil::{Builder, Io};
+use turmoil::{io, Builder};
 
 #[derive(Debug)]
 struct Echo(String);
@@ -42,18 +42,18 @@ fn simulation() {
     let mut sim = Builder::new().build();
 
     // register a host
-    sim.register("server", |host: Io<Echo>| async move {
+    sim.host("server", async {
         loop {
-            let (msg, src) = host.recv().await;
-            host.send(src, msg);
+            let (msg, src) = io::recv::<Echo>().await;
+            io::send(src, msg);
         }
     });
 
     // register a client (this is the test code)
-    sim.client("client", |host: Io<Echo>| async move {
-        host.send("server", Echo("hello, server!".to_string()));
+    sim.client("client", async {
+        io::send("server", Echo("hello, server!".to_string()));
 
-        let (echo, _) = host.recv().await;
+        let (echo, _) = io::recv::<Echo>().await;
         assert_eq!("hello, server!", echo.0);
     });
 

--- a/src/host.rs
+++ b/src/host.rs
@@ -10,14 +10,14 @@ use tokio::time::{Duration, Instant};
 /// A host in the simulated network
 pub(crate) struct Host {
     /// Host address
-    addr: SocketAddr,
+    pub(crate) addr: SocketAddr,
 
     /// Messages in-flight to the host. Some of these may still be "on the
     /// network".
     inbox: IndexMap<SocketAddr, VecDeque<Envelope>>,
 
     /// Signaled when a message becomes available to receive
-    notify: Arc<Notify>,
+    pub(crate) notify: Arc<Notify>,
 
     /// Current instant at the host
     pub(crate) now: Instant,

--- a/src/io.rs
+++ b/src/io.rs
@@ -1,94 +1,57 @@
-use crate::{message, Message, ToSocketAddr, World};
+use crate::{lookup, message, Message, ToSocketAddr, World};
 
 use std::net::SocketAddr;
-use std::sync::Arc;
-use tokio::sync::Notify;
 
-pub struct Io<M: Message> {
-    /// The address also serves as the identifier to access host state from the
-    /// world.
-    addr: SocketAddr,
+/// Send a message to `dst`.
+///
+/// Must be called from a host within a Turmoil simulation.
+pub fn send<M: Message>(dst: impl ToSocketAddr, message: M) {
+    World::current(|world| {
+        let dst = world.lookup(dst);
 
-    /// Signaled when a new message becomes ready to consume.
-    notify: Arc<Notify>,
-
-    _p: std::marker::PhantomData<M>,
+        world.send(dst, Box::new(message));
+    });
 }
 
-impl<M: Message> Io<M> {
-    pub(crate) fn new(addr: SocketAddr, notify: Arc<Notify>) -> Io<M> {
-        Io {
-            addr,
-            notify,
-            _p: std::marker::PhantomData,
-        }
-    }
+/// Receive a message.
+///
+/// Must be called from a host within a Turmoil simulation.
+pub async fn recv<M: Message>() -> (M, SocketAddr) {
+    loop {
+        let (maybe_envelope, notify) = World::current(|world| {
+            let host = world.current_host();
+            let notify = host.notify.clone();
 
-    /// Return the socket address associated with this `Io`
-    pub fn local_addr(&self) -> SocketAddr {
-        self.addr
-    }
-
-    pub fn send(&self, dst: impl ToSocketAddr, message: M) {
-        World::current(|world| {
-            let dst = world.lookup(dst);
-
-            world.send(self.addr, dst, Box::new(message));
+            (world.recv(host.addr), notify)
         });
-    }
 
-    pub async fn recv(&self) -> (M, SocketAddr) {
-        loop {
-            let maybe_envelope = World::current(|world| {
-                if let Some(current) = world.current {
-                    assert_eq!(current, self.addr);
-                }
-
-                world.recv(self.addr)
-            });
-
-            if let Some(envelope) = maybe_envelope {
-                let message = message::downcast::<M>(envelope.message);
-                return (message, envelope.src.host);
-            }
-
-            self.notify.notified().await;
+        if let Some(envelope) = maybe_envelope {
+            let message = message::downcast::<M>(envelope.message);
+            return (message, envelope.src.host);
         }
-    }
 
-    /// Receive a message from the specific host
-    pub async fn recv_from(&self, peer: impl ToSocketAddr) -> M {
-        let peer = self.lookup(peer);
-
-        loop {
-            let maybe_envelope = World::current(|world| {
-                if let Some(current) = world.current {
-                    assert_eq!(current, self.addr);
-                }
-
-                world.recv_from(self.addr, peer)
-            });
-
-            if let Some(envelope) = maybe_envelope {
-                return message::downcast::<M>(envelope.message);
-            }
-
-            self.notify.notified().await;
-        }
-    }
-
-    /// Lookup a socket address by host name.
-    pub fn lookup(&self, addr: impl ToSocketAddr) -> SocketAddr {
-        World::current(|world| world.lookup(addr))
+        notify.notified().await;
     }
 }
 
-impl<M: Message> Clone for Io<M> {
-    fn clone(&self) -> Io<M> {
-        Io {
-            addr: self.addr,
-            notify: self.notify.clone(),
-            _p: std::marker::PhantomData,
+/// Receive a message from `peer`.
+///
+/// Must be called from a host within a Turmoil simulation.
+pub async fn recv_from<M: Message>(peer: impl ToSocketAddr) -> M {
+    let peer = lookup(peer);
+
+    loop {
+        let (maybe_envelope, notify) = World::current(|world| {
+            let host = world.current_host();
+            let notify = host.notify.clone();
+
+            (world.recv_from(host.addr, peer), notify)
+        });
+
+        if let Some(envelope) = maybe_envelope {
+            return message::downcast::<M>(envelope.message);
         }
+
+        notify.notified().await;
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,7 @@
 mod builder;
 
+use std::net::SocketAddr;
+
 pub use builder::Builder;
 
 mod config;
@@ -18,8 +20,7 @@ use envelope::Envelope;
 mod host;
 use host::Host;
 
-mod io;
-pub use io::Io;
+pub mod io;
 
 mod log;
 use log::Log;
@@ -43,6 +44,13 @@ mod version;
 
 mod world;
 use world::World;
+
+/// Lookup a socket address by host name.
+///
+/// Must be called from within a Turmoil simulation.
+pub fn lookup(addr: impl ToSocketAddr) -> SocketAddr {
+    World::current(|world| world.lookup(addr))
+}
 
 /// Partition two hosts, resulting in all messages sent between them to be
 /// dropped.

--- a/src/world.rs
+++ b/src/world.rs
@@ -58,6 +58,12 @@ impl World {
         CURRENT.set(world, f)
     }
 
+    /// Return a reference to the currently executing host
+    pub(crate) fn current_host(&self) -> &Host {
+        let addr = self.current.expect("current host missing");
+        self.hosts.get(&addr).expect("host missing")
+    }
+
     /// Return a reference to the host
     pub(crate) fn host(&self, addr: SocketAddr) -> &Host {
         self.hosts.get(&addr).expect("host missing")
@@ -92,7 +98,9 @@ impl World {
     }
 
     /// Send a message between two hosts
-    pub(crate) fn send(&mut self, host: SocketAddr, dst: SocketAddr, message: Box<dyn Message>) {
+    pub(crate) fn send(&mut self, dst: SocketAddr, message: Box<dyn Message>) {
+        let host = self.current.expect("host is not set");
+
         if let Some(delay) = self.topology.send_delay(&mut self.rng, host, dst) {
             let host = &self.hosts[&host];
             let dot = host.dot();

--- a/src/world.rs
+++ b/src/world.rs
@@ -99,7 +99,7 @@ impl World {
 
     /// Send a message between two hosts
     pub(crate) fn send(&mut self, dst: SocketAddr, message: Box<dyn Message>) {
-        let host = self.current.expect("host is not set");
+        let host = self.current_host().addr;
 
         if let Some(delay) = self.topology.send_delay(&mut self.rng, host, dst) {
             let host = &self.hosts[&host];


### PR DESCRIPTION
This approach has a few advantages:

- Less restrictive typing: send and recv can have different
message types.
- Simpler registration and io access for hosts.
- Opens the door for free functions that allow connecting and
accepting connections.
