### PR TITLE
TcpListener implements `Send`

### DIFF
--- a/src/net/stream.rs
+++ b/src/net/stream.rs
@@ -148,7 +148,7 @@ impl TcpStream {
         world
             .current_host_mut()
             .tcp
-            .assing_send_seq(self.pair)
+            .assign_send_seq(self.pair)
             .ok_or_else(|| io::Error::new(io::ErrorKind::BrokenPipe, "Broken pipe"))
     }
 
@@ -184,7 +184,7 @@ impl AsyncWrite for TcpStream {
 impl Drop for TcpStream {
     fn drop(&mut self) {
         World::current_if_set(|world| {
-            if let Some(seq) = world.current_host_mut().tcp.assing_send_seq(self.pair) {
+            if let Some(seq) = world.current_host_mut().tcp.assign_send_seq(self.pair) {
                 self.send(world, Segment::Fin(seq));
                 world.current_host_mut().tcp.remove_stream(self.pair);
             }

--- a/tests/async_send_sync.rs
+++ b/tests/async_send_sync.rs
@@ -1,0 +1,96 @@
+//! Copied over from:
+//! https://github.com/tokio-rs/tokio/blob/master/tokio/tests/async_send_sync.rs
+
+#[allow(dead_code)]
+fn require_send<T: Send>(_t: &T) {}
+#[allow(dead_code)]
+fn require_sync<T: Sync>(_t: &T) {}
+#[allow(dead_code)]
+fn require_unpin<T: Unpin>(_t: &T) {}
+
+#[allow(dead_code)]
+struct Invalid;
+
+trait AmbiguousIfSend<A> {
+    fn some_item(&self) {}
+}
+impl<T: ?Sized> AmbiguousIfSend<()> for T {}
+impl<T: ?Sized + Send> AmbiguousIfSend<Invalid> for T {}
+
+trait AmbiguousIfSync<A> {
+    fn some_item(&self) {}
+}
+impl<T: ?Sized> AmbiguousIfSync<()> for T {}
+impl<T: ?Sized + Sync> AmbiguousIfSync<Invalid> for T {}
+
+trait AmbiguousIfUnpin<A> {
+    fn some_item(&self) {}
+}
+impl<T: ?Sized> AmbiguousIfUnpin<()> for T {}
+impl<T: ?Sized + Unpin> AmbiguousIfUnpin<Invalid> for T {}
+
+macro_rules! into_todo {
+    ($typ:ty) => {{
+        let x: $typ = todo!();
+        x
+    }};
+}
+
+macro_rules! async_assert_fn_send {
+    (Send & $(!)?Sync & $(!)?Unpin, $value:expr) => {
+        require_send(&$value);
+    };
+    (!Send & $(!)?Sync & $(!)?Unpin, $value:expr) => {
+        AmbiguousIfSend::some_item(&$value);
+    };
+}
+
+macro_rules! async_assert_fn_sync {
+    ($(!)?Send & Sync & $(!)?Unpin, $value:expr) => {
+        require_sync(&$value);
+    };
+    ($(!)?Send & !Sync & $(!)?Unpin, $value:expr) => {
+        AmbiguousIfSync::some_item(&$value);
+    };
+}
+
+macro_rules! async_assert_fn_unpin {
+    ($(!)?Send & $(!)?Sync & Unpin, $value:expr) => {
+        require_unpin(&$value);
+    };
+    ($(!)?Send & $(!)?Sync & !Unpin, $value:expr) => {
+        AmbiguousIfUnpin::some_item(&$value);
+    };
+}
+
+macro_rules! async_assert_fn {
+    ($($f:ident $(< $($generic:ty),* > )? )::+($($arg:ty),*): $($tok:tt)*) => {
+        #[allow(unreachable_code)]
+        #[allow(unused_variables)]
+        const _: fn() = || {
+            let f = $($f $(::<$($generic),*>)? )::+( $( into_todo!($arg) ),* );
+            async_assert_fn_send!($($tok)*, f);
+            async_assert_fn_sync!($($tok)*, f);
+            async_assert_fn_unpin!($($tok)*, f);
+        };
+    };
+}
+macro_rules! assert_value {
+    ($type:ty: $($tok:tt)*) => {
+        #[allow(unreachable_code)]
+        #[allow(unused_variables)]
+        const _: fn() = || {
+            let f: $type = todo!();
+            async_assert_fn_send!($($tok)*, f);
+            async_assert_fn_sync!($($tok)*, f);
+            async_assert_fn_unpin!($($tok)*, f);
+        };
+    };
+}
+
+assert_value!(turmoil::net::TcpListener: Send & Sync & Unpin);
+assert_value!(turmoil::net::TcpStream: Send & Sync & Unpin);
+// assert_value!(turmoil::net::tcp::OwnedReadHalf: Send & Sync & Unpin);
+// assert_value!(turmoil::net::tcp::OwnedWriteHalf: Send & Sync & Unpin);
+// assert_value!(turmoil::net::tcp::ReuniteError: Send & Sync & Unpin);
+async_assert_fn!(turmoil::net::TcpListener::accept(_): Send & Sync & !Unpin);

--- a/tests/tcp.rs
+++ b/tests/tcp.rs
@@ -175,9 +175,11 @@ fn accept_front_of_line_blocking() -> Result {
     sim.host("B", || async {
         let listener = bind().await;
 
-        while let Ok((_, peer)) = listener.accept().await {
-            tracing::debug!("peer {}", peer);
-        }
+        tokio::spawn(async move {
+            while let Ok((_, peer)) = listener.accept().await {
+                tracing::debug!("peer {}", peer);
+            }
+        });
     });
 
     // Hold all traffic from A:B

--- a/tests/tcp.rs
+++ b/tests/tcp.rs
@@ -175,11 +175,9 @@ fn accept_front_of_line_blocking() -> Result {
     sim.host("B", || async {
         let listener = bind().await;
 
-        tokio::spawn(async move {
-            while let Ok((_, peer)) = listener.accept().await {
-                tracing::debug!("peer {}", peer);
-            }
-        });
+        while let Ok((_, peer)) = listener.accept().await {
+            tracing::debug!("peer {}", peer);
+        }
     });
 
     // Hold all traffic from A:B


### PR DESCRIPTION
Interior mutability was initially chosen to align with the `tokio::net`
API. This actually diverged, as the listener could not be moved into
spawned tasks.

We go back to a simple `Notify` and `VecDeque` channel, which when Arc'd
can be moved into spawned tasks.
