### PR TITLE
Fix host elapsed time across software restarts

### DIFF
--- a/src/builder.rs
+++ b/src/builder.rs
@@ -1,7 +1,7 @@
 use crate::*;
 
 use rand::{RngCore, SeedableRng};
-use std::time::Duration;
+use std::time::{Duration, SystemTime};
 
 /// Configure the simulation
 pub struct Builder {
@@ -22,6 +22,12 @@ impl Builder {
                 message_loss: Some(config::MessageLoss::default()),
             },
         }
+    }
+
+    /// When the simulation starts.
+    pub fn epoch(&mut self, value: SystemTime) -> &mut Self {
+        self.config.epoch = value;
+        self
     }
 
     /// How long the test should run for in simulated time

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,5 +1,5 @@
 use rand_distr::Exp;
-use std::time::Duration;
+use std::time::{Duration, SystemTime};
 
 #[derive(Clone)]
 pub(crate) struct Config {
@@ -8,6 +8,9 @@ pub(crate) struct Config {
 
     /// How much simulated time should elapse each tick
     pub(crate) tick: Duration,
+
+    /// When the simulation starts
+    pub(crate) epoch: SystemTime,
 }
 
 /// Configures link behavior.
@@ -48,6 +51,7 @@ impl Default for Config {
         Config {
             duration: Duration::from_secs(10),
             tick: Duration::from_millis(1),
+            epoch: SystemTime::now(),
         }
     }
 }

--- a/src/role.rs
+++ b/src/role.rs
@@ -37,7 +37,16 @@ impl<'a> Role<'a> {
         }
     }
 
-    pub(crate) fn tick(&self, duration: Duration) -> Instant {
+    pub(crate) fn now(&self) -> Instant {
+        let rt = match self {
+            Role::Client { rt, .. } => rt,
+            Role::Simulated { rt, .. } => rt,
+        };
+
+        rt.now()
+    }
+
+    pub(crate) fn tick(&self, duration: Duration) {
         let rt = match self {
             Role::Client { rt, .. } => rt,
             Role::Simulated { rt, .. } => rt,

--- a/src/rt.rs
+++ b/src/rt.rs
@@ -56,16 +56,11 @@ impl Rt {
     // 3. Other tasks on the `LocalSet` get a chance to run
     // 4. The sleep finishes
     // 5. The runtime pauses
-    //
-    // Return the finish time and store that in [`crate::Host::now`] to maintain
-    // the host's local elapsed duration.
-    pub(crate) fn tick(&self, duration: Duration) -> Instant {
+    pub(crate) fn tick(&self, duration: Duration) {
         self.block_on(async {
             self.local
                 .run_until(async {
                     sleep(duration).await;
-
-                    Instant::now()
                 })
                 .await
         })

--- a/src/world.rs
+++ b/src/world.rs
@@ -6,7 +6,7 @@ use rand::RngCore;
 use scoped_tls::scoped_thread_local;
 use std::cell::RefCell;
 use std::net::{IpAddr, SocketAddr};
-use tokio::time::Instant;
+use std::time::Duration;
 
 /// Tracks all the state for the simulated world.
 pub(crate) struct World {
@@ -89,7 +89,7 @@ impl World {
     }
 
     /// Register a new host with the simulation.
-    pub(crate) fn register(&mut self, addr: IpAddr, epoch: Instant) {
+    pub(crate) fn register(&mut self, addr: IpAddr) {
         assert!(
             !self.hosts.contains_key(&addr),
             "already registered host for the given ip address"
@@ -103,7 +103,7 @@ impl World {
         }
 
         // Initialize host state
-        self.hosts.insert(addr, Host::new(addr, epoch));
+        self.hosts.insert(addr, Host::new(addr));
     }
 
     /// Send `message` from `src` to `dst`. Delivery is asynchronous and not
@@ -113,8 +113,11 @@ impl World {
             .enqueue_message(&mut self.rng, src, dst, message);
     }
 
-    /// Tick the host at `addr` to `now`.
-    pub(crate) fn tick(&mut self, addr: IpAddr, now: Instant) {
-        self.hosts.get_mut(&addr).expect("missing host").tick(now);
+    /// Tick the host at `addr` by `duration`.
+    pub(crate) fn tick(&mut self, addr: IpAddr, duration: Duration) {
+        self.hosts
+            .get_mut(&addr)
+            .expect("missing host")
+            .tick(duration);
     }
 }


### PR DESCRIPTION
Previously, we simply tracked the elapsed duration after each tick. This makes it impossible to get a host-level view of elapsed time from within the software. Software _could_ use an `Instant` + base `SystemTime` approach, but the `Instant` has issues across host restarts as the tokio runtime is replaced.

This change fixes that by tracking bulk elapsed time on each tick and uses that as a base along with a new `Instant` that is set each time the software runs. With the elapsed base we can accurately give a current elapsed time to running software and survive restarts.

I admit this isn't the cleanest, but I can't figure out how to use a single `Instant` across runtimes, and re-using the runtime seems a lot more complicated.