### PR TITLE
Make tokio unstable opt in

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ examples, check out the [tests](tests) directory.
 
 ### tokio_unstable
 
-Turmoil uses [unhandled_panic] to foward host panics as test failures. See
+Turmoil uses [unhandled_panic] to forward host panics as test failures. See
 [unstable features] to opt in.
 
 [unhandled_panic]: https://docs.rs/tokio/latest/tokio/runtime/struct.Builder.html#method.unhandled_panic

--- a/README.md
+++ b/README.md
@@ -58,10 +58,16 @@ sim.client("client", async move {
 sim.run();
 ```
 
-`RUSTFLAG="--cfg tokio_unstable"` is necessary to compile the project.
-
 See `ping_pong` in [udp.rs](tests/udp.rs) for a networking example. For more
 examples, check out the [tests](tests) directory.
+
+### tokio_unstable
+
+Turmoil uses [unhandled_panic] to foward host panics as test failures. See
+[unstable features] to opt in.
+
+[unhandled_panic]: https://docs.rs/tokio/latest/tokio/runtime/struct.Builder.html#method.unhandled_panic
+[unstable features]: https://docs.rs/tokio/latest/tokio/#unstable-features
 
 ## License
 

--- a/src/rt.rs
+++ b/src/rt.rs
@@ -85,9 +85,8 @@ impl Rt {
 fn init() -> (Runtime, LocalSet) {
     let mut builder = tokio::runtime::Builder::new_current_thread();
 
-    if cfg!(tokio_unstable) {
-        builder.unhandled_panic(tokio::runtime::UnhandledPanic::ShutdownRuntime);
-    }
+    #[cfg(tokio_unstable)]
+    builder.unhandled_panic(tokio::runtime::UnhandledPanic::ShutdownRuntime);
 
     let tokio = builder.enable_time().start_paused(true).build().unwrap();
 
@@ -102,9 +101,8 @@ fn init() -> (Runtime, LocalSet) {
 fn new_local() -> LocalSet {
     let mut local = LocalSet::new();
 
-    if cfg!(tokio_unstable) {
-        local.unhandled_panic(tokio::runtime::UnhandledPanic::ShutdownRuntime);
-    }
+    #[cfg(tokio_unstable)]
+    local.unhandled_panic(tokio::runtime::UnhandledPanic::ShutdownRuntime);
 
     local
 }

--- a/src/rt.rs
+++ b/src/rt.rs
@@ -83,12 +83,13 @@ impl Rt {
 }
 
 fn init() -> (Runtime, LocalSet) {
-    let tokio = tokio::runtime::Builder::new_current_thread()
-        .enable_time()
-        .start_paused(true)
-        .unhandled_panic(tokio::runtime::UnhandledPanic::ShutdownRuntime)
-        .build()
-        .unwrap();
+    let mut builder = tokio::runtime::Builder::new_current_thread();
+
+    if cfg!(tokio_unstable) {
+        builder.unhandled_panic(tokio::runtime::UnhandledPanic::ShutdownRuntime);
+    }
+
+    let tokio = builder.enable_time().start_paused(true).build().unwrap();
 
     tokio.block_on(async {
         // Sleep to "round" `Instant::now()` to the closest `ms`
@@ -100,6 +101,10 @@ fn init() -> (Runtime, LocalSet) {
 
 fn new_local() -> LocalSet {
     let mut local = LocalSet::new();
-    local.unhandled_panic(tokio::runtime::UnhandledPanic::ShutdownRuntime);
+
+    if cfg!(tokio_unstable) {
+        local.unhandled_panic(tokio::runtime::UnhandledPanic::ShutdownRuntime);
+    }
+
     local
 }


### PR DESCRIPTION
We use `unhandled_panic` to forward host software panics 
as test failures.

Consider the test:

```rust
#[test]
fn panics() -> turmoil::Result {
    let mut sim = turmoil::Builder::new().build();

    sim.host("host", || async {
        tokio::spawn(async { panic!("boom!") });

        future::pending().await
    });

    sim.client("client", async { Ok(()) });

    sim.run()
}
```

With `tokio_unstable` the test fails, which can be useful for
uncovering issues early.

Forcing this is a bit invasive for consumers of the crate, so
instead we make it enabled conditionally.
