### PR TITLE
Add support for simulated TCP connections

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,6 +17,7 @@ keywords = ["Deterministic", "Simulation", "Testing"]
 categories = ["asynchronous", "network-programming", "simulation"]
 
 [dependencies]
+bytes = "1.2.1"
 futures = "0.3"
 indexmap = "1.9"
 rand = { version = "0.8.5", features = ["small_rng"] }
@@ -27,6 +28,7 @@ serde_json = "1.0.83"
 tokio = { version = "1.19.2", features = ["full"] }
 tokio-stream = "0.1.9"
 tokio-test = { version = "0.4.2" }
+tokio-util = "0.7.4"
 unicycle = "0.9.2"
 
 [dev-dependencies]

--- a/src/host.rs
+++ b/src/host.rs
@@ -1,14 +1,23 @@
 use crate::envelope::DeliveryInstructions;
+use crate::net::{Segment, SocketPair, StreamEnvelope, Syn};
 use crate::{version, Envelope, Message};
 
 use indexmap::IndexMap;
 use std::collections::VecDeque;
+use std::io;
 use std::net::SocketAddr;
 use std::rc::Rc;
+use std::sync::Arc;
 use tokio::sync::Notify;
 use tokio::time::{Duration, Instant};
 
-/// A host in the simulated network
+/// A host in the simulated network.
+///
+/// Hosts support two networking modes:
+/// - Datagram via [`crate::io::send`] and [`crate::io::recv`]
+/// - Stream via [`crate::net::Listener`] and [`crate::net::Stream`]
+///
+/// Both modes may be used by host software simulatanesouly.
 pub(crate) struct Host {
     /// Host address
     pub(crate) addr: SocketAddr,
@@ -17,16 +26,34 @@ pub(crate) struct Host {
     /// network".
     inbox: IndexMap<SocketAddr, VecDeque<Envelope>>,
 
-    /// Signaled when a message becomes available to receive
+    /// Signaled when a message becomes available to receive.
     pub(crate) notify: Rc<Notify>,
 
-    /// Current instant at the host
+    /// Optional accept queue; set if the host is bound. This simulates a server
+    /// socket.
+    listener: Option<Inbox<Envelope>>,
+
+    /// In-flight messages for active connections. Some of these may still be
+    /// "on the network".
+    connections: IndexMap<SocketPair, Inbox<StreamEnvelope>>,
+
+    /// Current instant at the host.
     pub(crate) now: Instant,
 
     epoch: Instant,
 
-    /// Current host version. This is incremented each time a message is received.
+    /// Current host version. This is incremented each time a network operation
+    /// occurs.
     pub(crate) version: u64,
+}
+
+/// A simple unbounded channel.
+struct Inbox<T> {
+    /// Pending connections
+    deque: VecDeque<T>,
+
+    /// Signaled when an item is available
+    notify: Arc<Notify>,
 }
 
 impl Host {
@@ -35,15 +62,53 @@ impl Host {
             addr,
             inbox: IndexMap::new(),
             notify,
+            listener: None,
+            connections: IndexMap::new(),
             now,
             epoch: now,
             version: 0,
         }
     }
 
+    /// Creates a new listener queue, which is bound to the host's `addr`.
+    ///
+    /// This is called by `Listener::bind()` and the returned `Notify` is used
+    /// to signal when connections are available to accept.
+    // TODO: Support binding to multiple ports
+    pub(crate) fn bind(&mut self) -> io::Result<Arc<Notify>> {
+        if self.listener.is_some() {
+            return Err(io::Error::new(
+                io::ErrorKind::AddrInUse,
+                self.addr.to_string(),
+            ));
+        }
+
+        let notify = Arc::new(Notify::new());
+
+        self.listener.replace(Inbox {
+            deque: VecDeque::new(),
+            notify: notify.clone(),
+        });
+
+        Ok(notify)
+    }
+
+    /// Unbind the host, dropping all pending connections.
+    pub(crate) fn unbind(&mut self) {
+        self.listener.take();
+    }
+
     /// Returns how long the host has been executing for in virtual time
     pub(crate) fn elapsed(&self) -> Duration {
         self.now - self.epoch
+    }
+
+    /// Bump the version for this host and return a dot.
+    ///
+    /// Called when a host establishes a new connection with a remote peer.
+    pub(crate) fn bump(&mut self) -> version::Dot {
+        self.version += 1;
+        self.dot()
     }
 
     /// Returns a dot for the host at its current version
@@ -52,6 +117,67 @@ impl Host {
             host: self.addr,
             version: self.version,
         }
+    }
+
+    pub(crate) fn accept(&mut self) -> Option<Envelope> {
+        let now = Instant::now();
+        let deque = &mut self.listener.as_mut()?.deque;
+
+        match deque.front() {
+            Some(Envelope {
+                instructions: DeliveryInstructions::DeliverAt(time),
+                ..
+            }) if *time <= now => {
+                self.version += 1;
+                deque.pop_front()
+            }
+            _ => None,
+        }
+    }
+
+    pub(crate) fn syn(&mut self, src: version::Dot, delay: Option<Duration>, syn: Syn) {
+        if let Some(listener) = self.listener.as_mut() {
+            let instructions = match delay {
+                Some(d) => DeliveryInstructions::DeliverAt(self.now + d),
+                None => DeliveryInstructions::ExplicitlyHeld,
+            };
+
+            listener.deque.push_back(Envelope {
+                src,
+                instructions,
+                message: Box::new(syn),
+            });
+
+            listener.notify.notify_one();
+        }
+
+        // notify drops, connection is refused
+    }
+
+    /// Finalize the connection, returning a `Notify` to build the stream.
+    ///
+    /// This is idempotent. If the connection has already been initialized, the
+    /// `Notify` is simply cloned and returned.
+    pub(crate) fn finish_connect(&mut self, pair: SocketPair) -> Arc<Notify> {
+        let inbox = self.connections.entry(pair).or_insert_with(|| Inbox {
+            deque: VecDeque::new(),
+            notify: Arc::new(Notify::new()),
+        });
+
+        inbox.notify.clone()
+    }
+
+    pub(crate) fn register_connection(&mut self, pair: SocketPair) {
+        assert!(self
+            .connections
+            .insert(
+                pair,
+                Inbox {
+                    deque: VecDeque::new(),
+                    notify: Arc::new(Notify::new()),
+                }
+            )
+            .is_none());
     }
 
     pub(crate) fn embark(
@@ -73,6 +199,28 @@ impl Host {
         self.version += 1;
 
         self.notify.notify_one();
+    }
+
+    pub(crate) fn embark_on(
+        &mut self,
+        pair: SocketPair,
+        delay: Option<Duration>,
+        segment: Segment,
+    ) {
+        let inbox = self.connections.get_mut(&pair).expect("no connection");
+
+        let instructions = match delay {
+            Some(d) => DeliveryInstructions::DeliverAt(self.now + d),
+            None => DeliveryInstructions::ExplicitlyHeld,
+        };
+
+        inbox.deque.push_back(StreamEnvelope {
+            instructions,
+            segment,
+        });
+        self.version += 1;
+
+        inbox.notify.notify_one();
     }
 
     pub(crate) fn recv(&mut self) -> (Option<Envelope>, Rc<Notify>) {
@@ -97,9 +245,9 @@ impl Host {
 
     pub(crate) fn recv_from(&mut self, peer: SocketAddr) -> (Option<Envelope>, Rc<Notify>) {
         let now = Instant::now();
-        let notify = self.notify.clone();
 
         let deque = self.inbox.entry(peer).or_default();
+        let notify = self.notify.clone();
 
         match deque.front() {
             Some(Envelope {
@@ -113,13 +261,63 @@ impl Host {
         }
     }
 
+    pub(crate) fn recv_on(&mut self, pair: SocketPair) -> Option<Segment> {
+        let now = Instant::now();
+
+        let deque = self
+            .connections
+            .get_mut(&pair)
+            .map(|i| &mut i.deque)
+            .expect("no connection");
+
+        match deque.front() {
+            Some(StreamEnvelope {
+                instructions: DeliveryInstructions::DeliverAt(time),
+                ..
+            }) if *time <= now => {
+                self.version += 1;
+                deque.pop_front().map(|e| e.segment)
+            }
+            _ => None,
+        }
+    }
+
     /// Releases all messages previously received from [`peer`]. These messages
     /// may be received immediately (on the next call to `[Host::recv]`).
     pub(crate) fn release(&mut self, peer: SocketAddr) {
         let now = Instant::now();
-        let deque = self.inbox.entry(peer).or_default();
 
-        for envelope in deque {
+        if let Some(listener) = self.listener.as_mut() {
+            for syn in listener.deque.iter_mut() {
+                if let Envelope {
+                    instructions: DeliveryInstructions::ExplicitlyHeld,
+                    ..
+                } = syn
+                {
+                    syn.instructions = DeliveryInstructions::DeliverAt(now);
+                }
+            }
+
+            listener.notify.notify_one();
+        }
+
+        for (pair, inbox) in self.connections.iter_mut() {
+            if pair.peer.host == peer {
+                for envelope in &mut inbox.deque {
+                    if let StreamEnvelope {
+                        instructions: DeliveryInstructions::ExplicitlyHeld,
+                        ..
+                    } = envelope
+                    {
+                        envelope.instructions = DeliveryInstructions::DeliverAt(now);
+                    }
+                }
+
+                inbox.notify.notify_one();
+            }
+        }
+
+        for envelope in self.inbox.entry(peer).or_default() {
             if let Envelope {
                 instructions: DeliveryInstructions::ExplicitlyHeld,
                 ..
@@ -134,6 +332,30 @@ impl Host {
 
     pub(crate) fn tick(&mut self, now: Instant) {
         self.now = now;
+
+        if let Some(listener) = self.listener.as_ref() {
+            if let Some(Envelope {
+                instructions: DeliveryInstructions::DeliverAt(time),
+                ..
+            }) = listener.deque.front()
+            {
+                if *time <= now {
+                    listener.notify.notify_one();
+                }
+            }
+        }
+
+        for inbox in self.connections.values() {
+            if let Some(StreamEnvelope {
+                instructions: DeliveryInstructions::DeliverAt(time),
+                ..
+            }) = inbox.deque.front()
+            {
+                if *time <= now {
+                    inbox.notify.notify_one();
+                }
+            }
+        }
 
         for deque in self.inbox.values() {
             if let Some(Envelope {

--- a/src/host.rs
+++ b/src/host.rs
@@ -89,6 +89,7 @@ impl Host {
             deque: VecDeque::new(),
             notify: notify.clone(),
         });
+        self.version += 1;
 
         Ok(notify)
     }
@@ -96,6 +97,7 @@ impl Host {
     /// Unbind the host, dropping all pending connections.
     pub(crate) fn unbind(&mut self) {
         self.listener.take();
+        self.version += 1;
     }
 
     /// Returns how long the host has been executing for in virtual time
@@ -196,7 +198,6 @@ impl Host {
             instructions,
             message,
         });
-        self.version += 1;
 
         self.notify.notify_one();
     }
@@ -218,7 +219,6 @@ impl Host {
             instructions,
             segment,
         });
-        self.version += 1;
 
         inbox.notify.notify_one();
     }

--- a/src/io.rs
+++ b/src/io.rs
@@ -1,3 +1,4 @@
+// TODO: Move this to the net mod and rename
 use crate::{lookup, message, Message, ToSocketAddr, World};
 
 use std::net::SocketAddr;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -28,6 +28,8 @@ use log::Log;
 mod message;
 pub use message::Message;
 
+pub mod net;
+
 mod role;
 use role::Role;
 

--- a/src/log.rs
+++ b/src/log.rs
@@ -130,6 +130,7 @@ impl Log {
                 },
             )
             .unwrap();
+            write!(writer, "\n").unwrap();
         }
     }
 
@@ -156,6 +157,7 @@ impl Log {
                 },
             )
             .unwrap();
+            write!(writer, "\n").unwrap();
         }
     }
 
@@ -178,6 +180,7 @@ impl Log {
                 },
             )
             .unwrap();
+            write!(writer, "\n").unwrap();
         }
     }
 
@@ -248,6 +251,7 @@ impl Log {
                 },
             )
             .unwrap();
