### PR TITLE
Simulated TCP streams

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,6 +28,7 @@ tokio-stream = "0.1.9"
 tokio-test = { version = "0.4.2" }
 tokio-util = "0.7.4"
 tracing = "0.1"
+tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 
 [dev-dependencies]
 doc-comment = "0.3.3"

--- a/README.md
+++ b/README.md
@@ -32,37 +32,19 @@ turmoil = "0.2"
 Next, create a test file and add a test:
 
 ```rust
-use std::net::{IpAddr, Ipv4Addr};
-
-use turmoil::{lookup, net, Builder};
-
-let port = 1234;
-let unspecified = IpAddr::from(Ipv4Addr::UNSPECIFIED);
-
-let mut sim = Builder::new().build();
+let mut sim = turmoil::Builder::new().build();
 
 // register a host
 sim.host("server", || async move {
-    let sock = net::UdpSocket::bind((unspecified, port)).await.unwrap();
-
-    loop {
-        let mut buf = vec![0; 12];
-        let (_, origin) = sock.recv_from(&mut buf).await.unwrap();
-
-        let _ = sock.send_to(&buf, origin).await;
-    }
+    // host software goes here
 });
 
-// register a client (this is the test code)
+// register a client
 sim.client("client", async move {
-    let sock = net::UdpSocket::bind((unspecified, port)).await?;
+    // dns lookup for "server"
+    let addr = turmoil::lookup("server");
 
-    let server_addr = lookup("server");
-    sock.send_to(b"hello, world", (server_addr, port)).await?;
-
-    let mut buf = vec![0; 12];
-    let _ = sock.recv_from(&mut buf).await?;
-    assert_eq!(b"hello, world", &buf[..]);
+    // test code goes here
 
     Ok(())
 });
@@ -71,7 +53,7 @@ sim.client("client", async move {
 sim.run();
 ```
 
-For more examples, check out the [tests](tests) directory.
+For more examples (with simulated networking), check out the [tests](tests) directory.
 
 ## License
 

