### PR TITLE
Refactor stream socket

### DIFF
--- a/src/net/tcp/listener.rs
+++ b/src/net/tcp/listener.rs
@@ -65,9 +65,9 @@ impl TcpListener {
                 }
 
                 let pair = SocketPair::new(self.local_addr, origin);
-                let rx = host.tcp.new_stream(pair);
+                host.tcp.new_stream(pair);
 
-                Some((TcpStream::new(pair, rx), origin))
+                Some((TcpStream::new(pair), origin))
             });
 
             if let Some(accepted) = maybe_accept {


### PR DESCRIPTION
This PR refactors `StreamSocket` to make use of an internal buffer along with a waker instead of using a tokio channel. This is a step towards implementing the `peek` method family on TCP stream.