+            write!(writer, "\n").unwrap();
         }
     }
 }

--- a/src/log.rs
+++ b/src/log.rs
@@ -26,6 +26,26 @@ struct Event<'a> {
 #[derive(serde::Serialize)]
 #[serde(rename_all = "snake_case")]
 enum Kind<'a> {
+    /// Start listening for new connections
+    Bind,
+    /// Initiate a new connection
+    Syn {
+        /// where the message is being sent
+        dst: &'a str,
+
+        /// How long the message will be delayed before the peer receives it.
+        delay: Option<Duration>,
+
+        /// If true, the message is dropped.
+        dropped: bool,
+    },
+    /// Accept a new connection
+    SynAck {
+        /// Host & version at which the message originated
+        src: Dot<'a>,
+    },
+    /// Stop listening
+    Unbind,
     /// The host received a message
     Recv {
         /// Host & version at which the message originated
@@ -99,6 +119,68 @@ impl Log {
         }
     }
 
+    pub(crate) fn bind(&mut self, dns: &Dns, host: version::Dot, elapsed: Duration) {
+        if let Some(writer) = &mut self.writer {
+            serde_json::to_writer_pretty(
+                &mut *writer,
+                &Event {
+                    host: Dot::from(host, dns),
+                    elapsed,
+                    kind: Kind::Bind,
+                },
+            )
+            .unwrap();
+        }
+    }
+
+    pub(crate) fn syn(
+        &mut self,
+        dns: &Dns,
+        host: version::Dot,
+        elapsed: Duration,
+        dst: SocketAddr,
+        delay: Option<Duration>,
+        dropped: bool,
+    ) {
+        if let Some(writer) = &mut self.writer {
+            serde_json::to_writer_pretty(
+                &mut *writer,
+                &Event {
+                    host: Dot::from(host, dns),
+                    elapsed,
+                    kind: Kind::Syn {
+                        dst: dns.reverse(dst),
+                        delay,
+                        dropped,
+                    },
+                },
+            )
+            .unwrap();
+        }
+    }
+
+    pub(crate) fn syn_ack(
+        &mut self,
+        dns: &Dns,
+        host: version::Dot,
+        elapsed: Duration,
+        src: version::Dot,
+    ) {
+        if let Some(writer) = &mut self.writer {
+            serde_json::to_writer_pretty(
+                &mut *writer,
+                &Event {
+                    host: Dot::from(host, dns),
+                    elapsed,
+                    kind: Kind::SynAck {
+                        src: Dot::from(src, dns),
+                    },
+                },
+            )
+            .unwrap();
+        }
+    }
+
     pub(crate) fn recv(
         &mut self,
         dns: &Dns,
@@ -152,6 +234,20 @@ impl Log {
             write!(writer, "\n").unwrap();
             message.write_json(writer);
             write!(writer, "\n").unwrap();
+        }
+    }
+
+    pub(crate) fn unbind(&mut self, dns: &Dns, host: version::Dot, elapsed: Duration) {
+        if let Some(writer) = &mut self.writer {
+            serde_json::to_writer_pretty(
+                &mut *writer,
+                &Event {
+                    host: Dot::from(host, dns),
+                    elapsed,
+                    kind: Kind::Unbind,
+                },
+            )
+            .unwrap();
         }
     }
 }

