### PR TITLE
Add `hyper` tests

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -33,3 +33,5 @@ unicycle = "0.9.2"
 
 [dev-dependencies]
 doc-comment = "0.3.3"
+hyper = { version = "0.14", features = ["full"] }
+async-stream = "0.3"

--- a/tests/hyper.rs
+++ b/tests/hyper.rs
@@ -1,0 +1,68 @@
+use std::{
+    convert::Infallible,
+    sync::{
+        atomic::{AtomicUsize, Ordering},
+        Arc,
+    },
+};
+
+use hyper::{
+    client::conn::handshake,
+    server::accept::from_stream,
+    service::{make_service_fn, service_fn},
+    Body, Request, Response, Server,
+};
+use tokio::task::spawn_local;
+use turmoil::{net, Builder};
+
+#[test]
+fn smoke() {
+    let count = Arc::new(AtomicUsize::new(0));
+    let mut sim = Builder::new().build();
+
+    sim.host("server", || {
+        let count = count.clone();
+        async move {
+            let listener = net::TcpListener::bind().await.unwrap();
+
+            let accept = from_stream(async_stream::stream! {
+                yield listener.accept().await.map(|(s, _)| s);
+            });
+
+            Server::builder(accept)
+                .serve(make_service_fn(move |_| {
+                    let count = count.clone();
+                    async move {
+                        Ok::<_, Infallible>(service_fn(move |_: Request<Body>| {
+                            let count = count.clone();
+                            async move {
+                                count.fetch_add(1, Ordering::SeqCst);
+                                Ok::<_, Infallible>(Response::new(Body::from("Hello World!")))
+                            }
+                        }))
+                    }
+                }))
+                .await
+                .unwrap();
+        }
+    });
+
+    let count = count.clone();
+    sim.client("client", async move {
+        let s = net::TcpStream::connect("server").await.unwrap();
+
+        let (mut sr, conn) = handshake(s).await.unwrap();
+
+        spawn_local(conn);
+
+        let req = Request::new(Body::empty());
+
+        sr.send_request(req).await.unwrap();
+
+        assert_eq!(count.load(Ordering::SeqCst), 1);
+
+        Ok(())
+    });
+
+    sim.run().unwrap();
+}


### PR DESCRIPTION
This PR adds a test file that tests a hyper server and client using the internal TCP implementation.

The tests currently fail due to RST not being implemented so opening this as a draft until that is merged.