### PR TITLE
Allow pause/resume of hosts

### DIFF
--- a/src/host.rs
+++ b/src/host.rs
@@ -22,6 +22,10 @@ pub(crate) struct Host {
     /// Current instant at the host
     pub(crate) now: Instant,
 
+    /// When true, this host is playing Go Fish and doesn't do any work. This
+    /// allows simulation of arbitrary and complete pauses.
+    pub(crate) gone_fishing: bool,
+
     epoch: Instant,
 
     /// Current host version. This is incremented each time a message is received.
@@ -35,6 +39,7 @@ impl Host {
             inbox: IndexMap::new(),
             notify,
             now,
+            gone_fishing: false,
             epoch: now,
             version: 0,
         }
@@ -66,6 +71,10 @@ impl Host {
     }
 
     pub(crate) fn recv(&mut self) -> Option<Envelope> {
+        // When the simulation correctly pauses a host, it should never schedule
+        // any code that can receive messages while the host is taking a break.
+        assert!(!self.gone_fishing);
+
         let now = Instant::now();
 
         for deque in self.inbox.values_mut() {
@@ -95,6 +104,9 @@ impl Host {
     }
 
     pub(crate) fn tick(&mut self, now: Instant) {
+        // Don't you even dare ask me to tick.
+        assert!(!self.gone_fishing);
+
         self.now = now;
 
         for deque in self.inbox.values() {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -65,6 +65,23 @@ pub fn partition(a: impl ToSocketAddr, b: impl ToSocketAddr) {
     })
 }
 
+/// Pause a host. No futures will run, and time will not move forward.
+pub fn pause(h: impl ToSocketAddr) {
+    World::current(|world| {
+        let h = world.lookup(h);
+        world.pause(h);
+    });
+}
+
+/// The opposite of [`pause`]. While time will resume on the host, it probably
+/// now won't be the same as that of other hosts.
+pub fn resume(h: impl ToSocketAddr) {
+    World::current(|world| {
+        let h = world.lookup(h);
+        world.resume(h);
+    });
+}
+
 /// Repair the connection between two hosts, resulting in messages to be
 /// delivered.
 ///

--- a/src/sim.rs
+++ b/src/sim.rs
@@ -155,6 +155,10 @@ impl Sim {
             let mut is_finished = true;
 
             for (&addr, rt) in self.rts.iter() {
+                if self.world.borrow().host(addr).gone_fishing {
+                    continue;
+                }
+
                 // Set the current host
                 self.world.borrow_mut().current = Some(addr);
 

--- a/src/world.rs
+++ b/src/world.rs
@@ -81,6 +81,20 @@ impl World {
         self.topology.repair(a, b);
     }
 
+    pub(crate) fn pause(&mut self, addr: SocketAddr) {
+        self.hosts
+            .get_mut(&addr)
+            .expect("host missing")
+            .gone_fishing = true;
+    }
+
+    pub(crate) fn resume(&mut self, addr: SocketAddr) {
+        self.hosts
+            .get_mut(&addr)
+            .expect("host missing")
+            .gone_fishing = false;
+    }
+
     /// Register a new host with the simulation
     pub(crate) fn register(&mut self, addr: SocketAddr, epoch: Instant, notify: Arc<Notify>) {
         assert!(


### PR DESCRIPTION
The idea here is to simulate a host *completely* locking up. This could
be due to a hardware fault. When a host locks up, often it doesn't even
know that it did. For example, it may think only 1 second has elapsed
when minutes may have.

In the real world, something like NTP would eventually clue the host in
to the problem.

There is a small test. If you interrogate `Instant::now` on both hosts,
you'll see that the server (which is paused) thinks this test only takes
5ms, while the client thinks it takes over a second.

I'm not sure we actually want to merge this feature yet. I more wrote it
to understand how things were fitting together.

See also: https://questforglory.fandom.com/wiki/Butcher_Shop