--- a/src/net/listener.rs
+++ b/src/net/listener.rs
@@ -4,22 +4,22 @@ use tokio::sync::Notify;
 
 use crate::world::World;
 
-use super::Stream;
+use super::TcpStream;
 
 /// A simulated socket server, listening for connections.
 ///
 /// All methods must be called from a host within a Turmoil simulation.
-pub struct Listener {
+pub struct TcpListener {
     notify: Arc<Notify>,
 }
 
-impl Listener {
+impl TcpListener {
     /// Creates a new listener, which will be bound to the currently executing
     /// host's address.
     ///
     /// The returned listener is ready for accepting connections.
     pub async fn bind() -> io::Result<Self> {
-        Ok(Listener {
+        Ok(Self {
             notify: World::current(|world| {
                 let ret = world.current_host_mut().bind();
 
@@ -34,7 +34,7 @@ impl Listener {
     }
 
     /// Accepts a new incoming connection from this listener.
-    pub async fn accept(&self) -> io::Result<(Stream, SocketAddr)> {
+    pub async fn accept(&self) -> io::Result<(TcpStream, SocketAddr)> {
         loop {
             let maybe_accept = World::current(|world| world.accept());
 
@@ -47,7 +47,7 @@ impl Listener {
     }
 }
 
-impl Drop for Listener {
+impl Drop for TcpListener {
     fn drop(&mut self) {
         World::current_if_set(|world| {
             world.current_host_mut().unbind();

--- a/src/net/listener.rs
+++ b/src/net/listener.rs
@@ -1,0 +1,59 @@
+use std::{io, net::SocketAddr, sync::Arc};
+
+use tokio::sync::Notify;
+
+use crate::world::World;
+
+use super::Stream;
+
+/// A simulated socket server, listening for connections.
+///
+/// All methods must be called from a host within a Turmoil simulation.
+pub struct Listener {
+    notify: Arc<Notify>,
+}
+
+impl Listener {
+    /// Creates a new listener, which will be bound to the currently executing
+    /// host's address.
+    ///
+    /// The returned listener is ready for accepting connections.
+    pub async fn bind() -> io::Result<Self> {
+        Ok(Listener {
+            notify: World::current(|world| {
+                let ret = world.current_host_mut().bind();
+
+                if let Ok(_) = &ret {
+                    let host = world.current_host();
+                    world.log.bind(&world.dns, host.dot(), host.elapsed());
+                }
+
+                ret
+            })?,
+        })
+    }
+
+    /// Accepts a new incoming connection from this listener.
+    pub async fn accept(&self) -> io::Result<(Stream, SocketAddr)> {
+        loop {
+            let maybe_accept = World::current(|world| world.accept());
+
+            if let Some(accept) = maybe_accept {
+                return Ok(accept);
+            }
+
+            self.notify.notified().await;
+        }
+    }
+}
+
+impl Drop for Listener {
+    fn drop(&mut self) {
+        World::current_if_set(|world| {
+            world.current_host_mut().unbind();
+
+            let host = world.current_host();
+            world.log.unbind(&world.dns, host.dot(), host.elapsed());
+        })
+    }
+}

--- a/src/net/mod.rs
+++ b/src/net/mod.rs
@@ -9,10 +9,10 @@ use tokio::sync::oneshot;
 mod listener;
 
 use bytes::Bytes;
-pub use listener::Listener;
+pub use listener::TcpListener;
 
 mod stream;
-pub use stream::Stream;
+pub use stream::TcpStream;
 
 /// Uniquely identifies a connection between two hosts.
 ///

--- a/src/net/mod.rs
+++ b/src/net/mod.rs
@@ -2,6 +2,7 @@
 //!
 //! They mirror [tokio::net](https://docs.rs/tokio/latest/tokio/net/) to provide
 //! a high fidelity implementation.
+
 use crate::{envelope::DeliveryInstructions, version::Dot, Message};
 
 use tokio::sync::oneshot;

--- a/src/net/mod.rs
+++ b/src/net/mod.rs
@@ -1,0 +1,75 @@
+//! This module contains the simulated TCP/UDP networking types.
+//!
+//! They mirror [tokio::net](https://docs.rs/tokio/latest/tokio/net/) to provide
+//! a high fidelity implementation.
+use crate::{envelope::DeliveryInstructions, version::Dot, Message};
+
+use tokio::sync::oneshot;
+
+mod listener;
+
+use bytes::Bytes;
+pub use listener::Listener;
+
+mod stream;
+pub use stream::Stream;
+
+/// Uniquely identifies a connection between two hosts.
+///
+/// Using `Dot` allows us to support multiple connections between the same two
+/// hosts, as version bumps for every network operation, ie connect.
+#[derive(Debug, Copy, Clone, Eq, Hash, PartialEq)]
+pub(crate) struct SocketPair {
+    pub(crate) local: Dot,
+    pub(crate) peer: Dot,
+}
+
+impl SocketPair {
+    pub(crate) fn flip(self) -> Self {
+        Self {
+            local: self.peer,
+            peer: self.local,
+        }
+    }
+}
+
+/// Message used to initiate a new connection with a host.
+#[derive(Debug)]
+pub(crate) struct Syn {
+    /// Notify the peer that the connection has been accepted.
+    ///
+    /// To connect, we only send one message (the SYN) and the rest (SYN-ACK and
+    /// ACK) is instantaneous. The SYN message is subject to turmoil when a host
+    /// connects, such as added delay, which sufficiently simulates the 3-step
+    /// handshake.
+    pub(crate) notify: oneshot::Sender<Dot>,
+}
+
+impl Message for Syn {
+    fn write_json(&self, dst: &mut dyn std::io::Write) {
+        write!(dst, "Syn").unwrap()
+    }
+}
+
+/// Envelope for messages on an established connection.
+pub(crate) struct StreamEnvelope {
+    /// When (or if) to deliver the message
+    pub(crate) instructions: DeliveryInstructions,
+
+    /// Segment type
+    pub(crate) segment: Segment,
+}
+
+/// Message types for established connections.
+#[derive(Debug)]
+pub(crate) enum Segment {
+    Data(Bytes),
+}
+
+impl Message for Segment {
+    fn write_json(&self, dst: &mut dyn std::io::Write) {
+        match self {
+            Segment::Data(_) => write!(dst, "Data").unwrap(),
+        }
+    }
+}

--- a/src/net/stream.rs
+++ b/src/net/stream.rs
@@ -19,13 +19,13 @@ use super::{Segment, SocketPair};
 /// A simulated connection between two hosts.
 ///
 /// All methods must be called from a host within a Turmoil simulation.
-pub struct Stream {
+pub struct TcpStream {
     pub(crate) pair: SocketPair,
     notify: Arc<Notify>,
     read_fut: Option<ReusableBoxFuture<'static, ()>>,
 }
 
-impl Stream {
+impl TcpStream {
     pub(crate) fn new(pair: SocketPair, notify: Arc<Notify>) -> Self {
         Self {
             pair,
@@ -51,7 +51,7 @@ impl Stream {
         let pair = SocketPair { local, peer };
         let notify = World::current(|world| world.current_host_mut().finish_connect(pair));
 
-        Ok(Stream::new(pair, notify))
+        Ok(Self::new(pair, notify))
     }
 
     fn poll_read_priv(
@@ -115,7 +115,7 @@ impl Stream {
     }
 }
 
-impl AsyncRead for Stream {
+impl AsyncRead for TcpStream {
     fn poll_read(
         mut self: Pin<&mut Self>,
         cx: &mut Context<'_>,
@@ -125,7 +125,7 @@ impl AsyncRead for Stream {
     }
 }
 
-impl AsyncWrite for Stream {
+impl AsyncWrite for TcpStream {
     fn poll_write(
         self: Pin<&mut Self>,
         _cx: &mut Context<'_>,

--- a/src/net/stream.rs
+++ b/src/net/stream.rs
@@ -1,0 +1,157 @@
+use bytes::Bytes;
+use std::{
+    io,
+    pin::Pin,
+    sync::Arc,
+    task::{Context, Poll},
+};
+use tokio_util::sync::ReusableBoxFuture;
+
+use tokio::{
+    io::{AsyncRead, AsyncWrite, ReadBuf},
+    sync::Notify,
+};
+
+use crate::{world::World, ToSocketAddr};
+
+use super::{Segment, SocketPair};
+
+/// A simulated connection between two hosts.
+///
+/// All methods must be called from a host within a Turmoil simulation.
+pub struct Stream {
+    pub(crate) pair: SocketPair,
+    notify: Arc<Notify>,
+    read_fut: Option<ReusableBoxFuture<'static, ()>>,
+}
+
+impl Stream {
+    pub(crate) fn new(pair: SocketPair, notify: Arc<Notify>) -> Self {
+        Self {
+            pair,
+            notify,
+            read_fut: None,
+        }
+    }
+
+    /// Opens a connection to a remote host.
+    ///
+    /// `addr` is an address of the remote host. Anything which implements the
+    /// [`ToSocketAddr`] trait can be supplied as the address.
+    pub async fn connect(addr: impl ToSocketAddr) -> io::Result<Self> {
+        let ((local, wait), dst) = World::current(|world| {
+            let dst = world.lookup(addr);
+            (world.connect(dst), dst)
+        });
+
+        let peer = wait
+            .await
+            .map_err(|_| io::Error::new(io::ErrorKind::ConnectionRefused, dst.to_string()))?;
+
+        let pair = SocketPair { local, peer };
+        let notify = World::current(|world| world.current_host_mut().finish_connect(pair));
+
+        Ok(Stream::new(pair, notify))
+    }
+
+    fn poll_read_priv(
+        &mut self,
+        cx: &mut Context<'_>,
+        buf: &mut ReadBuf<'_>,
+    ) -> Poll<io::Result<()>> {
+        let read_fut = match self.read_fut.as_mut() {
+            Some(fut) => fut,
+            None => {
+                // fast path if we can recv immediately
+                let maybe = Self::recv(self.pair, buf);
+                if let Some(res) = maybe {
+                    return Poll::Ready(res);
+                }
+
+                let notify = Arc::clone(&self.notify);
+                self.read_fut
+                    .get_or_insert(ReusableBoxFuture::new(
+                        async move { notify.notified().await },
+                    ))
+            }
+        };
+
+        match read_fut.poll(cx) {
+            Poll::Ready(_) => {
+                // Loop until we recv a segment from the host or the read future
+                // is pending. This is necessary as we might be notified, but
+                // the segment is still "on the network" and we need to continue
+                // polling.
+                loop {
+                    let notify = Arc::clone(&self.notify);
+                    read_fut.set(async move { notify.notified().await });
+
+                    match Self::recv(self.pair, buf) {
+                        Some(res) => return Poll::Ready(res),
+                        _ => {
+                            if let Poll::Pending = read_fut.poll(cx) {
+                                break;
+                            }
+                        }
+                    }
+                }
+
+                Poll::Pending
+            }
+            Poll::Pending => Poll::Pending,
+        }
+    }
+
+    fn recv(pair: SocketPair, buf: &mut ReadBuf<'_>) -> Option<io::Result<()>> {
+        match World::current(|world| world.recv_on(pair)) {
+            Some(seg) => match seg {
+                Segment::Data(bytes) => {
+                    buf.put_slice(bytes.as_ref());
+                    return Some(Ok(()));
+                }
+            },
+            _ => None,
+        }
+    }
+
+    fn poll_write_priv(&self, buf: &[u8]) -> Poll<Result<usize, io::Error>> {
+        World::current(|world| {
+            let bytes = Bytes::copy_from_slice(buf);
+            world.embark_on(self.pair, Segment::Data(bytes))
+        });
+
+        Poll::Ready(Ok(buf.len()))
+    }
+}
+
+impl Drop for Stream {
+    fn drop(&mut self) {}
+}
+
+impl AsyncRead for Stream {
+    fn poll_read(
+        mut self: Pin<&mut Self>,
+        cx: &mut Context<'_>,
+        buf: &mut ReadBuf<'_>,
+    ) -> Poll<io::Result<()>> {
+        self.poll_read_priv(cx, buf)
+    }
+}
+
+impl AsyncWrite for Stream {
+    fn poll_write(
+        self: Pin<&mut Self>,
+        _cx: &mut Context<'_>,
+        buf: &[u8],
+    ) -> Poll<Result<usize, io::Error>> {
+        self.poll_write_priv(buf)
+    }
+
+    fn poll_flush(self: Pin<&mut Self>, _cx: &mut Context<'_>) -> Poll<Result<(), io::Error>> {
+        Poll::Ready(Ok(()))
+    }
+
+    fn poll_shutdown(self: Pin<&mut Self>, _cx: &mut Context<'_>) -> Poll<Result<(), io::Error>> {
+        unimplemented!("shutdown is not implemented yet")
+    }
+}

--- a/src/version.rs
+++ b/src/version.rs
@@ -4,7 +4,7 @@ use std::net::SocketAddr;
 /// vector" [1].
 ///
 /// [1]: https://riak.com/posts/technical/vector-clocks-revisited-part-2-dotted-version-vectors/index.html
-#[derive(Debug, Copy, Clone)]
+#[derive(Debug, Copy, Clone, Hash, Eq, PartialEq)]
 pub(crate) struct Dot {
     pub(crate) host: SocketAddr,
     pub(crate) version: u64,

--- a/src/world.rs
+++ b/src/world.rs
@@ -1,4 +1,4 @@
-use crate::net::{Segment, SocketPair, Stream, Syn};
+use crate::net::{Segment, SocketPair, Syn, TcpStream};
 use crate::top::Embark;
 use crate::{config, message, version, Dns, Envelope, Host, Log, Message, ToSocketAddr, Topology};
 
@@ -161,7 +161,7 @@ impl World {
     }
 
     /// Accept a new incoming connection on the currently executing host.
-    pub(crate) fn accept(&mut self) -> Option<(Stream, SocketAddr)> {
+    pub(crate) fn accept(&mut self) -> Option<(TcpStream, SocketAddr)> {
         let ret = self.current_host_mut().accept();
 
         if let Some(Envelope { src, message, .. }) = ret {
@@ -186,7 +186,7 @@ impl World {
             // hasn't seen the ack yet.
             self.hosts[&src.host].register_connection(pair.flip());
 
-            return Some((Stream::new(pair, notify), src.host));
+            return Some((TcpStream::new(pair, notify), src.host));
         }
 
         None

--- a/src/world.rs
+++ b/src/world.rs
@@ -1,5 +1,6 @@
+use crate::net::{Segment, SocketPair, Stream, Syn};
 use crate::top::Embark;
-use crate::{config, Dns, Envelope, Host, Log, Message, ToSocketAddr, Topology};
+use crate::{config, message, version, Dns, Envelope, Host, Log, Message, ToSocketAddr, Topology};
 
 use indexmap::IndexMap;
 use rand::RngCore;
@@ -7,7 +8,7 @@ use scoped_tls::scoped_thread_local;
 use std::cell::RefCell;
 use std::net::SocketAddr;
 use std::rc::Rc;
-use tokio::sync::Notify;
+use tokio::sync::{oneshot, Notify};
 use tokio::time::Instant;
 
 /// Tracks all the state for the simulated world.
@@ -47,12 +48,22 @@ impl World {
         }
     }
 
-    /// Get a mutable reference to the **current** world.
+    /// Run `f` on the world.
     pub(crate) fn current<R>(f: impl FnOnce(&mut World) -> R) -> R {
         CURRENT.with(|current| {
             let mut current = current.borrow_mut();
             f(&mut *current)
         })
+    }
+
+    /// Run `f` if the world is set - otherwise no-op.
+    ///
+    /// Used in drop paths, where the simulation may be shutting
+    /// down and we don't need to do anything.
+    pub(crate) fn current_if_set(f: impl FnOnce(&mut World) -> ()) {
+        if CURRENT.is_set() {
+            Self::current(f);
+        }
     }
 
     pub(crate) fn enter<R>(world: &RefCell<World>, f: impl FnOnce() -> R) -> R {
@@ -63,6 +74,12 @@ impl World {
     pub(crate) fn current_host(&self) -> &Host {
         let addr = self.current.expect("current host missing");
         self.hosts.get(&addr).expect("host missing")
+    }
+
+    /// Return a mutable reference to the currently executing host.
+    pub(crate) fn current_host_mut(&mut self) -> &mut Host {
+        let addr = self.current.expect("current host missing");
+        self.hosts.get_mut(&addr).expect("host missing")
     }
 
     /// Return a reference to the host at `addr`.
@@ -110,6 +127,72 @@ impl World {
         self.hosts.insert(addr, Host::new(addr, epoch, notify));
     }
 
+    /// Initiate a new connection with `dst` from the currently executing host.
+    pub(crate) fn connect(
+        &mut self,
+        dst: SocketAddr,
+    ) -> (version::Dot, oneshot::Receiver<version::Dot>) {
+        let (sender, receiver) = oneshot::channel();
+        let syn = Syn { notify: sender };
+
+        // Bump the version to uniquely identify the new connection
+        let dot = self.current_host_mut().bump();
+        let elapsed = self.current_host().elapsed();
+
+        match self.topology.embark_one(&mut self.rng, dot.host, dst) {
+            it @ Embark::Delay(_) | it @ Embark::Hold => {
+                let delay = if let Embark::Delay(d) = it {
+                    Some(d)
+                } else {
+                    None
+                };
+
+                self.log.syn(&self.dns, dot, elapsed, dst, delay, false);
+
+                self.hosts[&dst].syn(dot, delay, syn);
+                (dot, receiver)
+            }
+            Embark::Drop => {
+                self.log.syn(&self.dns, dot, elapsed, dst, None, true);
+
+                // Let sender drop naturally to err on the receive side
+                (dot, receiver)
+            }
+        }
+    }
+
+    /// Accept a new incoming connection on the currently executing host.
+    pub(crate) fn accept(&mut self) -> Option<(Stream, SocketAddr)> {
+        let ret = self.current_host_mut().accept();
+
+        if let Some(Envelope { src, message, .. }) = ret {
+            let host = self.current_host();
+
+            let syn = message::downcast::<Syn>(message);
+            let local = host.dot();
+            let elapsed = host.elapsed();
+
+            // notify the peer, returning early if they have hung up to avoid
+            // host mutations
+            syn.notify.send(local).ok()?;
+
+            let pair = SocketPair { local, peer: src };
+            let notify = self.current_host_mut().finish_connect(pair);
+
+            self.log.syn_ack(&self.dns, local, elapsed, src);
+
+            // Setup the connection on the peer. This has to happen on the
+            // accept side because as soon as this returns the currently
+            // executing host may use the stream, even though initiating host
+            // hasn't seen the ack yet.
+            self.hosts[&src.host].register_connection(pair.flip());
+
+            return Some((Stream::new(pair, notify), src.host));
+        }
+
+        None
+    }
+
     /// Embark a message from the currently executing host to `dst`.
     ///
     /// This begins the message's journey, queuing it on the destination inbox,
@@ -143,6 +226,31 @@ impl World {
         }
     }
 
+    /// Embark a segment from the currently executing host to `pair`'s peer.
+    pub(crate) fn embark_on(&mut self, pair: SocketPair, segment: Segment) {
+        let host = self.current_host().addr;
+        let dst = pair.peer.host;
+
+        match self.topology.embark_one(&mut self.rng, host, dst) {
+            it @ Embark::Delay(_) | it @ Embark::Hold => {
+                let host = &self.hosts[&host];
+                let dot = host.dot();
+
+                let delay = if let Embark::Delay(d) = it {
+                    Some(d)
+                } else {
+                    None
+                };
+
+                self.log
+                    .send(&self.dns, dot, host.elapsed(), dst, delay, false, &segment);
+
+                self.hosts[&pair.peer.host].embark_on(pair.flip(), delay, segment);
+            }
+            _ => unimplemented!("Drop is not supported yet"),
+        }
+    }
+
     /// Receive a message on the currently executing host.
     pub(crate) fn recv(&mut self) -> (Option<Envelope>, Rc<Notify>) {
         let addr = self.current_host().addr;
@@ -166,6 +274,19 @@ impl World {
         if let Some(Envelope { src, message, .. }) = &ret.0 {
             self.log
                 .recv(&self.dns, host.dot(), host.elapsed(), *src, &**message);
+        }
+
+        ret
+    }
+
+    /// Receive a segment from `pair's peer on the currently executing host.
+    pub(crate) fn recv_on(&mut self, pair: SocketPair) -> Option<Segment> {
+        let host = &mut self.hosts[&pair.local.host];
+        let ret = host.recv_on(pair);
+
+        if let Some(seg) = &ret {
+            self.log
+                .recv(&self.dns, host.dot(), host.elapsed(), pair.peer, seg);
         }
 
         ret

--- a/tests/net.rs
+++ b/tests/net.rs
@@ -1,0 +1,341 @@
+use std::{io, rc::Rc, str::from_utf8, time::Duration};
+
+use bytes::Bytes;
+use tokio::{
+    io::{AsyncReadExt, AsyncWriteExt},
+    sync::Notify,
+    time::timeout,
+};
+use turmoil::{net, Builder};
+
+/// Augments a stream with a simple ping/pong protocol.
+struct Connection {
+    stream: net::Stream,
+}
+
+impl Connection {
+    fn new(stream: net::Stream) -> Self {
+        Self { stream }
+    }
+
+    async fn send_ping(&mut self, how_many: u16) -> io::Result<()> {
+        self.stream.write_u16(how_many).await
+    }
+
+    async fn send_pong(&mut self) -> io::Result<()> {
+        self.stream.write_all_buf(&mut Bytes::from("pong")).await
+    }
+
+    async fn recv_ping(&mut self) -> io::Result<u16> {
+        self.stream.read_u16().await
+    }
+
+    async fn recv_pong(&mut self) -> io::Result<()> {
+        let mut buf = [0; 4];
+        self.stream.read_exact(&mut buf).await?;
+        let s = from_utf8(&buf).unwrap();
+        assert_eq!("pong", s);
+        Ok(())
+    }
+}
+
+fn assert_error_kind<T>(res: io::Result<T>, kind: io::ErrorKind) {
+    assert_eq!(res.err().map(|e| e.kind()), Some(kind));
+}
+
+#[test]
+fn network_partitions() {
+    let mut sim = Builder::new().build();
+
+    sim.host("server", || async {
+        let listener = net::Listener::bind().await.unwrap();
+        loop {
+            let _ = listener.accept().await;
+        }
+    });
+
+    sim.client("client", async {
+        turmoil::partition("client", "server");
+
+        assert_error_kind(
+            net::Stream::connect("server").await,
+            io::ErrorKind::ConnectionRefused,
+        );
+
+        turmoil::repair("client", "server");
+
+        turmoil::hold("client", "server");
+
+        assert!(
+            timeout(Duration::from_secs(1), net::Stream::connect("server"))
+                .await
+                .is_err()
+        );
+    });
+
+    sim.run();
+}
+
+#[test]
+fn hold_and_release_on_connect() {
+    let mut sim = Builder::new().build();
+
+    let timeout_secs = 1;
+
+    sim.client("server", async move {
+        let listener = net::Listener::bind().await.unwrap();
+
+        assert!(
+            timeout(Duration::from_secs(timeout_secs * 2), listener.accept())
+                .await
+                .is_err()
+        );
+    });
+
+    sim.client("client", async move {
+        turmoil::hold("client", "server");
+
+        assert!(timeout(
+            Duration::from_secs(timeout_secs),
+            net::Stream::connect("server")
+        )
+        .await
+        .is_err());
+
+        turmoil::release("client", "server");
+    });
+
+    sim.run();
+}
+
+#[test]
+fn hold_and_release_once_connected() {
+    let mut sim = Builder::new().build();
+
+    let notify = Rc::new(Notify::new());
+    let wait = notify.clone();
+
+    sim.client("server", async move {
+        let listener = net::Listener::bind().await.unwrap();
+        let (s, _) = listener.accept().await.unwrap();
+        let mut c = Connection::new(s);
+
+        wait.notified().await;
+        let _ = c.send_ping(1).await;
+    });
+
+    sim.client("client", async move {
+        let s = net::Stream::connect("server").await.unwrap();
+        let mut c = Connection::new(s);
+
+        turmoil::hold("server", "client");
+
+        notify.notify_one();
+
+        assert!(timeout(Duration::from_secs(1), c.recv_ping())
+            .await
+            .is_err());
+
+        turmoil::release("server", "client");
+
+        assert!(c.recv_ping().await.is_ok());
+    });
+
+    sim.run();
+}
+
+#[test]
+fn send_upon_accept() {
+    let mut sim = Builder::new().build();
+
+    sim.host("server", || async {
+        let listener = net::Listener::bind().await.unwrap();
+
+        while let Ok((s, _)) = listener.accept().await {
+            let mut c = Connection::new(s);
+            assert!(c.send_ping(1).await.is_ok());
+        }
+    });
+
+    sim.client("client", async {
+        let s = net::Stream::connect("server").await.unwrap();
+        let mut c = Connection::new(s);
+
+        assert!(c.recv_ping().await.is_ok());
+    });
+
+    sim.run();
+}
+
+#[test]
+fn n_responses() {
+    let mut sim = Builder::new().build();
+
+    sim.host("server", || async {
+        let listener = net::Listener::bind().await.unwrap();
+
+        while let Ok((s, _)) = listener.accept().await {
+            let mut c = Connection::new(s);
+
+            tokio::spawn(async move {
+                while let Ok(how_many) = c.recv_ping().await {
+                    for _ in 0..how_many {
+                        let _ = c.send_pong().await;
+                    }
+                }
+            });
+        }
+    });
+
+    sim.client("client", async {
+        let s = net::Stream::connect("server").await.unwrap();
+        let mut c = Connection::new(s);
+
+        let how_many = 3;
+        assert!(c.send_ping(how_many).await.is_ok());
+
+        for _ in 0..how_many {
+            assert!(c.recv_pong().await.is_ok());
+        }
+    });
+
+    sim.run();
+}
+
+#[test]
+fn server_concurrency() {
+    let mut sim = Builder::new().build();
+
+    sim.host("server", || async {
+        let listener = net::Listener::bind().await.unwrap();
+
+        while let Ok((s, _)) = listener.accept().await {
+            let mut c = Connection::new(s);
+
+            tokio::spawn(async move {
+                while let Ok(how_many) = c.recv_ping().await {
+                    for _ in 0..how_many {
+                        let _ = c.send_pong().await;
+                    }
+                }
+            });
+        }
+    });
+
+    let how_many = 3;
+
+    for i in 0..how_many {
+        sim.client(format!("client-{}", i), async move {
+            let s = net::Stream::connect("server").await.unwrap();
+            let mut c = Connection::new(s);
+
+            assert!(c.send_ping(how_many).await.is_ok());
+
+            for _ in 0..how_many {
+                assert!(c.recv_pong().await.is_ok());
+            }
+        });
+    }
+
+    sim.run();
+}
+
+#[test]
+fn drop_listener() {
+    let how_many_conns = 3;
+
+    let wait = Rc::new(Notify::new());
+    let notify = wait.clone();
+
+    let mut sim = Builder::new().build();
+
+    sim.host("server", || {
+        let notify = notify.clone();
+
+        async move {
+            let listener = net::Listener::bind().await.unwrap();
+
+            for _ in 0..how_many_conns {
+                let (s, _) = listener.accept().await.unwrap();
+                let mut c = Connection::new(s);
+
+                tokio::spawn(async move {
+                    while let Ok(how_many) = c.recv_ping().await {
+                        for _ in 0..how_many {
+                            let _ = c.send_pong().await;
+                        }
+                    }
+                });
+            }
+
+            drop(listener);
+            notify.notify_one();
+        }
+    });
+
+    sim.client("client", async move {
+        let mut conns = vec![];
+
+        for _ in 0..how_many_conns {
+            let s = net::Stream::connect("server").await.unwrap();
+            conns.push(Connection::new(s));
+        }
+
+        wait.notified().await;
+
+        for mut c in conns {
+            let how_many = 3;
+            let _ = c.send_ping(how_many).await;
+
+            for _ in 0..how_many {
+                assert!(c.recv_pong().await.is_ok());
+            }
+        }
+
+        assert_error_kind(
+            net::Stream::connect("server").await,
+            io::ErrorKind::ConnectionRefused,
+        );
+    });
+
+    sim.run();
+}
+
+#[test]
+fn drop_listener_with_non_empty_queue() {
+    let how_many_conns = 3;
+
+    let notify = Rc::new(Notify::new());
+    let wait = notify.clone();
+
+    let tick = Duration::from_millis(10);
+    let mut sim = Builder::new().tick_duration(tick).build();
+
+    sim.host("server", || {
+        let wait = wait.clone();
+
+        async move {
+            let listener = net::Listener::bind().await.unwrap();
+            wait.notified().await;
+            drop(listener);
+        }
+    });
+
+    sim.client("client", async move {
+        let mut conns = vec![];
+
+        for _ in 0..how_many_conns {
+            conns.push(tokio::task::spawn_local(net::Stream::connect("server")));
+        }
+
+        // sleep for one iteration to land syns in the listener
+        tokio::time::sleep(tick).await;
+        notify.notify_one();
+
+        for fut in conns {
+            assert_error_kind(fut.await.unwrap(), io::ErrorKind::ConnectionRefused);
+        }
+    });
+
+    sim.run();
+}

--- a/tests/net.rs
+++ b/tests/net.rs
@@ -146,7 +146,7 @@ fn hold_and_release_once_connected() {
 
 #[test]
 fn send_upon_accept() {
-    let mut sim = Builder::new().log(Path::new("/tmp/net.trace")).build();
+    let mut sim = Builder::new().build();
 
     sim.host("server", || async {
         let listener = net::Listener::bind().await.unwrap();

--- a/tests/net.rs
+++ b/tests/net.rs
@@ -1,4 +1,4 @@
-use std::{io, rc::Rc, str::from_utf8, time::Duration};
+use std::{io, path::Path, rc::Rc, str::from_utf8, time::Duration};
 
 use bytes::Bytes;
 use tokio::{
@@ -146,7 +146,7 @@ fn hold_and_release_once_connected() {
 
 #[test]
 fn send_upon_accept() {
-    let mut sim = Builder::new().build();
+    let mut sim = Builder::new().log(Path::new("/tmp/net.trace")).build();
 
     sim.host("server", || async {
         let listener = net::Listener::bind().await.unwrap();

--- a/tests/net.rs
+++ b/tests/net.rs
@@ -1,4 +1,4 @@
-use std::{io, path::Path, rc::Rc, str::from_utf8, time::Duration};
+use std::{io, rc::Rc, str::from_utf8, time::Duration};
 
 use bytes::Bytes;
 use tokio::{


### PR DESCRIPTION
The `net` module mirrors [tokio::net](https://docs.rs/tokio/latest/tokio/net/index.html).

Hosts now have the ability to bind their current `SocketAddr`,
which sets up a listener queue for accepting connections.

Connections are identified using a `SocketPair`, which is
a tuple of `version::Dot`. Note that each network operation
bumps the host's version number ensuring this is unique.

Support for "bounce" and "drop" (via RST) will follow in a subsequent
change set.
