### PR TITLE
Fix host crash behavior

### DIFF
--- a/src/world.rs
+++ b/src/world.rs
@@ -92,7 +92,7 @@ impl World {
     pub(crate) fn register(&mut self, addr: IpAddr, epoch: Instant) {
         assert!(
             !self.hosts.contains_key(&addr),
-            "already registered host for the given socket address"
+            "already registered host for the given ip address"
         );
 
         trace!(hostname = ?self.dns.reverse(addr), ?addr, "New");


### PR DESCRIPTION
I observed a bug where moving a `TcpListener` into a spawned task
was not dropped after crash returns. If you bounce the host, it would
error with `ErrorKind::AddrInUse`.

Now we also drop and replace the runtime, which has the desired
effect of blocking the calling thread until all tasks have dropped,
cleaning up all resources.
