### PR TITLE
Add host error support

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ let mut sim = turmoil::Builder::new().build();
 sim.host("server", || async move {
     // host software goes here
 
-    Err("Host software finished unexpectedly")?
+    Ok(())
 });
 
 // register a client

--- a/README.md
+++ b/README.md
@@ -40,6 +40,8 @@ let mut sim = turmoil::Builder::new().build();
 // register a host
 sim.host("server", || async move {
     // host software goes here
+
+    Err("Host software finished unexpectedly")?
 });
 
 // register a client

--- a/src/role.rs
+++ b/src/role.rs
@@ -19,7 +19,7 @@ pub(crate) enum Role<'a> {
     Simulated {
         rt: Rt,
         software: Software<'a>,
-        handle: Option<JoinHandle<Result>>,
+        handle: JoinHandle<Result>,
     },
 }
 
@@ -38,7 +38,7 @@ impl<'a> Role<'a> {
         Self::Simulated {
             rt,
             software: wrapped,
-            handle: Some(handle),
+            handle,
         }
     }
 

--- a/tests/tcp.rs
+++ b/tests/tcp.rs
@@ -5,7 +5,7 @@ use std::{
     time::Duration,
 };
 
-use futures::future;
+use std::future;
 use tokio::{
     io::{AsyncReadExt, AsyncWriteExt},
     sync::Notify,


### PR DESCRIPTION
This change only captures a host failure during a run of a simulation. Bounces assign a new JoinHandle which is checked after a subsequent run. This change is a breaking change for those that do not produce a `Result` or loop forever.

Since this approach removes the host runtime from the `rts` map when it completes, a few of the existing tests would fail as all of the resources owned by completed hosts would be dropped. I opted to use `future::pending()` to prevent the host from finishing on the happy path, as this seems preferable. However, I can handle hosts differently if the previous behavior is preferred.

This addresses #36.