### PR TITLE
implement TcpStream::peek methods

### DIFF
--- a/src/host.rs
+++ b/src/host.rs
@@ -430,4 +430,68 @@ mod test {
 
         Ok(())
     }
+
+    #[test]
+    fn socket_read() {
+        struct MockWaker(AtomicU8);
+        impl Wake for MockWaker {
+            fn wake(self: std::sync::Arc<Self>) {
+                self.0.fetch_add(1, Ordering::Relaxed);
+            }
+        }
+
+        let waker = Arc::new(MockWaker(AtomicU8::new(0)));
+
+        let mut socket = StreamSocket::new();
+        assert_eq!(
+            socket.poll_read_ready(&mut Context::from_waker(&waker.clone().into())),
+            Poll::Pending,
+        );
+        assert_eq!(waker.0.load(Ordering::Relaxed), 0);
+
+        let mut buf = [0; 512];
+        assert_eq!(socket.try_read(&mut buf), 0);
+
+        socket
+            .buffer(1, SequencedSegment::Data(Bytes::from_static(b"hello")))
+            .unwrap();
+
+        // ensure that the task was woken
+        assert_eq!(waker.0.load(Ordering::Relaxed), 1);
+        assert_eq!(
+            socket.poll_read_ready(&mut Context::from_waker(&waker.clone().into())),
+            Poll::Ready(()),
+        );
+        assert_eq!(socket.try_read(&mut buf), 5);
+        assert_eq!(&buf[..5], b"hello");
+    }
+
+    #[test]
+    fn socket_read_small_buffer() {
+        let mut socket = StreamSocket::new();
+        // In this test, we read a single segment in two calls to try_read, and make sure that no
+        // data is lost
+        socket
+            .buffer(1, SequencedSegment::Data(Bytes::from_static(b"helloworld")))
+            .unwrap();
+        let mut buf = [0; 5];
+        assert_eq!(socket.try_read(&mut buf), 5);
+        assert_eq!(&buf, b"hello");
+        assert_eq!(socket.try_read(&mut buf), 5);
+        assert_eq!(&buf, b"world");
+    }
+
+    #[test]
+    fn socket_read_two_segments() {
+        let mut socket = StreamSocket::new();
+        socket
+            .buffer(1, SequencedSegment::Data(Bytes::from_static(b"hello")))
+            .unwrap();
+        socket
+            .buffer(2, SequencedSegment::Data(Bytes::from_static(b"world")))
+            .unwrap();
+        let mut buf = [0; 10];
+        assert_eq!(socket.try_read(&mut buf), 10);
+        assert_eq!(&buf, b"helloworld");
+    }
 }

--- a/src/host.rs
+++ b/src/host.rs
@@ -3,13 +3,14 @@ use crate::net::{SocketPair, TcpListener, UdpSocket};
 use crate::world::World;
 use crate::{Envelope, TRACING_TARGET};
 
-use bytes::Bytes;
+use bytes::{Buf, Bytes};
 use indexmap::IndexMap;
 use std::collections::VecDeque;
 use std::fmt::Display;
 use std::io;
 use std::net::{IpAddr, SocketAddr};
 use std::sync::Arc;
+use std::task::{Context, Poll, Waker};
 use tokio::sync::{mpsc, Notify};
 use tokio::time::{Duration, Instant};
 
