### PR TITLE
Add an enum for delivery instructions

### DIFF
--- a/src/envelope.rs
+++ b/src/envelope.rs
@@ -6,9 +6,14 @@ pub(crate) struct Envelope {
     /// Who sent the message
     pub(crate) src: version::Dot,
 
-    /// When to deliver the message. If `None`, the message is stuck without an ETA.
-    pub(crate) deliver_at: Option<Instant>,
+    /// When (or if) to deliver the message
+    pub(crate) instructions: DeliveryInstructions,
 
     /// Message value
     pub(crate) message: Box<dyn Message>,
+}
+
+pub(crate) enum DeliveryInstructions {
+    ExplicitlyHeld,
+    DeliverAt(Instant),
 }


### PR DESCRIPTION
Cleanup the previous change, which relied on special semantics for None.