--- a/README.md
+++ b/README.md
@@ -53,7 +53,9 @@ sim.client("client", async move {
 sim.run();
 ```
 
-For more examples (with simulated networking), check out the [tests](tests) directory.
+See `ping_pong` in [udp.rs](tests/udp.rs) for a TCP example.
+
+For more examples, check out the [tests](tests) directory.
 
 ## License
 

--- a/src/dns.rs
+++ b/src/dns.rs
@@ -61,6 +61,7 @@ impl ToIpAddr for IpAddr {
     }
 }
 
+// Hostname and port
 impl ToSocketAddr for (String, u16) {
     fn to_socket_addr(&self, dns: &Dns) -> SocketAddr {
         (&self.0[..], self.1).to_socket_addr(dns)

--- a/src/dns.rs
+++ b/src/dns.rs
@@ -11,7 +11,7 @@ pub trait ToIpAddr {
 }
 
 pub trait ToSocketAddr {
-    fn to_socket_addr(&self) -> SocketAddr;
+    fn to_socket_addr(&self, dns: &Dns) -> SocketAddr;
 }
 
 impl Dns {
@@ -61,14 +61,29 @@ impl ToIpAddr for IpAddr {
     }
 }
 
+impl ToSocketAddr for (String, u16) {
+    fn to_socket_addr(&self, dns: &Dns) -> SocketAddr {
+        (&self.0[..], self.1).to_socket_addr(dns)
+    }
+}
+
+impl<'a> ToSocketAddr for (&'a str, u16) {
+    fn to_socket_addr(&self, dns: &Dns) -> SocketAddr {
+        match dns.names.get(self.0) {
+            Some(ip) => (*ip, self.1).into(),
+            None => panic!("no hostname found for ip address"),
+        }
+    }
+}
+
 impl ToSocketAddr for SocketAddr {
-    fn to_socket_addr(&self) -> SocketAddr {
+    fn to_socket_addr(&self, _: &Dns) -> SocketAddr {
         *self
     }
 }
 
 impl ToSocketAddr for (IpAddr, u16) {
-    fn to_socket_addr(&self) -> SocketAddr {
+    fn to_socket_addr(&self, _: &Dns) -> SocketAddr {
         (*self).into()
     }
 }

--- a/src/envelope.rs
+++ b/src/envelope.rs
@@ -1,7 +1,7 @@
 use std::{fmt::Display, net::SocketAddr};
 
 use bytes::Bytes;
-use futures::channel::oneshot;
+use tokio::sync::oneshot;
 
 #[derive(Debug)]
 pub(crate) struct Envelope {

--- a/src/envelope.rs
+++ b/src/envelope.rs
@@ -23,7 +23,7 @@ pub(crate) struct Datagram(pub Bytes);
 ///
 /// We implement just enough to ensure fidelity and provide knobs for real world
 /// scenarios, but we skip a ton of complexity (e.g. checksums, flow control,
-/// etc) because said complexity isn't useful needed in tests.
+/// etc) because said complexity isn't useful in tests.
 #[derive(Debug)]
 pub(crate) enum Segment {
     Syn(Syn),

--- a/src/envelope.rs
+++ b/src/envelope.rs
@@ -19,25 +19,17 @@ pub(crate) enum Protocol {
 #[derive(Debug)]
 pub(crate) struct Datagram(pub Bytes);
 
-/// This is a parody of TCP.
+/// This is a simplification of real TCP.
 ///
-/// We implement just enough to make it realistic, but we skip a ton of
-/// complexity (e.g. checksums, flow control, etc).
+/// We implement just enough to ensure fidelity and provide knobs for real world
+/// scenarios, but we skip a ton of complexity (e.g. checksums, flow control,
+/// etc) because said complexity isn't useful needed in tests.
 #[derive(Debug)]
 pub(crate) enum Segment {
     Syn(Syn),
-    Data(u64, StreamData),
+    Data(u64, Bytes),
     Fin(u64),
     Rst,
-}
-
-#[derive(Debug)]
-pub(crate) struct StreamData(pub Bytes);
-
-impl StreamData {
-    pub(crate) fn eof() -> Self {
-        Self(Bytes::new())
-    }
 }
 
 #[derive(Debug)]
@@ -56,8 +48,7 @@ impl Display for Protocol {
 
 impl Display for Datagram {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        write!(f, "UDP ")?;
-        hex(&self.0, f)
+        hex("UDP", &self.0, f)
     }
 }
 
@@ -65,26 +56,19 @@ impl Display for Segment {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
             Segment::Syn(_) => write!(f, "TCP SYN"),
-            Segment::Data(_, data) => Display::fmt(&data, f),
+            Segment::Data(_, data) => hex("TCP", &data, f),
             Segment::Fin(_) => write!(f, "TCP FIN"),
             Segment::Rst => write!(f, "TCP RST"),
         }
     }
 }
 
-impl Display for StreamData {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        if self.0.is_empty() {
-            write!(f, "FIN")
-        } else {
-            write!(f, "TCP ")?;
-            hex(&self.0, f)
-        }
-    }
-}
-
-fn hex(bytes: &Bytes, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-    write!(f, "[")?;
+pub(crate) fn hex(
+    protocol: &str,
+    bytes: &Bytes,
+    f: &mut std::fmt::Formatter<'_>,
+) -> std::fmt::Result {
+    write!(f, "{} [", protocol)?;
 
     for (i, &b) in bytes.iter().enumerate() {
         if i < bytes.len() - 1 {

--- a/src/envelope.rs
+++ b/src/envelope.rs
@@ -1,6 +1,7 @@
 use std::{fmt::Display, net::SocketAddr};
 
 use bytes::Bytes;
+use futures::channel::oneshot;
 
 #[derive(Debug)]
 pub(crate) struct Envelope {
@@ -11,15 +12,43 @@ pub(crate) struct Envelope {
 
 #[derive(Debug)]
 pub(crate) enum Protocol {
+    Tcp(Segment),
     Udp(Datagram),
 }
 
 #[derive(Debug)]
 pub(crate) struct Datagram(pub Bytes);
 
+/// This is a parody of TCP.
+///
+/// We implement just enough to make it realistic, but we skip a ton of
+/// complexity (e.g. checksums, flow control, etc).
+#[derive(Debug)]
+pub(crate) enum Segment {
+    Syn(Syn),
+    Data(u64, StreamData),
+    Fin(u64),
+    Rst,
+}
+
+#[derive(Debug)]
+pub(crate) struct StreamData(pub Bytes);
+
+impl StreamData {
+    pub(crate) fn eof() -> Self {
+        Self(Bytes::new())
+    }
+}
+
+#[derive(Debug)]
+pub(crate) struct Syn {
+    pub(crate) ack: oneshot::Sender<()>,
+}
+
 impl Display for Protocol {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
+            Protocol::Tcp(segment) => Display::fmt(segment, f),
             Protocol::Udp(datagram) => Display::fmt(&datagram, f),
         }
     }
@@ -27,15 +56,38 @@ impl Display for Protocol {
 
 impl Display for Datagram {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        udp_fmt(&self.0, f)
+        write!(f, "UDP ")?;
+        hex(&self.0, f)
     }
 }
 
-fn udp_fmt(datagram: &Bytes, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-    write!(f, "UDP [")?;
+impl Display for Segment {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Segment::Syn(_) => write!(f, "TCP SYN"),
+            Segment::Data(_, data) => Display::fmt(&data, f),
+            Segment::Fin(_) => write!(f, "TCP FIN"),
+            Segment::Rst => write!(f, "TCP RST"),
+        }
+    }
+}
 
-    for (i, &b) in datagram.iter().enumerate() {
-        if i < datagram.len() - 1 {
+impl Display for StreamData {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        if self.0.is_empty() {
+            write!(f, "FIN")
+        } else {
+            write!(f, "TCP ")?;
+            hex(&self.0, f)
+        }
+    }
+}
+
+fn hex(bytes: &Bytes, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+    write!(f, "[")?;
+
+    for (i, &b) in bytes.iter().enumerate() {
+        if i < bytes.len() - 1 {
             write!(f, "{:#2X}, ", b)?;
         } else {
             write!(f, "{:#2X}", b)?;

--- a/src/net/listener.rs
+++ b/src/net/listener.rs
@@ -1,4 +1,88 @@
-/// A simulated socket server, listening for connections.
+use std::{cell::RefCell, io::Result, net::SocketAddr};
+
+use tokio::sync::mpsc;
+
+use crate::{envelope::Syn, net::SocketPair, trace, world::World, ToSocketAddr};
+
+use super::TcpStream;
+
+/// A simulated TCP socket server, listening for connections.
 ///
 /// All methods must be called from a host within a Turmoil simulation.
-pub struct TcpListener;
+pub struct TcpListener {
+    local_addr: SocketAddr,
+    receiver: RefCell<mpsc::UnboundedReceiver<(Syn, SocketAddr)>>,
+}
+
+impl TcpListener {
+    pub(crate) fn new(
+        local_addr: SocketAddr,
+        receiver: mpsc::UnboundedReceiver<(Syn, SocketAddr)>,
+    ) -> Self {
+        Self {
+            local_addr,
+            receiver: RefCell::new(receiver),
+        }
+    }
+
+    /// Creates a new TcpListener, which will be bound to the specified address.
+    ///
+    /// The returned listener is ready for accepting connections.
+    ///
+    /// Only 0.0.0.0 is currently supported.
+    pub async fn bind<A: ToSocketAddr>(addr: A) -> Result<TcpListener> {
+        World::current(|world| {
+            let mut addr = addr.to_socket_addr(&world.dns);
+            let host = world.current_host_mut();
+
+            if !addr.ip().is_unspecified() {
+                panic!("{} is not supported", addr);
+            }
+
+            // Unspecified -> host's IP
+            addr.set_ip(host.addr);
+
+            host.tcp.bind(addr)
+        })
+    }
+
+    /// Accepts a new incoming connection from this listener.
+    ///
+    /// This function will yield once a new TCP connection is established. When
+    /// established, the corresponding [`TcpStream`] and the remote peer’s
+    /// address will be returned.
+    pub async fn accept(&self) -> Result<(TcpStream, SocketAddr)> {
+        loop {
+            let (syn, origin) = self.receiver.borrow_mut().recv().await.unwrap();
+            trace!(dst = ?origin, src = ?self.local_addr, protocol = %"TCP SYN", "Recv");
+
+            let maybe = World::current(|world| {
+                let host = world.current_host_mut();
+
+                // Send SYN-ACK -> origin. If Ok we proceed (acts as the ACK),
+                // else we return early to avoid host mutations.
+                let ack = syn.ack.send(());
+                trace!(src = ?self.local_addr, dst = ?origin, protocol = %"TCP SYN-ACK", "Send");
+
+                if ack.is_err() {
+                    return None;
+                }
+
+                let pair = SocketPair::new(self.local_addr, origin);
+                let rx = host.tcp.new_stream(pair);
+
+                Some((TcpStream::new(pair, rx), origin))
+            });
+
+            if let Some(accepted) = maybe {
+                return Ok(accepted);
+            }
+        }
+    }
+}
+
+impl Drop for TcpListener {
+    fn drop(&mut self) {
+        World::current_if_set(|world| world.current_host_mut().tcp.unbind(self.local_addr));
+    }
+}

--- a/src/net/listener.rs
+++ b/src/net/listener.rs
@@ -11,14 +11,11 @@ use super::TcpStream;
 /// All methods must be called from a host within a Turmoil simulation.
 pub struct TcpListener {
     local_addr: SocketAddr,
-    receiver: RefCell<mpsc::UnboundedReceiver<(Syn, SocketAddr)>>,
+    receiver: RefCell<mpsc::Receiver<(Syn, SocketAddr)>>,
 }
 
 impl TcpListener {
-    pub(crate) fn new(
-        local_addr: SocketAddr,
-        receiver: mpsc::UnboundedReceiver<(Syn, SocketAddr)>,
-    ) -> Self {
+    pub(crate) fn new(local_addr: SocketAddr, receiver: mpsc::Receiver<(Syn, SocketAddr)>) -> Self {
         Self {
             local_addr,
             receiver: RefCell::new(receiver),

--- a/src/net/mod.rs
+++ b/src/net/mod.rs
@@ -4,6 +4,8 @@
 //! a high fidelity implementation.
 
 mod listener;
+use std::net::SocketAddr;
+
 pub use listener::TcpListener;
 
 mod stream;
@@ -11,3 +13,16 @@ pub use stream::TcpStream;
 
 mod udp;
 pub use udp::UdpSocket;
+
+#[derive(Debug, Copy, Clone, Hash, Eq, PartialEq)]
+pub(crate) struct SocketPair {
+    pub(crate) local: SocketAddr,
+    pub(crate) remote: SocketAddr,
+}
+
+impl SocketPair {
+    pub(crate) fn new(local: SocketAddr, remote: SocketAddr) -> SocketPair {
+        assert_ne!(local, remote);
+        SocketPair { local, remote }
+    }
+}

--- a/src/net/stream.rs
+++ b/src/net/stream.rs
@@ -1,4 +1,188 @@
-/// A simulated connection between two hosts.
+use std::{
+    io::{self, Result},
+    pin::Pin,
+    task::{ready, Context, Poll},
+};
+
+use bytes::{Buf, Bytes};
+use futures::channel::oneshot;
+use tokio::{
+    io::{AsyncRead, AsyncWrite, ReadBuf},
+    sync::mpsc,
+};
+
+use crate::{
+    envelope::{Protocol, Segment, StreamData, Syn},
+    trace,
+    world::World,
+    ToSocketAddr,
+};
+
+use super::SocketPair;
+
+/// A simulated TCP stream between a local and a remote socket.
 ///
 /// All methods must be called from a host within a Turmoil simulation.
-pub struct TcpStream;
+// TODO: implement split_into
+pub struct TcpStream {
+    pair: SocketPair,
+    receiver: mpsc::UnboundedReceiver<StreamData>,
+    /// EOF received
+    is_closed: bool,
+    /// FIN sent, closed for writes
+    is_shutdown: bool,
+}
+
+impl TcpStream {
+    pub(crate) fn new(pair: SocketPair, receiver: mpsc::UnboundedReceiver<StreamData>) -> Self {
+        Self {
+            pair,
+            receiver,
+            is_closed: false,
+            is_shutdown: false,
+        }
+    }
+
+    /// Opens a TCP connection to a remote host.
+    pub async fn connect<A: ToSocketAddr>(addr: A) -> Result<TcpStream> {
+        let (ack, syn_ack) = oneshot::channel();
+
+        let (pair, rx) = World::current(|world| {
+            let dst = addr.to_socket_addr(&world.dns);
+            let syn = Segment::Syn(Syn { ack });
+
+            let host = world.current_host_mut();
+            let local_addr = (host.addr, host.assign_ephemeral_port()).into();
+
+            let pair = SocketPair::new(local_addr, dst);
+            let rx = host.tcp.new_stream(pair);
+            world.send_message(local_addr, dst, Protocol::Tcp(syn));
+
+            (pair, rx)
+        });
+
+        syn_ack.await.map_err(|_| {
+            io::Error::new(io::ErrorKind::ConnectionRefused, pair.remote.to_string())
+        })?;
+
+        trace!(dst = ?pair.local, src = ?pair.remote, protocol = %"TCP SYN-ACK", "Recv");
+
+        Ok(TcpStream::new(pair, rx))
+    }
+
+    fn poll_read_priv(&mut self, cx: &mut Context<'_>, buf: &mut ReadBuf) -> Poll<Result<()>> {
+        if self.is_closed || buf.capacity() == 0 {
+            return Poll::Ready(Ok(()));
+        }
+
+        match ready!(self.receiver.poll_recv(cx)) {
+            Some(data) => {
+                trace!(dst = ?self.pair.local, src = ?self.pair.remote, protocol = %data, "Recv");
+
+                let bytes = data.0.as_ref();
+                buf.put_slice(bytes);
+                self.is_closed = bytes.is_empty();
+
+                Poll::Ready(Ok(()))
+            }
+            None => Poll::Ready(Err(io::Error::new(
+                io::ErrorKind::ConnectionReset,
+                "Connection reset",
+            ))),
+        }
+    }
+
+    fn poll_write_priv(&self, _cx: &mut Context<'_>, buf: &[u8]) -> Poll<Result<usize>> {
+        if buf.remaining() == 0 {
+            return Poll::Ready(Ok(0));
+        }
+
+        if self.is_shutdown {
+            return Poll::Ready(Err(io::Error::new(
+                io::ErrorKind::BrokenPipe,
+                "Broken pipe",
+            )));
+        }
+
+        let res = World::current(|world| {
+            let bytes = Bytes::copy_from_slice(buf);
+            let len = bytes.len();
+
+            let seq = self.seq(world)?;
+            self.send(world, Segment::Data(seq, StreamData(bytes)));
+
+            Ok(len)
+        });
+
+        Poll::Ready(res)
+    }
+
+    fn poll_shutdown_priv(&mut self) -> Poll<Result<()>> {
+        if self.is_shutdown {
+            return Poll::Ready(Err(io::Error::new(
+                io::ErrorKind::NotConnected,
+                "Socket is not connected",
+            )));
+        }
+
+        let res = World::current(|world| {
+            let seq = self.seq(world)?;
+            self.send(world, Segment::Fin(seq));
+
+            self.is_shutdown = true;
+
+            Ok(())
+        });
+
+        Poll::Ready(res)
+    }
+
+    // If a seq is not assignable the connection has been reset by the
+    // peer.
+    fn seq(&self, world: &mut World) -> Result<u64> {
+        world
+            .current_host_mut()
+            .tcp
+            .assing_send_seq(self.pair)
+            .ok_or_else(|| io::Error::new(io::ErrorKind::BrokenPipe, "Broken pipe"))
+    }
+
+    fn send(&self, world: &mut World, segment: Segment) {
+        world.send_message(self.pair.local, self.pair.remote, Protocol::Tcp(segment));
+    }
+}
+
+impl AsyncRead for TcpStream {
+    fn poll_read(
+        mut self: Pin<&mut Self>,
+        cx: &mut Context<'_>,
+        buf: &mut ReadBuf,
+    ) -> Poll<Result<()>> {
+        self.poll_read_priv(cx, buf)
+    }
+}
+
+impl AsyncWrite for TcpStream {
+    fn poll_write(self: Pin<&mut Self>, cx: &mut Context<'_>, buf: &[u8]) -> Poll<Result<usize>> {
+        self.poll_write_priv(cx, buf)
+    }
+
+    fn poll_flush(self: Pin<&mut Self>, _cx: &mut Context<'_>) -> Poll<Result<()>> {
+        Poll::Ready(Ok(()))
+    }
+
+    fn poll_shutdown(mut self: Pin<&mut Self>, _cx: &mut Context<'_>) -> Poll<Result<()>> {
+        self.poll_shutdown_priv()
+    }
+}
+
+impl Drop for TcpStream {
+    fn drop(&mut self) {
+        World::current_if_set(|world| {
+            if let Some(seq) = world.current_host_mut().tcp.assing_send_seq(self.pair) {
+                self.send(world, Segment::Fin(seq));
+                world.current_host_mut().tcp.remove_stream(self.pair);
+            }
+        })
+    }
+}

--- a/src/net/stream.rs
+++ b/src/net/stream.rs
@@ -5,10 +5,9 @@ use std::{
 };
 
 use bytes::{Buf, Bytes};
-use futures::channel::oneshot;
 use tokio::{
     io::{AsyncRead, AsyncWrite, ReadBuf},
-    sync::mpsc,
+    sync::{mpsc, oneshot},
 };
 
 use crate::{

--- a/src/net/udp.rs
+++ b/src/net/udp.rs
@@ -13,14 +13,11 @@ use std::{cell::RefCell, cmp, io::Result, net::SocketAddr};
 /// All methods must be called from a host within a Turmoil simulation.
 pub struct UdpSocket {
     local_addr: SocketAddr,
-    rx: RefCell<mpsc::UnboundedReceiver<(Datagram, SocketAddr)>>,
+    rx: RefCell<mpsc::Receiver<(Datagram, SocketAddr)>>,
 }
 
 impl UdpSocket {
-    pub(crate) fn new(
-        local_addr: SocketAddr,
-        rx: mpsc::UnboundedReceiver<(Datagram, SocketAddr)>,
-    ) -> Self {
+    pub(crate) fn new(local_addr: SocketAddr, rx: mpsc::Receiver<(Datagram, SocketAddr)>) -> Self {
         Self {
             local_addr,
             rx: RefCell::new(rx),

--- a/src/sim.rs
+++ b/src/sim.rs
@@ -193,9 +193,12 @@ impl<'a> Sim<'a> {
                     // We need to move deliverable messages off the network and
                     // into the dst host. This requires two mutable borrows.
                     let World {
-                        topology, hosts, ..
+                        rng,
+                        topology,
+                        hosts,
+                        ..
                     } = world.deref_mut();
-                    topology.deliver_messages(hosts.get_mut(&addr).expect("missing host"));
+                    topology.deliver_messages(rng, hosts.get_mut(&addr).expect("missing host"));
                     // Set the current host (see method docs)
                     world.current = Some(addr);
                 }

--- a/src/top.rs
+++ b/src/top.rs
@@ -291,7 +291,7 @@ impl Link {
 
         for message in deliverable {
             let (src, dst) = (message.src, message.dst);
-            if let Some(message) = host.receive_from_network(message) {
+            if let Err(message) = host.receive_from_network(message) {
                 self.enqueue_message(global_config, rand, dst, src, message);
             }
         }

--- a/src/top.rs
+++ b/src/top.rs
@@ -131,10 +131,10 @@ impl Topology {
     }
 
     // Move messages from any network links to the `dst` host.
-    pub(crate) fn deliver_messages(&mut self, dst: &mut Host) {
+    pub(crate) fn deliver_messages(&mut self, rand: &mut dyn RngCore, dst: &mut Host) {
         for (pair, link) in &mut self.links {
             if pair.0 == dst.addr || pair.1 == dst.addr {
-                link.deliver_messages(dst);
+                link.deliver_messages(&self.config, rand, dst);
             }
         }
     }
@@ -198,6 +198,8 @@ impl Link {
         dst: SocketAddr,
         message: Protocol,
     ) {
+        trace!(?src, ?dst, protocol = %message, "Send");
+
         self.rand_partition_or_repair(global_config, rand);
         self.enqueue(global_config, rand, src, dst, message);
         self.process_deliverables();
@@ -222,12 +224,12 @@ impl Link {
                 DeliveryStatus::DeliverAfter(self.now + delay)
             }
             State::Hold => {
-                trace!("Hold {} {} {}", src, dst, message);
+                trace!(?src, ?dst, protocol = %message, "Hold");
 
                 DeliveryStatus::Hold
             }
             _ => {
-                trace!("Drop {} {} {}", src, dst, message);
+                trace!(?src, ?dst, protocol = %message, "Drop");
 
                 return;
             }
@@ -274,9 +276,24 @@ impl Link {
     // FIXME: This implementation does not respect message delivery order. If
     // host A and host B are ordered (by addr), and B sends before A, then this
     // method will deliver A's message before B's.
-    fn deliver_messages(&mut self, dst: &mut Host) {
-        for message in self.deliverable.entry(dst.addr).or_default().drain(..) {
-            dst.receive_from_network(message)
+    fn deliver_messages(
+        &mut self,
+        global_config: &config::Link,
+        rand: &mut dyn RngCore,
+        host: &mut Host,
+    ) {
+        let deliverable = self
+            .deliverable
+            .entry(host.addr)
+            .or_default()
+            .drain(..)
+            .collect::<Vec<Envelope>>();
+
+        for message in deliverable {
+            let (src, dst) = (message.src, message.dst);
+            if let Some(message) = host.receive_from_network(message) {
+                self.enqueue_message(global_config, rand, dst, src, message);
+            }
         }
     }
 

--- a/src/tracing.rs
+++ b/src/tracing.rs
@@ -1,9 +1,85 @@
-/// Very simple tracing at `info` level.
+/// Tracing via delegating to [`tracing::event!`] at `INFO` level.
 ///
 /// Uses `target: "turmoil"` for subscriber filtering and routing.
 #[macro_export]
 macro_rules! trace {
-    ( $($t:tt)* ) => {{
-        tracing::info!(target: "turmoil", $($t)*)
-    }};
+    ({ $($field:tt)+ }, $($arg:tt)+ ) => (
+        tracing::event!(
+            target: "turmoil",
+            tracing::Level::INFO,
+            { $($field)+ },
+            $($arg)+
+        )
+    );
+    ($($k:ident).+ = $($field:tt)*) => (
+        tracing::event!(
+            target: "turmoil",
+            tracing::Level::INFO,
+            { $($k).+ = $($field)*}
+        )
+    );
+    (?$($k:ident).+ = $($field:tt)*) => (
+        tracing::event!(
+            target: "turmoil",
+            tracing::Level::INFO,
+            { ?$($k).+ = $($field)*}
+        )
+    );
+    (%$($k:ident).+ = $($field:tt)*) => (
+        tracing::event!(
+            target: "turmoil",
+            tracing::Level::INFO,
+            { %$($k).+ = $($field)*}
+        )
+    );
+    ($($k:ident).+, $($field:tt)*) => (
+        tracing::event!(
+            target: "turmoil",
+            tracing::Level::INFO,
+            { $($k).+, $($field)*}
+        )
+    );
+    (?$($k:ident).+, $($field:tt)*) => (
+        tracing::event!(
+            target: "turmoil",
+            tracing::Level::INFO,
+            { ?$($k).+, $($field)*}
+        )
+    );
+    (%$($k:ident).+, $($field:tt)*) => (
+        tracing::event!(
+            target: "turmoil",
+            tracing::Level::INFO,
+            { %$($k).+, $($field)*}
+        )
+    );
+    (?$($k:ident).+) => (
+        tracing::event!(
+            target: "turmoil",
+            tracing::Level::INFO,
+            { ?$($k).+ }
+        )
+    );
+    (%$($k:ident).+) => (
+        tracing::event!(
+            target: "turmoil",
+            tracing::Level::INFO,
+            { %$($k).+ }
+        )
+    );
+    ($($k:ident).+) => (
+        tracing::event!(
+            target: "turmoil",
+            tracing::Level::INFO,
+            { $($k).+ }
+        )
+    );
+    ($($arg:tt)+) => (
+        tracing::event!(
+            target: "turmoil",
+            tracing::Level::INFO,
+            {},
+            $($arg)+
+        )
+    );
 }

--- a/src/world.rs
+++ b/src/world.rs
@@ -24,7 +24,7 @@ pub(crate) struct World {
 
     /// Random number generator used for all decisions. To make execution
     /// determinstic, reuse the same seed.
-    rng: Box<dyn RngCore>,
+    pub(crate) rng: Box<dyn RngCore>,
 }
 
 scoped_thread_local!(static CURRENT: RefCell<World>);
@@ -95,7 +95,7 @@ impl World {
             "already registered host for the given socket address"
         );
 
-        trace!("New {} @{}", self.dns.reverse(addr), addr);
+        trace!(hostname = ?self.dns.reverse(addr), ?addr, "New");
 
         // Register links between the new host and all existing hosts
         for existing in self.hosts.keys() {
@@ -109,8 +109,6 @@ impl World {
     /// Send `message` from `src` to `dst`. Delivery is asynchronous and not
     /// guaranteed.
     pub(crate) fn send_message(&mut self, src: SocketAddr, dst: SocketAddr, message: Protocol) {
-        trace!("Send {} {} {}", src, dst, message);
-
         self.topology
             .enqueue_message(&mut self.rng, src, dst, message);
     }

--- a/tests/tcp.rs
+++ b/tests/tcp.rs
@@ -1,0 +1,563 @@
+use std::{
+    io,
+    net::{IpAddr, Ipv4Addr},
+    rc::Rc,
+    time::Duration,
+};
+
+use tokio::{
+    io::{AsyncReadExt, AsyncWriteExt},
+    sync::Notify,
+    time::timeout,
+};
+use turmoil::{
+    net::{TcpListener, TcpStream},
+    Builder, Result,
+};
+
+const PORT: u16 = 1738;
+
+fn assert_error_kind<T>(res: io::Result<T>, kind: io::ErrorKind) {
+    assert_eq!(res.err().map(|e| e.kind()), Some(kind));
+}
+
+async fn bind() -> TcpListener {
+    TcpListener::bind((IpAddr::from(Ipv4Addr::UNSPECIFIED), PORT))
+        .await
+        .unwrap()
+}
+
+#[test]
+fn network_partitions_during_connect() -> Result {
+    let mut sim = Builder::new().build();
+
+    sim.host("server", || async {
+        let listener = bind().await;
+        loop {
+            let _ = listener.accept().await;
+        }
+    });
+
+    sim.client("client", async {
+        turmoil::partition("client", "server");
+
+        assert_error_kind(
+            TcpStream::connect(("server", PORT)).await,
+            io::ErrorKind::ConnectionRefused,
+        );
+
+        turmoil::repair("client", "server");
+        turmoil::hold("client", "server");
+
+        assert!(
+            timeout(Duration::from_secs(1), TcpStream::connect(("server", PORT)))
+                .await
+                .is_err()
+        );
+
+        Ok(())
+    });
+
+    sim.run()
+}
+
+#[test]
+fn client_hangup_on_connect() -> Result {
+    let mut sim = Builder::new().build();
+
+    let timeout_secs = 1;
+
+    sim.client("server", async move {
+        let listener = bind().await;
+
+        assert!(
+            timeout(Duration::from_secs(timeout_secs * 2), listener.accept())
+                .await
+                .is_err()
+        );
+
+        Ok(())
+    });
+
+    sim.client("client", async move {
+        turmoil::hold("client", "server");
+
+        assert!(timeout(
+            Duration::from_secs(timeout_secs),
+            TcpStream::connect(("server", PORT))
+        )
+        .await
+        .is_err());
+
+        turmoil::release("client", "server");
+
+        Ok(())
+    });
+
+    sim.run()
+}
+
+#[test]
+fn hold_and_release_once_connected() -> Result {
+    let mut sim = Builder::new().build();
+
+    let notify = Rc::new(Notify::new());
+    let wait = notify.clone();
+
+    sim.client("server", async move {
+        let listener = bind().await;
+        let (mut s, _) = listener.accept().await?;
+
+        wait.notified().await;
+        let _ = s.write_u8(1).await?;
+
+        Ok(())
+    });
+
+    sim.client("client", async move {
+        let mut s = TcpStream::connect(("server", PORT)).await?;
+
+        turmoil::hold("server", "client");
+
+        notify.notify_one();
+
+        assert!(timeout(Duration::from_secs(1), s.read_u8()).await.is_err());
+
+        turmoil::release("server", "client");
+
+        assert_eq!(1, s.read_u8().await?);
+
+        Ok(())
+    });
+
+    sim.run()
+}
+
+#[test]
+fn network_partition_once_connected() -> Result {
+    let mut sim = Builder::new().build();
+
+    sim.client("server", async move {
+        let listener = bind().await;
+        let (mut s, _) = listener.accept().await?;
+
+        assert!(timeout(Duration::from_secs(1), s.read_u8()).await.is_err());
+
+        s.write_u8(1).await?;
+
+        Ok(())
+    });
+
+    sim.client("client", async move {
+        let mut s = TcpStream::connect(("server", PORT)).await?;
+
+        turmoil::partition("server", "client");
+
+        s.write_u8(1).await?;
+
+        assert!(timeout(Duration::from_secs(1), s.read_u8()).await.is_err());
+
+        Ok(())
+    });
+
+    sim.run()
+}
+
+#[test]
+fn accept_front_of_line_blocking() -> Result {
+    let wait = Rc::new(Notify::new());
+    let notify = wait.clone();
+
+    let mut sim = Builder::new().build();
+
+    // We setup the simulation with hosts A, B, and C
+
+    sim.host("B", || async {
+        let listener = bind().await;
+
+        while let Ok((_, peer)) = listener.accept().await {
+            tracing::debug!("peer {}", peer);
+        }
+    });
+
+    // Hold all traffic from A:B
+    sim.client("A", async move {
+        turmoil::hold("A", "B");
+
+        assert!(
+            timeout(Duration::from_secs(1), TcpStream::connect(("B", PORT)))
+                .await
+                .is_err()
+        );
+        notify.notify_one();
+
+        Ok(())
+    });
+
+    // C:B should succeed, and should not be blocked behind the A:B, which is
+    // not eligible for delivery
+    sim.client("C", async move {
+        wait.notified().await;
+
+        let _ = TcpStream::connect(("B", PORT)).await?;
+
+        Ok(())
+    });
+
+    sim.run()
+}
+
+#[test]
+fn send_upon_accept() -> Result {
+    let mut sim = Builder::new().build();
+
+    sim.host("server", || async {
+        let listener = bind().await;
+
+        while let Ok((mut s, _)) = listener.accept().await {
+            assert!(s.write_u8(9).await.is_ok());
+        }
+    });
+
+    sim.client("client", async {
+        let mut s = TcpStream::connect(("server", PORT)).await?;
+
+        assert_eq!(9, s.read_u8().await?);
+
+        Ok(())
+    });
+
+    sim.run()
+}
+
+#[test]
+fn n_responses() -> Result {
+    let mut sim = Builder::new().build();
+
+    sim.host("server", || async {
+        let listener = bind().await;
+
+        while let Ok((mut s, _)) = listener.accept().await {
+            tokio::spawn(async move {
+                while let Ok(how_many) = s.read_u8().await {
+                    for i in 0..how_many {
+                        let _ = s.write_u8(i).await;
+                    }
+                }
+            });
+        }
+    });
+
+    sim.client("client", async {
+        let mut s = TcpStream::connect(("server", PORT)).await?;
+
+        let how_many = 3;
+        s.write_u8(how_many).await?;
+
+        for i in 0..how_many {
+            assert_eq!(i, s.read_u8().await?);
+        }
+
+        Ok(())
+    });
+
+    sim.run()
+}
+
+#[test]
+fn server_concurrency() -> Result {
+    let mut sim = Builder::new().build();
+
+    sim.host("server", || async {
+        let listener = bind().await;
+
+        while let Ok((mut s, _)) = listener.accept().await {
+            tokio::spawn(async move {
+                while let Ok(how_many) = s.read_u8().await {
+                    for i in 0..how_many {
+                        let _ = s.write_u8(i).await;
+                    }
+                }
+            });
+        }
+    });
+
+    let how_many = 3;
+
+    for i in 0..how_many {
+        sim.client(format!("client-{}", i), async move {
+            let mut s = TcpStream::connect(("server", PORT)).await?;
+
+            s.write_u8(how_many).await?;
+
+            for i in 0..how_many {
+                assert_eq!(i, s.read_u8().await?);
+            }
+
+            Ok(())
+        });
+    }
+
+    sim.run()
+}
+
+#[test]
+fn drop_listener() -> Result {
+    let how_many_conns = 3;
+
+    let wait = Rc::new(Notify::new());
+    let notify = wait.clone();
+
+    let mut sim = Builder::new().build();
+
+    sim.host("server", || {
+        let notify = notify.clone();
+
+        async move {
+            let listener = bind().await;
+
+            for _ in 0..how_many_conns {
+                let (mut s, _) = listener.accept().await.unwrap();
+                tokio::spawn(async move {
+                    while let Ok(how_many) = s.read_u8().await {
+                        for i in 0..how_many {
+                            let _ = s.write_u8(i).await;
+                        }
+                    }
+                });
+            }
+
+            drop(listener);
+            notify.notify_one();
+        }
+    });
+
+    sim.client("client", async move {
+        let mut conns = vec![];
+
+        for _ in 0..how_many_conns {
+            let s = TcpStream::connect(("server", 1738)).await?;
+            conns.push(s);
+        }
+
+        wait.notified().await;
+
+        for mut s in conns {
+            let how_many = 3;
+            let _ = s.write_u8(how_many).await;
+
+            for i in 0..how_many {
+                assert_eq!(i, s.read_u8().await?);
+            }
+        }
+
+        assert_error_kind(
+            TcpStream::connect(("server", 1738)).await,
+            io::ErrorKind::ConnectionRefused,
+        );
+
+        Ok(())
+    });
+
+    sim.run()
+}
+
+#[test]
+fn drop_listener_with_non_empty_queue() -> Result {
+    let how_many_conns = 3;
+
+    let notify = Rc::new(Notify::new());
+    let wait = notify.clone();
+
+    let tick = Duration::from_millis(10);
+    let mut sim = Builder::new().tick_duration(tick).build();
+
+    sim.host("server", || {
+        let wait = wait.clone();
+
+        async move {
+            let listener = bind().await;
+            wait.notified().await;
+            drop(listener);
+        }
+    });
+
+    sim.client("client", async move {
+        let mut conns = vec![];
+
+        for _ in 0..how_many_conns {
+            conns.push(tokio::task::spawn_local(TcpStream::connect((
+                "server", PORT,
+            ))));
+        }
+
+        // sleep for one iteration to land syns in the listener
+        tokio::time::sleep(tick).await;
+        notify.notify_one();
+
+        for fut in conns {
+            assert_error_kind(fut.await?, io::ErrorKind::ConnectionRefused);
+        }
+
+        Ok(())
+    });
+
+    sim.run()
+}
+
+#[test]
+fn recycle_server_socket_bind() -> Result {
+    let mut sim = Builder::new().build();
+
+    sim.client("server", async {
+        for _ in 0..3 {
+            let _ = TcpListener::bind((IpAddr::from(Ipv4Addr::UNSPECIFIED), 1234)).await?;
+        }
+
+        Ok(())
+    });
+
+    sim.run()
+}
+
+#[test]
+fn hangup() -> Result {
+    let notify = Rc::new(Notify::new());
+    let wait = notify.clone();
+
+    let mut sim = Builder::new().build();
+
+    sim.client("server", async move {
+        let listener = bind().await;
+        let (mut s, _) = listener.accept().await?;
+
+        let mut buf = [0; 8];
+        assert!(matches!(s.read(&mut buf).await, Ok(0)));
+
+        // Read again to ensure EOF
+        assert!(matches!(s.read(&mut buf).await, Ok(0)));
+
+        // Write until RST arrives
+        loop {
+            tokio::time::sleep(Duration::from_millis(100)).await;
+
+            if let Err(e) = s.write_u8(1).await {
+                assert_eq!(io::ErrorKind::BrokenPipe, e.kind());
+                break;
+            }
+        }
+        notify.notify_one();
+
+        Ok(())
+    });
+
+    sim.client("client", async move {
+        let s = TcpStream::connect(("server", PORT)).await?;
+
+        drop(s);
+        wait.notified().await;
+
+        Ok(())
+    });
+
+    sim.run()
+}
+
+#[test]
+fn shutdown_write() -> Result {
+    let mut sim = Builder::new().build();
+
+    sim.client("server", async move {
+        let listener = bind().await;
+        let (mut s, _) = listener.accept().await?;
+
+        for i in 1..=3 {
+            assert_eq!(i, s.read_u8().await?);
+        }
+
+        let mut buf = [0; 8];
+        assert!(matches!(s.read(&mut buf).await, Ok(0)));
+
+        for i in 0..3 {
+            s.write_u8(i).await?;
+        }
+
+        Ok(())
+    });
+
+    sim.client("client", async move {
+        let mut s = TcpStream::connect(("server", PORT)).await?;
+
+        for i in 1..=3 {
+            s.write_u8(i).await?;
+        }
+
+        s.shutdown().await?;
+
+        assert_error_kind(s.shutdown().await, io::ErrorKind::NotConnected);
+        assert_error_kind(s.write_u8(1).await, io::ErrorKind::BrokenPipe);
+
+        // Ensure the other half is still open
+        for i in 0..3 {
+            assert_eq!(i, s.read_u8().await?);
+        }
+
+        Ok(())
+    });
+
+    sim.run()
+}
+
+#[test]
+fn read_with_no_capacity() -> Result {
+    let mut sim = Builder::new().build();
+
+    sim.client("server", async move {
+        let listener = bind().await;
+        let _ = listener.accept().await?;
+
+        Ok(())
+    });
+
+    sim.client("client", async move {
+        let mut s = TcpStream::connect(("server", PORT)).await?;
+
+        // no-op
+        let mut buf = [0; 0];
+        let n = s.read(&mut buf).await?;
+        assert_eq!(0, n);
+
+        Ok(())
+    });
+
+    sim.run()
+}
+
+#[test]
+fn write_zero_bytes() -> Result {
+    let mut sim = Builder::new().build();
+
+    sim.client("server", async move {
+        let listener = bind().await;
+        let (mut s, _) = listener.accept().await?;
+
+        assert_eq!(1, s.read_u8().await?);
+
+        Ok(())
+    });
+
+    sim.client("client", async move {
+        let mut s = TcpStream::connect(("server", PORT)).await?;
+
+        // no-op
+        let buf = [0; 0];
+        s.write(&buf).await?;
+
+        // actual write to ensure server:read_u8 is not EOF
+        s.write_u8(1).await?;
+
+        Ok(())
+    });
+
+    sim.run()
+}

--- a/tests/tcp.rs
+++ b/tests/tcp.rs
@@ -509,7 +509,7 @@ fn shutdown_write() -> Result {
 }
 
 #[test]
-fn read_with_no_capacity() -> Result {
+fn read_with_empty_buffer() -> Result {
     let mut sim = Builder::new().build();
 
     sim.client("server", async move {


### PR DESCRIPTION
`TcpListener` and `TcpStream` are implemented with the minimal APIs mirrored
from `tokio::net` to be functional.

Tracing is updated to use structured k/v pairs.