@@ -170,9 +171,6 @@ pub(crate) struct Tcp {
 
     /// Active stream sockets
     sockets: IndexMap<SocketPair, StreamSocket>,
-
-    /// TcpStream channel capacity
-    socket_capacity: usize,
 }
 
 struct ServerSocket {
@@ -183,15 +181,17 @@ struct ServerSocket {
     deque: VecDeque<(Syn, SocketAddr)>,
 }
 
-struct StreamSocket {
-    local_addr: SocketAddr,
+pub(crate) struct StreamSocket {
     buf: IndexMap<u64, SequencedSegment>,
     next_send_seq: u64,
     recv_seq: u64,
-    sender: mpsc::Sender<SequencedSegment>,
+    rcv_buffer: VecDeque<SequencedSegment>,
+    /// Waker from the last context that polled with read interest. This mirrors tokio's behaviour.
+    reader: Option<Waker>,
     /// A simple reference counter for tracking read/write half drops. Once 0, the
     /// socket may be removed from the host.
     ref_ct: usize,
+    closed: bool,
 }
 
 /// Stripped down version of [`Segment`] for delivery out to the application
@@ -212,18 +212,52 @@ impl Display for SequencedSegment {
 }
 
 impl StreamSocket {
-    fn new(local_addr: SocketAddr, capacity: usize) -> (Self, mpsc::Receiver<SequencedSegment>) {
-        let (tx, rx) = mpsc::channel(capacity);
+    fn new() -> Self {
         let sock = Self {
-            local_addr,
             buf: IndexMap::new(),
             next_send_seq: 1,
             recv_seq: 0,
-            sender: tx,
             ref_ct: 2,
+            rcv_buffer: Default::default(),
+            reader: None,
+            closed: false,
         };
 
-        (sock, rx)
+        sock
+    }
+
+    pub(crate) fn poll_read_ready(&mut self, cx: &mut Context<'_>) -> Poll<()> {
+        if self.rcv_buffer.is_empty() && !self.closed {
+            self.reader.replace(cx.waker().clone());
+            Poll::Pending
+        } else {
+            Poll::Ready(())
+        }
+    }
+
+    pub(crate) fn try_read(&mut self, buf: &mut [u8]) -> usize {
+        let mut total_read = 0;
+        while total_read < buf.len() {
+            match self.rcv_buffer.pop_front() {
+                Some(SequencedSegment::Data(mut data)) => {
+                    let n = data.len().min(buf.len() - total_read);
+                    buf[total_read..total_read + n].copy_from_slice(&data[..n]);
+                    data.advance(n);
+                    // buf is not large enough to contains all the data in the segment: re-enqueue it
+                    // for later.
+                    if data.has_remaining() {
+                        self.rcv_buffer.push_front(SequencedSegment::Data(data));
+                    }
+                    total_read += n;
+                }
+                Some(SequencedSegment::Fin) => {
+                    self.closed = true;
+                    break;
+                }
+                None => break,
+            }
+        }
+        total_read
     }
 
     fn assign_seq(&mut self) -> u64 {
@@ -235,8 +269,6 @@ impl StreamSocket {
     // Buffer and re-order received segments by `seq` as the network may deliver
     // them out of order.
     fn buffer(&mut self, seq: u64, segment: SequencedSegment) -> Result<(), Protocol> {
-        use mpsc::error::TrySendError::Closed;
-
         let exists = self.buf.insert(seq, segment);
 
         assert!(exists.is_none(), "duplicate segment {}", seq);
@@ -245,10 +277,11 @@ impl StreamSocket {
             self.recv_seq += 1;
 
             let segment = self.buf.remove(&self.recv_seq).unwrap();
-            self.sender.try_send(segment).map_err(|e| match e {
-                Closed(_) => Protocol::Tcp(Segment::Rst),
-                _ => todo!("{} socket buffer full", self.local_addr),
-            })?;
+            self.rcv_buffer.push_back(segment);
+        }
+
+        if let Some(waker) = self.reader.take() {
+            waker.wake();
         }
 
         Ok(())
@@ -262,7 +295,6 @@ impl Tcp {
             sockets: IndexMap::new(),
             // TODO: Make capacity configurable
             server_socket_capacity: 64,
-            socket_capacity: 64,
         }
     }
 
@@ -287,14 +319,12 @@ impl Tcp {
         Ok(TcpListener::new(addr, notify))
     }
 
-    pub(crate) fn new_stream(&mut self, pair: SocketPair) -> mpsc::Receiver<SequencedSegment> {
-        let (sock, rx) = StreamSocket::new(pair.local, self.socket_capacity);
+    pub(crate) fn new_stream(&mut self, pair: SocketPair) {
+        let sock = StreamSocket::new();
 
         let exists = self.sockets.insert(pair, sock);
 
         assert!(exists.is_none(), "{:?} is already connected", pair);
-
-        rx
     }
 
     pub(crate) fn accept(&mut self, addr: SocketAddr) -> Option<(Syn, SocketAddr)> {
@@ -364,11 +394,23 @@ impl Tcp {
 
         tracing::info!(target: TRACING_TARGET, ?addr, protocol = %"TCP", "Unbind");
     }
+
+    pub(crate) fn socket_mut(&mut self, pair: &SocketPair) -> Option<&mut StreamSocket> {
+        self.sockets.get_mut(pair)
+    }
 }
 
 #[cfg(test)]
 mod test {
-    use crate::{Host, Result};
+    use std::sync::atomic::{AtomicU8, Ordering};
+    use std::sync::Arc;
+    use std::task::{Context, Poll, Wake};
+
+    use bytes::Bytes;
+
+    use crate::{host::SequencedSegment, Host, Result};
+
+    use super::StreamSocket;
 
     #[test]
     fn recycle_ports() -> Result {

--- a/src/net/tcp/listener.rs
+++ b/src/net/tcp/listener.rs
@@ -65,9 +65,9 @@ impl TcpListener {
                 }
 
                 let pair = SocketPair::new(self.local_addr, origin);
-                let rx = host.tcp.new_stream(pair);
+                host.tcp.new_stream(pair);
 
-                Some((TcpStream::new(pair, rx), origin))
+                Some((TcpStream::new(pair), origin))
             });
 
             if let Some(accepted) = maybe_accept {

--- a/src/net/tcp/stream.rs
+++ b/src/net/tcp/stream.rs
@@ -10,12 +10,11 @@ use std::{
 use bytes::{Buf, Bytes};
 use tokio::{
     io::{AsyncRead, AsyncWrite, ReadBuf},
-    sync::{mpsc, oneshot},
+    sync::oneshot,
 };
 
 use crate::{
     envelope::{Protocol, Segment, Syn},
-    host::SequencedSegment,
     net::SocketPair,
     world::World,
     ToSocketAddr, TRACING_TARGET,
@@ -33,13 +32,9 @@ pub struct TcpStream {
 }
 
 impl TcpStream {
-    pub(crate) fn new(pair: SocketPair, receiver: mpsc::Receiver<SequencedSegment>) -> Self {
+    pub(crate) fn new(pair: SocketPair) -> Self {
         let pair = Arc::new(pair);
-        let read_half = ReadHalf {
-            pair: pair.clone(),
-            receiver,
-            is_closed: false,
-        };
+        let read_half = ReadHalf { pair: pair.clone() };
 
         let write_half = WriteHalf {
             pair,
@@ -56,7 +51,7 @@ impl TcpStream {
     pub async fn connect<A: ToSocketAddr>(addr: A) -> Result<TcpStream> {
         let (ack, syn_ack) = oneshot::channel();
 
-        let (pair, rx) = World::current(|world| {
+        let pair = World::current(|world| {
             let dst = addr.to_socket_addr(&world.dns);
             let syn = Segment::Syn(Syn { ack });
 
@@ -64,10 +59,10 @@ impl TcpStream {
             let local_addr = (host.addr, host.assign_ephemeral_port()).into();
 
             let pair = SocketPair::new(local_addr, dst);
-            let rx = host.tcp.new_stream(pair);
+            host.tcp.new_stream(pair);
             world.send_message(local_addr, dst, Protocol::Tcp(syn));
 
-            (pair, rx)
+            pair
         });
 
         syn_ack.await.map_err(|_| {
@@ -76,7 +71,7 @@ impl TcpStream {
 
         tracing::trace!(target: TRACING_TARGET, dst = ?pair.local, src = ?pair.remote, protocol = %"TCP SYN-ACK", "Recv");
 
-        Ok(TcpStream::new(pair, rx))
+        Ok(TcpStream::new(pair))
     }
 
     /// Returns the local address that this stream is bound to.
@@ -115,48 +110,39 @@ impl TcpStream {
     }
 }
 
+#[derive(Debug)]
 pub(crate) struct ReadHalf {
     pub(crate) pair: Arc<SocketPair>,
-    receiver: mpsc::Receiver<SequencedSegment>,
-    /// FIN received, EOF for reades
-    is_closed: bool,
 }
 
 impl ReadHalf {
     fn poll_read_priv(&mut self, cx: &mut Context<'_>, buf: &mut ReadBuf) -> Poll<Result<()>> {
-        if self.is_closed || buf.capacity() == 0 {
+        if buf.capacity() == 0 {
             return Poll::Ready(Ok(()));
         }
 
-        match ready!(self.receiver.poll_recv(cx)) {
-            Some(seg) => {
-                tracing::trace!(target: TRACING_TARGET, dst = ?self.pair.local, src = ?self.pair.remote, protocol = %seg, "Recv");
-
-                match seg {
-                    SequencedSegment::Data(bytes) => {
-                        buf.put_slice(bytes.as_ref());
-                    }
-                    SequencedSegment::Fin => {
-                        self.is_closed = true;
+        World::current(|world| {
+            let host = world.current_host_mut();
+            match host.tcp.socket_mut(&self.pair) {
+                Some(socket) => {
+                    ready!(socket.poll_read_ready(cx));
+                    unsafe {
+                        let buffer = std::slice::from_raw_parts_mut(
+                            buf.unfilled_mut().as_mut_ptr() as _,
+                            buf.remaining(),
+                        );
+                        let n = socket.try_read(buffer);
+                        buf.assume_init(buf.initialized().len() + n);
+                        buf.advance(n);
+                        Poll::Ready(Ok(()))
                     }
                 }
-
-                Poll::Ready(Ok(()))
+                None => Poll::Ready(Err(io::Error::new(
+                    io::ErrorKind::ConnectionReset,
+                    "Connection reset",
+                ))),
             }
-            None => Poll::Ready(Err(io::Error::new(
-                io::ErrorKind::ConnectionReset,
-                "Connection reset",
-            ))),
-        }
-    }
-}
-
-impl Debug for ReadHalf {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        f.debug_struct("ReadHalf")
-            .field("pair", &self.pair)
-            .field("is_closed", &self.is_closed)
-            .finish()
+        })
     }
 }
 

--- a/tests/tcp.rs
+++ b/tests/tcp.rs
@@ -613,3 +613,33 @@ fn split() -> Result {
 
     sim.run()
 }
+
+#[test]
+fn peek() -> Result {
+    let mut sim = Builder::new().build();
+
+    sim.client("server", async move {
+        let listener = bind().await;
+        let (stream, _) = listener.accept().await?;
+        let mut buf = [0; 10];
+        assert_eq!(stream.peek(&mut buf).await.unwrap(), 5);
+        assert_eq!(&buf[..5], b"hello");
+
+        // peek twice
+        let mut buf = [0; 10];
+        assert_eq!(stream.peek(&mut buf).await.unwrap(), 5);
+        assert_eq!(&buf[..5], b"hello");
+
+        Ok(())
+    });
+
+    sim.client("client", async move {
+        let mut s = TcpStream::connect(("server", PORT)).await?;
+
+        s.write_all(b"hello").await.unwrap();
+
+        Ok(())
+    });
+
+    sim.run()
+}


### PR DESCRIPTION
This PR implements the `TcpStream` `peek` and `poll_peek` methods.

depends on #63
