### PR TITLE
Use an explicit lifetime for host's software factory

### DIFF
--- a/src/builder.rs
+++ b/src/builder.rs
@@ -17,8 +17,8 @@ pub struct Builder {
 }
 
 impl Builder {
-    pub fn new() -> Builder {
-        Builder {
+    pub fn new() -> Self {
+        Self {
             rng: None,
             config: Config::default(),
             link: config::Link {
@@ -81,11 +81,11 @@ impl Builder {
         self
     }
 
-    pub fn build(&self) -> Sim {
+    pub fn build<'a>(&self) -> Sim<'a> {
         self.build_with_rng(Box::new(rand::rngs::SmallRng::from_entropy()))
     }
 
-    pub fn build_with_rng(&self, rng: Box<dyn RngCore>) -> Sim {
+    pub fn build_with_rng<'a>(&self, rng: Box<dyn RngCore>) -> Sim<'a> {
         let log = self
             .log
             .as_ref()

--- a/src/sim.rs
+++ b/src/sim.rs
@@ -9,7 +9,7 @@ use tokio::sync::Notify;
 use tokio::time::Duration;
 
 /// Network simulation
-pub struct Sim {
+pub struct Sim<'a> {
     /// Simulation configuration
     config: Config,
 
@@ -19,12 +19,12 @@ pub struct Sim {
     world: RefCell<World>,
 
     /// Per simulated host runtimes
-    rts: IndexMap<SocketAddr, Role>,
+    rts: IndexMap<SocketAddr, Role<'a>>,
 }
 
-impl Sim {
-    pub(crate) fn new(config: Config, world: World) -> Sim {
-        Sim {
+impl<'a> Sim<'a> {
+    pub(crate) fn new(config: Config, world: World) -> Self {
+        Self {
             config,
             world: RefCell::new(world),
             rts: IndexMap::new(),
@@ -59,12 +59,9 @@ impl Sim {
     /// [`Sim::client`] which just takes a future. The reason for this is we
     /// might restart the host, and so need to be able to call the future
     /// multiple times.
-    ///
-    // TODO: Removing the `'static` bound on `F` would make writing some tests
-    // easier.
     pub fn host<F, Fut>(&mut self, addr: impl ToSocketAddr, host: F)
     where
-        F: Fn() -> Fut + 'static,
+        F: Fn() -> Fut + 'a,
         Fut: Future<Output = ()> + 'static,
     {
         let rt = Rt::new();


### PR DESCRIPTION
While the `Future` must be `'static`, the `Fn` to generate it does
not need to be.

Specifying an explicit lifetime here makes it simpler to write tests
that capture state in the closure.
