### PR TITLE
Add simple simulation tracing

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -31,5 +31,3 @@ tracing = "0.1"
 
 [dev-dependencies]
 doc-comment = "0.3.3"
-
-tracing-subscriber = { version = "0.3", features = ["env-filter"] }

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,6 +27,9 @@ tokio = { version = "1.19.2", features = ["full"] }
 tokio-stream = "0.1.9"
 tokio-test = { version = "0.4.2" }
 tokio-util = "0.7.4"
+tracing = "0.1"
 
 [dev-dependencies]
 doc-comment = "0.3.3"
+
+tracing-subscriber = { version = "0.3", features = ["env-filter"] }

--- a/src/dns.rs
+++ b/src/dns.rs
@@ -31,7 +31,7 @@ impl Dns {
             .iter()
             .find(|(_, a)| **a == addr)
             .map(|(name, _)| name)
-            .expect("no hostname found for socket address")
+            .expect("no hostname found for ip address")
     }
 }
 

--- a/src/dns.rs
+++ b/src/dns.rs
@@ -26,7 +26,7 @@ impl Dns {
         addr.to_ip_addr(self)
     }
 
-    pub(crate) fn _reverse(&self, addr: IpAddr) -> &str {
+    pub(crate) fn reverse(&self, addr: IpAddr) -> &str {
         self.names
             .iter()
             .find(|(_, a)| **a == addr)

--- a/src/envelope.rs
+++ b/src/envelope.rs
@@ -1,4 +1,4 @@
-use std::net::SocketAddr;
+use std::{fmt::Display, net::SocketAddr};
 
 use bytes::Bytes;
 
@@ -11,5 +11,36 @@ pub(crate) struct Envelope {
 
 #[derive(Debug)]
 pub(crate) enum Protocol {
-    Udp(Bytes),
+    Udp(Datagram),
+}
+
+#[derive(Debug)]
+pub(crate) struct Datagram(pub Bytes);
+
+impl Display for Protocol {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Protocol::Udp(datagram) => Display::fmt(&datagram, f),
+        }
+    }
+}
+
+impl Display for Datagram {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        udp_fmt(&self.0, f)
+    }
+}
+
+fn udp_fmt(datagram: &Bytes, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+    write!(f, "UDP [")?;
+
+    for (i, &b) in datagram.iter().enumerate() {
+        if i < datagram.len() - 1 {
+            write!(f, "{:#2X}, ", b)?;
+        } else {
+            write!(f, "{:#2X}", b)?;
+        }
+    }
+
+    write!(f, "]")
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -37,6 +37,8 @@ pub use sim::Sim;
 mod top;
 use top::Topology;
 
+mod tracing;
+
 mod world;
 use world::World;
 

--- a/src/net/udp.rs
+++ b/src/net/udp.rs
@@ -1,20 +1,23 @@
 use bytes::{Buf, BufMut, Bytes};
 use tokio::sync::mpsc;
 
-use crate::{envelope::Protocol, ToSocketAddr, World};
+use crate::{
+    envelope::{Datagram, Protocol},
+    trace, ToSocketAddr, World,
+};
 
 use std::{cell::RefCell, cmp, io::Result, net::SocketAddr};
 
 /// A simulated UDP socket.
 pub struct UdpSocket {
     local_addr: SocketAddr,
-    rx: RefCell<mpsc::UnboundedReceiver<(Bytes, SocketAddr)>>,
+    rx: RefCell<mpsc::UnboundedReceiver<(Datagram, SocketAddr)>>,
 }
 
 impl UdpSocket {
     pub(crate) fn new(
         local_addr: SocketAddr,
-        rx: mpsc::UnboundedReceiver<(Bytes, SocketAddr)>,
+        rx: mpsc::UnboundedReceiver<(Datagram, SocketAddr)>,
     ) -> Self {
         Self {
             local_addr,
@@ -40,7 +43,13 @@ impl UdpSocket {
             // Unspecified -> host's IP
             addr.set_ip(host.addr);
 
-            host.udp.bind(addr)
+            let ret = host.udp.bind(addr);
+
+            if ret.is_ok() {
+                trace!("Bind {} UDP", addr);
+            }
+
+            ret
         })
     }
 
@@ -53,7 +62,7 @@ impl UdpSocket {
             world.send_message(
                 self.local_addr,
                 dst,
-                Protocol::Udp(Bytes::copy_from_slice(buf)),
+                Protocol::Udp(Datagram(Bytes::copy_from_slice(buf))),
             );
 
             Ok(buf.len())
@@ -67,10 +76,17 @@ impl UdpSocket {
     /// to hold the message bytes. If a message is too long to fit in the
     /// supplied buffer, excess bytes may be discarded.
     pub async fn recv_from(&self, buf: &mut [u8]) -> Result<(usize, SocketAddr)> {
-        let (bytes, origin) = self.rx.borrow_mut().recv().await.unwrap();
+        let (datagram, origin) = self.rx.borrow_mut().recv().await.unwrap();
+
+        // Grab the trace before we mutate things
+        let trace = format!("Recv {} {} {}", self.local_addr, origin, datagram);
+
+        let bytes = datagram.0;
         let limit = cmp::min(buf.len(), bytes.len());
 
         buf.as_mut().put(bytes.take(limit));
+
+        trace!("{}", trace);
 
         Ok((limit, origin))
     }
@@ -78,6 +94,10 @@ impl UdpSocket {
 
 impl Drop for UdpSocket {
     fn drop(&mut self) {
-        World::current_if_set(|world| world.current_host_mut().udp.unbind(self.local_addr))
+        World::current_if_set(|world| {
+            world.current_host_mut().udp.unbind(self.local_addr);
+
+            trace!("Unbind {} UDP", self.local_addr)
+        });
     }
 }

--- a/src/top.rs
+++ b/src/top.rs
@@ -1,7 +1,7 @@
-use crate::config;
 use crate::envelope::{Envelope, Protocol};
 use crate::host::Host;
 use crate::rt::Rt;
+use crate::{config, trace};
 
 use indexmap::IndexMap;
 use rand::{Rng, RngCore};
@@ -221,8 +221,14 @@ impl Link {
                 let delay = self.delay(global_config.latency(), rand);
                 DeliveryStatus::DeliverAfter(self.now + delay)
             }
-            State::Hold => DeliveryStatus::Hold,
+            State::Hold => {
+                trace!("Hold {} {} {}", src, dst, message);
+
+                DeliveryStatus::Hold
+            }
             _ => {
+                trace!("Drop {} {} {}", src, dst, message);
+
                 return;
             }
         };

--- a/src/tracing.rs
+++ b/src/tracing.rs
@@ -1,0 +1,9 @@
+/// Very simple tracing at `info` level.
+///
+/// Uses `target: "turmoil"` for subscriber filtering and routing.
+#[macro_export]
+macro_rules! trace {
+    ( $($t:tt)* ) => {{
+        tracing::info!(target: "turmoil", $($t)*)
+    }};
+}

--- a/src/world.rs
+++ b/src/world.rs
@@ -1,5 +1,5 @@
 use crate::envelope::Protocol;
-use crate::{config, Dns, Host, ToIpAddr, Topology};
+use crate::{config, trace, Dns, Host, ToIpAddr, Topology};
 
 use indexmap::IndexMap;
 use rand::RngCore;
@@ -95,6 +95,8 @@ impl World {
             "already registered host for the given socket address"
         );
 
+        trace!("New {} @{}", self.dns.reverse(addr), addr);
+
         // Register links between the new host and all existing hosts
         for existing in self.hosts.keys() {
             self.topology.register(*existing, addr);
@@ -107,6 +109,8 @@ impl World {
     /// Send `message` from `src` to `dst`. Delivery is asynchronous and not
     /// guaranteed.
     pub(crate) fn send_message(&mut self, src: SocketAddr, dst: SocketAddr, message: Protocol) {
+        trace!("Send {} {} {}", src, dst, message);
+
         self.topology
             .enqueue_message(&mut self.rng, src, dst, message);
     }

--- a/tests/udp.rs
+++ b/tests/udp.rs
@@ -71,7 +71,6 @@ fn ping_pong() -> Result {
     sim.run()
 }
 
-#[ignore]
 #[test]
 fn recv_buf_is_clipped() -> Result {
     let mut sim = Builder::new().build();


### PR DESCRIPTION
Here is an example trace ->

```txt
2022-10-20T21:20:02.325402Z  INFO turmoil: New server @127.0.0.1
2022-10-20T21:20:02.325633Z  INFO turmoil: New client @127.0.0.2
2022-10-20T21:20:02.325828Z  INFO turmoil: Bind 127.0.0.1:1738 UDP
2022-10-20T21:20:02.325937Z  INFO turmoil: Bind 127.0.0.2:1738 UDP
2022-10-20T21:20:02.325986Z  INFO turmoil: Send 127.0.0.2:1738 127.0.0.1:1738 UDP [0x70, 0x69, 0x6E, 0x67]
2022-10-20T21:20:02.328982Z  INFO turmoil: Delivered 127.0.0.1:1738 127.0.0.2:1738 UDP [0x70, 0x69, 0x6E, 0x67]
2022-10-20T21:20:02.329067Z  INFO turmoil: Recv 127.0.0.1:1738 127.0.0.2:1738 UDP [0x70, 0x69, 0x6E, 0x67]
2022-10-20T21:20:02.329092Z  INFO turmoil: Send 127.0.0.1:1738 127.0.0.2:1738 UDP [0x70, 0x6F, 0x6E, 0x67]
2022-10-20T21:20:02.329122Z  INFO turmoil: Unbind 127.0.0.1:1738 UDP
2022-10-20T21:20:02.329749Z  INFO turmoil: Delivered 127.0.0.2:1738 127.0.0.1:1738 UDP [0x70, 0x6F, 0x6E, 0x67]
2022-10-20T21:20:02.329809Z  INFO turmoil: Recv 127.0.0.2:1738 127.0.0.1:1738 UDP [0x70, 0x6F, 0x6E, 0x67]
2022-10-20T21:20:02.329832Z  INFO turmoil: Unbind 127.0.0.2:1738 UDP
```