### PR TITLE
rename ToSocketAddr to ToSocketAddrs

### DIFF
--- a/src/dns.rs
+++ b/src/dns.rs
@@ -10,7 +10,7 @@ pub trait ToIpAddr {
     fn to_ip_addr(&self, dns: &mut Dns) -> IpAddr;
 }
 
-pub trait ToSocketAddr {
+pub trait ToSocketAddrs {
     fn to_socket_addr(&self, dns: &Dns) -> SocketAddr;
 }
 
@@ -62,13 +62,13 @@ impl ToIpAddr for IpAddr {
 }
 
 // Hostname and port
-impl ToSocketAddr for (String, u16) {
+impl ToSocketAddrs for (String, u16) {
     fn to_socket_addr(&self, dns: &Dns) -> SocketAddr {
         (&self.0[..], self.1).to_socket_addr(dns)
     }
 }
 
-impl<'a> ToSocketAddr for (&'a str, u16) {
+impl<'a> ToSocketAddrs for (&'a str, u16) {
     fn to_socket_addr(&self, dns: &Dns) -> SocketAddr {
         match dns.names.get(self.0) {
             Some(ip) => (*ip, self.1).into(),
@@ -77,13 +77,13 @@ impl<'a> ToSocketAddr for (&'a str, u16) {
     }
 }
 
-impl ToSocketAddr for SocketAddr {
+impl ToSocketAddrs for SocketAddr {
     fn to_socket_addr(&self, _: &Dns) -> SocketAddr {
         *self
     }
 }
 
-impl ToSocketAddr for (IpAddr, u16) {
+impl ToSocketAddrs for (IpAddr, u16) {
     fn to_socket_addr(&self, _: &Dns) -> SocketAddr {
         (*self).into()
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -12,7 +12,7 @@ use config::Config;
 
 mod dns;
 use dns::Dns;
-pub use dns::{ToIpAddr, ToSocketAddr};
+pub use dns::{ToIpAddr, ToSocketAddrs};
 
 mod envelope;
 use envelope::Envelope;

--- a/src/net/tcp/listener.rs
+++ b/src/net/tcp/listener.rs
@@ -5,7 +5,7 @@ use tokio::sync::Notify;
 use crate::{
     net::{SocketPair, TcpStream},
     world::World,
-    ToSocketAddr, TRACING_TARGET,
+    ToSocketAddrs, TRACING_TARGET,
 };
 
 /// A simulated TCP socket server, listening for connections.
@@ -26,7 +26,7 @@ impl TcpListener {
     /// The returned listener is ready for accepting connections.
     ///
     /// Only 0.0.0.0 is currently supported.
-    pub async fn bind<A: ToSocketAddr>(addr: A) -> Result<TcpListener> {
+    pub async fn bind<A: ToSocketAddrs>(addr: A) -> Result<TcpListener> {
         World::current(|world| {
             let mut addr = addr.to_socket_addr(&world.dns);
             let host = world.current_host_mut();

--- a/src/net/tcp/stream.rs
+++ b/src/net/tcp/stream.rs
@@ -18,7 +18,7 @@ use crate::{
     host::SequencedSegment,
     net::SocketPair,
     world::World,
-    ToSocketAddr, TRACING_TARGET,
+    ToSocketAddrs, TRACING_TARGET,
 };
 
 use super::split_owned::{OwnedReadHalf, OwnedWriteHalf};
@@ -53,7 +53,7 @@ impl TcpStream {
     }
 
     /// Opens a TCP connection to a remote host.
-    pub async fn connect<A: ToSocketAddr>(addr: A) -> Result<TcpStream> {
+    pub async fn connect<A: ToSocketAddrs>(addr: A) -> Result<TcpStream> {
         let (ack, syn_ack) = oneshot::channel();
 
         let (pair, rx) = World::current(|world| {

--- a/src/net/udp.rs
+++ b/src/net/udp.rs
@@ -3,7 +3,7 @@ use tokio::sync::mpsc;
 
 use crate::{
     envelope::{Datagram, Protocol},
-    ToSocketAddr, World, TRACING_TARGET,
+    ToSocketAddrs, World, TRACING_TARGET,
 };
 
 use std::{cell::RefCell, cmp, io::Result, net::SocketAddr};
@@ -28,7 +28,7 @@ impl UdpSocket {
     /// provided.
     ///
     /// Only 0.0.0.0 is currently supported.
-    pub async fn bind<A: ToSocketAddr>(addr: A) -> Result<UdpSocket> {
+    pub async fn bind<A: ToSocketAddrs>(addr: A) -> Result<UdpSocket> {
         World::current(|world| {
             let mut addr = addr.to_socket_addr(&world.dns);
             let host = world.current_host_mut();
@@ -46,7 +46,7 @@ impl UdpSocket {
 
     /// Sends data on the socket to the given address. On success, returns the
     /// number of bytes written.
-    pub async fn send_to<A: ToSocketAddr>(&self, buf: &[u8], target: A) -> Result<usize> {
+    pub async fn send_to<A: ToSocketAddrs>(&self, buf: &[u8], target: A) -> Result<usize> {
         World::current(|world| {
             let dst = target.to_socket_addr(&world.dns);
 


### PR DESCRIPTION
Rename `ToSocketAddr` to `ToSocketAddrs` to make turmoil more compatible with tokio.

My motivation is that I am trying to mock parts of tokio with turmoil in my project, behind a feature flags. This is only possible is the crates are at least name-compatible.
