### PR TITLE
Split and reunite `TcpStream`s

### DIFF
--- a/src/net/mod.rs
+++ b/src/net/mod.rs
@@ -5,7 +5,7 @@
 
 use std::net::SocketAddr;
 
-mod tcp;
+pub mod tcp;
 pub use tcp::{listener::TcpListener, stream::TcpStream};
 
 mod udp;

--- a/src/net/mod.rs
+++ b/src/net/mod.rs
@@ -3,13 +3,10 @@
 //! They mirror [tokio::net](https://docs.rs/tokio/latest/tokio/net/) to provide
 //! a high fidelity implementation.
 
-mod listener;
 use std::net::SocketAddr;
 
-pub use listener::TcpListener;
-
-mod stream;
-pub use stream::TcpStream;
+mod tcp;
+pub use tcp::{listener::TcpListener, stream::TcpStream};
 
 mod udp;
 pub use udp::UdpSocket;

--- a/src/net/tcp/listener.rs
+++ b/src/net/tcp/listener.rs
@@ -2,9 +2,12 @@ use std::{io::Result, net::SocketAddr, sync::Arc};
 
 use tokio::sync::Notify;
 
-use crate::{net::SocketPair, trace, world::World, ToSocketAddr};
-
-use super::TcpStream;
+use crate::{
+    net::{SocketPair, TcpStream},
+    trace,
+    world::World,
+    ToSocketAddr,
+};
 
 /// A simulated TCP socket server, listening for connections.
 ///

--- a/src/net/tcp/mod.rs
+++ b/src/net/tcp/mod.rs
@@ -1,3 +1,6 @@
 pub(crate) mod listener;
-pub(crate) mod split_owned;
+
+mod split_owned;
+pub use split_owned::{OwnedReadHalf, OwnedWriteHalf};
+
 pub(crate) mod stream;

--- a/src/net/tcp/mod.rs
+++ b/src/net/tcp/mod.rs
@@ -1,0 +1,3 @@
+pub(crate) mod listener;
+pub(crate) mod split_owned;
+pub(crate) mod stream;

--- a/src/net/tcp/mod.rs
+++ b/src/net/tcp/mod.rs
@@ -1,6 +1,6 @@
 pub(crate) mod listener;
 
 mod split_owned;
-pub use split_owned::{OwnedReadHalf, OwnedWriteHalf};
+pub use split_owned::{OwnedReadHalf, OwnedWriteHalf, ReuniteError};
 
 pub(crate) mod stream;

--- a/src/net/tcp/split_owned.rs
+++ b/src/net/tcp/split_owned.rs
@@ -1,0 +1,102 @@
+use std::{
+    error::Error,
+    fmt, io,
+    pin::Pin,
+    sync::Arc,
+    task::{Context, Poll},
+};
+
+use tokio::io::{AsyncRead, AsyncWrite, ReadBuf};
+
+use crate::net::TcpStream;
+
+use super::stream::{ReadHalf, WriteHalf};
+
+/// Owned read half of a `TcpStream`, created by `into_split`.
+#[derive(Debug)]
+pub struct OwnedReadHalf {
+    pub(crate) inner: ReadHalf,
+}
+
+impl OwnedReadHalf {
+    /// Attempts to put the two halves of a `TcpStream` back together and
+    /// recover the original socket. Succeeds only if the two halves
+    /// originated from the same call to `into_split`.
+    pub fn reunite(self, other: OwnedWriteHalf) -> Result<TcpStream, ReuniteError> {
+        reunite(self, other)
+    }
+}
+
+/// Owned write half of a `TcpStream`, created by `into_split`.
+///
+/// Note that in the [`AsyncWrite`] implementation of this type, [`poll_shutdown`] will
+/// shut down the TCP stream in the write direction. Dropping the write half
+/// will also shut down the write half of the TCP stream.
+///
+/// [`AsyncWrite`]: trait@tokio::io::AsyncWrite
+/// [`poll_shutdown`]: fn@tokio::io::AsyncWrite::poll_shutdown
+#[derive(Debug)]
+pub struct OwnedWriteHalf {
+    pub(crate) inner: WriteHalf,
+}
+
+impl OwnedWriteHalf {
+    /// Attempts to put the two halves of a `TcpStream` back together and
+    /// recover the original socket. Succeeds only if the two halves
+    /// originated from the same call to `into_split`.
+    pub fn reunite(self, other: OwnedReadHalf) -> Result<TcpStream, ReuniteError> {
+        reunite(other, self)
+    }
+}
+
+fn reunite(read: OwnedReadHalf, write: OwnedWriteHalf) -> Result<TcpStream, ReuniteError> {
+    if Arc::ptr_eq(&read.inner.pair, &write.inner.pair) {
+        Ok(TcpStream::reunite(read.inner, write.inner))
+    } else {
+        Err(ReuniteError(read, write))
+    }
+}
+
+/// Error indicating that two halves were not from the same socket, and thus could
+/// not be reunited.
+#[derive(Debug)]
+pub struct ReuniteError(pub OwnedReadHalf, pub OwnedWriteHalf);
+
+impl fmt::Display for ReuniteError {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(
+            f,
+            "tried to reunite halves that are not from the same socket"
+        )
+    }
+}
+
+impl Error for ReuniteError {}
+
+impl AsyncRead for OwnedReadHalf {
+    fn poll_read(
+        mut self: Pin<&mut Self>,
+        cx: &mut Context<'_>,
+        buf: &mut ReadBuf,
+    ) -> Poll<io::Result<()>> {
+        Pin::new(&mut self.inner).poll_read(cx, buf)
+    }
+}
+
+impl AsyncWrite for OwnedWriteHalf {
+    fn poll_write(
+        mut self: Pin<&mut Self>,
+        cx: &mut Context<'_>,
+        buf: &[u8],
+    ) -> Poll<io::Result<usize>> {
+        Pin::new(&mut self.inner).poll_write(cx, buf)
+    }
+
+    fn poll_flush(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<io::Result<()>> {
+        Pin::new(&mut self.inner).poll_flush(cx)
+    }
+
+    fn poll_shutdown(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<io::Result<()>> {
+        Pin::new(&mut self.inner).poll_shutdown(cx)
+    }
+}

--- a/tests/async_send_sync.rs
+++ b/tests/async_send_sync.rs
@@ -90,7 +90,7 @@ macro_rules! assert_value {
 
 assert_value!(turmoil::net::TcpListener: Send & Sync & Unpin);
 assert_value!(turmoil::net::TcpStream: Send & Sync & Unpin);
-// assert_value!(turmoil::net::tcp::OwnedReadHalf: Send & Sync & Unpin);
-// assert_value!(turmoil::net::tcp::OwnedWriteHalf: Send & Sync & Unpin);
-// assert_value!(turmoil::net::tcp::ReuniteError: Send & Sync & Unpin);
+assert_value!(turmoil::net::tcp::OwnedReadHalf: Send & Sync & Unpin);
+assert_value!(turmoil::net::tcp::OwnedWriteHalf: Send & Sync & Unpin);
+assert_value!(turmoil::net::tcp::ReuniteError: Send & Sync & Unpin);
 async_assert_fn!(turmoil::net::TcpListener::accept(_): Send & Sync & !Unpin);


### PR DESCRIPTION
Refactor the stream to enable splitting into distinct read/write
halfs, with the ability to reunite halfs from the same stream at a
later point in time.

Each half is "owned" and may move to spawned tokio tasks.
