### PR TITLE
Expose a mechanism to manually drive the Sim

### DIFF
--- a/src/sim.rs
+++ b/src/sim.rs
@@ -287,7 +287,7 @@ impl<'a> Sim<'a> {
             ))?;
         }
 
-        return Ok(is_finished);
+        Ok(is_finished)
     }
 }
 


### PR DESCRIPTION
Break out the inside of the `run()` loop into a public method
to allow callers to create their own event loop.

Callers can now run custom logic each iteration of the simulation
to support richer test scenarios.

More changes will follow to add finer grained control over the
network.
