### PR TITLE
reexport ToSocketAddrs

### DIFF
--- a/src/net/mod.rs
+++ b/src/net/mod.rs
@@ -11,6 +11,8 @@ pub use tcp::{listener::TcpListener, stream::TcpStream};
 mod udp;
 pub use udp::UdpSocket;
 
+pub use tokio::net::ToSocketAddrs;
+
 #[derive(Debug, Copy, Clone, Hash, Eq, PartialEq)]
 pub(crate) struct SocketPair {
     pub(crate) local: SocketAddr,


### PR DESCRIPTION
This PR re-export `ToSocketAddrs`. My motivation is that I am trying to integrate turmoil as a feature-gated replacement for tokio in my project, and therefore need a compatible API.
