### PR TITLE
Implement hold and release, impls #11

### DIFF
--- a/src/envelope.rs
+++ b/src/envelope.rs
@@ -6,8 +6,8 @@ pub(crate) struct Envelope {
     /// Who sent the message
     pub(crate) src: version::Dot,
 
-    /// When to deliver the message
-    pub(crate) deliver_at: Instant,
+    /// When to deliver the message. If `None`, the message is stuck without an ETA.
+    pub(crate) deliver_at: Option<Instant>,
 
     /// Message value
     pub(crate) message: Box<dyn Message>,

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -52,6 +52,30 @@ pub fn lookup(addr: impl ToSocketAddr) -> SocketAddr {
     World::current(|world| world.lookup(addr))
 }
 
+/// Hold messages two hosts, until [`release`] is called.
+///
+/// Must be called from within a Turmoil simulation.
+pub fn hold(a: impl ToSocketAddr, b: impl ToSocketAddr) {
+    World::current(|world| {
+        let a = world.lookup(a);
+        let b = world.lookup(b);
+
+        world.hold(a, b);
+    })
+}
+
+/// The opposite of [`hold`]. All held messages are immediately delivered.
+///
+/// Must be called from within a Turmoil simulation.
+pub fn release(a: impl ToSocketAddr, b: impl ToSocketAddr) {
+    World::current(|world| {
+        let a = world.lookup(a);
+        let b = world.lookup(b);
+
+        world.release(a, b);
+    })
+}
+
 /// Partition two hosts, resulting in all messages sent between them to be
 /// dropped.
 ///


### PR DESCRIPTION
This commit introduces `turmoil::hold` and `::release` that temporarily hold packets between a sender and receiver. Unlike the partition and repair methods, held packets are not dropped. Instead, they are delivered after release is called.