### PR TITLE
Fix error in README.md

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -1,0 +1,33 @@
+name: CI Build
+
+on:
+  push:
+    branches: [ main ]
+  pull_request:
+    branches: [ main ]
+
+env:
+  CARGO_TERM_COLOR: always
+
+jobs:
+  build:
+    name: Build and Test
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix :
+        os: [ubuntu-latest]
+
+    steps:
+      - name: Git Checkout
+        uses: actions/checkout@v2
+      - name: Rust Toolchain
+        uses: actions-rs/toolchain@v1
+        with:
+          profile: minimal
+          toolchain: stable
+          override: true
+      - name: Cargo Test
+        uses: actions-rs/cargo@v1
+        with:
+          command: test
+          args: --verbose

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,3 +28,6 @@ tokio = { version = "1.19.2", features = ["full"] }
 tokio-stream = "0.1.9"
 tokio-test = { version = "0.4.2" }
 unicycle = "0.9.2"
+
+[dev-dependencies]
+doc-comment = "0.3.3"

--- a/README.md
+++ b/README.md
@@ -37,30 +37,29 @@ impl turmoil::Message for Echo {
     }
 }
 
-#[test]
-fn simulation() {
-    let mut sim = Builder::new().build();
+let mut sim = Builder::new().build();
 
-    // register a host
-    sim.host("server", async {
-        loop {
-            let (msg, src) = io::recv::<Echo>().await;
-            io::send(src, msg);
-        }
-    });
+// register a host
+sim.host("server", || async {
+    loop {
+        let (msg, src) = io::recv::<Echo>().await;
+        io::send(src, msg);
+    }
+});
 
-    // register a client (this is the test code)
-    sim.client("client", async {
-        io::send("server", Echo("hello, server!".to_string()));
+// register a client (this is the test code)
+sim.client("client", async {
+    io::send("server", Echo("hello, server!".to_string()));
 
-        let (echo, _) = io::recv::<Echo>().await;
-        assert_eq!("hello, server!", echo.0);
-    });
+    let (echo, _) = io::recv::<Echo>().await;
+    assert_eq!("hello, server!", echo.0);
+});
 
-    // run the simulation
-    sim.run();
-}
+// run the simulation
+sim.run();
 ```
+
+For more examples, check out the [tests](tests) directory.
 
 ## License
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,3 +1,6 @@
+#[cfg(doctest)]
+mod readme;
+
 mod builder;
 
 use std::net::SocketAddr;

--- a/src/readme.rs
+++ b/src/readme.rs
@@ -1,0 +1,8 @@
+///! The only purpose of this file is to run the README.md as if it was a
+///! doctest. The reason for a standalone file is so that any failures show up
+///! clearly as 'readme' failures, as opposed to tests in lib.rs or some other
+///! file.
+///!
+///! https://blog.guillaume-gomez.fr/articles/2020-03-07+cfg%28doctest%29+is+stable+and+you+should+use+it
+
+doc_comment::doctest!("../README.md");


### PR DESCRIPTION
In a recent commit, I changed the API for starting a host to require a future factory. The example in the README broke, but the PR was still merged.

In this commit, we use Github actions to run `cargo test --verbose` PRs to main (and adhoc pushes). For now, this just tests on ubuntu as we have no platform specific code.

In addition, we run the README as a doctest. This slightly harms the README because the example is no longer copy-paste ready. In particular, the `#[test] fn simulation() {  }` chrome is now removed so as to work within the doctest framework. I think that's OK, especially since we ship real examples in test/.

Finally, the actual bug was fixed by adding a tunnel, down which no variables slide.

---

Note that I pushed this to my fork and the CI worked: https://github.com/marcbowes/turmoil/actions/runs/3102304893/jobs/5024489886