### PR TITLE
Add option to query hosts via regex

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -14,6 +14,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix :
+        features: ["", regex]
         os: [ubuntu-latest]
     steps:
       - name: Git Checkout
@@ -27,7 +28,7 @@ jobs:
       - name: Cargo Test
         uses: actions-rs/cargo@v1
         with:
-          command: test
+          command: test --features "${{ matrix.features }}"
           args: --verbose
 
   clippy:

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -28,8 +28,8 @@ jobs:
       - name: Cargo Test
         uses: actions-rs/cargo@v1
         with:
-          command: test --features "${{ matrix.features }}"
-          args: --verbose
+          command: test
+          args: --verbose --features "${{ matrix.features }}"
 
   clippy:
     name: Run Clippy

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,6 +22,7 @@ futures = "0.3"
 indexmap = "1.9"
 rand = { version = "0.8.5", features = ["small_rng"] }
 rand_distr = "0.4.3"
+regex = "1"
 scoped-tls = "1.0.0"
 tokio = { version = "1.24.1", features = ["full"] }
 tokio-stream = "0.1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,7 +22,7 @@ futures = "0.3"
 indexmap = "1.9"
 rand = { version = "0.8.5", features = ["small_rng"] }
 rand_distr = "0.4.3"
-regex = "1"
+regex = { version = "1", optional = true }
 scoped-tls = "1.0.0"
 tokio = { version = "1.24.1", features = ["full"] }
 tokio-stream = "0.1"
@@ -33,3 +33,8 @@ tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 
 [dev-dependencies]
 doc-comment = "0.3.3"
+regex = "1"
+
+[features]
+default = []
+regex = ["dep:regex"]

--- a/src/dns.rs
+++ b/src/dns.rs
@@ -81,9 +81,12 @@ where
     }
 }
 
-impl ToIpAddrs for Vec<IpAddr> {
-    fn to_ip_addrs(&self, _: &mut Dns) -> Vec<IpAddr> {
-        self.clone()
+impl<T> ToIpAddrs for Vec<T>
+where
+    T: ToIpAddr,
+{
+    fn to_ip_addrs(&self, dns: &mut Dns) -> Vec<IpAddr> {
+        self.iter().map(|addr| addr.to_ip_addr(dns)).collect()
     }
 }
 

--- a/src/dns.rs
+++ b/src/dns.rs
@@ -82,15 +82,6 @@ where
     }
 }
 
-impl<T> ToIpAddrs for Vec<T>
-where
-    T: ToIpAddr,
-{
-    fn to_ip_addrs(&self, dns: &mut Dns) -> Vec<IpAddr> {
-        self.iter().map(|addr| addr.to_ip_addr(dns)).collect()
-    }
-}
-
 #[cfg(feature = "regex")]
 impl ToIpAddrs for Regex {
     fn to_ip_addrs(&self, dns: &mut Dns) -> Vec<IpAddr> {

--- a/src/dns.rs
+++ b/src/dns.rs
@@ -1,4 +1,5 @@
 use indexmap::IndexMap;
+#[cfg(feature = "regex")]
 use regex::Regex;
 use std::net::{IpAddr, SocketAddr};
 
@@ -90,6 +91,7 @@ where
     }
 }
 
+#[cfg(feature = "regex")]
 impl ToIpAddrs for Regex {
     fn to_ip_addrs(&self, dns: &mut Dns) -> Vec<IpAddr> {
         #[allow(clippy::needless_collect)]

--- a/src/envelope.rs
+++ b/src/envelope.rs
@@ -70,13 +70,13 @@ pub(crate) fn hex(
     bytes: &Bytes,
     f: &mut std::fmt::Formatter<'_>,
 ) -> std::fmt::Result {
-    write!(f, "{} [", protocol)?;
+    write!(f, "{protocol} [")?;
 
     for (i, &b) in bytes.iter().enumerate() {
         if i < bytes.len() - 1 {
-            write!(f, "{:#2X}, ", b)?;
+            write!(f, "{b:#2X}, ")?;
         } else {
-            write!(f, "{:#2X}", b)?;
+            write!(f, "{b:#2X}")?;
         }
     }
 

--- a/src/host.rs
+++ b/src/host.rs
@@ -159,14 +159,14 @@ impl Udp {
     fn receive_from_network(&mut self, src: SocketAddr, dst: SocketAddr, datagram: Datagram) {
         if let Some(s) = self.binds.get_mut(&dst) {
             s.try_send((datagram, src))
-                .unwrap_or_else(|_| panic!("unable to send to {}", dst))
+                .unwrap_or_else(|_| panic!("unable to send to {dst}"))
         }
     }
 
     pub(crate) fn unbind(&mut self, addr: SocketAddr) {
         let exists = self.binds.remove(&addr);
 
-        assert!(exists.is_some(), "unknown bind {}", addr);
+        assert!(exists.is_some(), "unknown bind {addr}");
 
         tracing::info!(target: TRACING_TARGET, ?addr, protocol = %"UDP", "Unbind");
     }
@@ -250,7 +250,7 @@ impl StreamSocket {
 
         let exists = self.buf.insert(seq, segment);
 
-        assert!(exists.is_none(), "duplicate segment {}", seq);
+        assert!(exists.is_none(), "duplicate segment {seq}");
 
         while self.buf.contains_key(&(self.recv_seq + 1)) {
             self.recv_seq += 1;
@@ -303,7 +303,7 @@ impl Tcp {
 
         let exists = self.sockets.insert(pair, sock);
 
-        assert!(exists.is_none(), "{:?} is already connected", pair);
+        assert!(exists.is_none(), "{pair:?} is already connected");
 
         rx
     }
@@ -371,7 +371,7 @@ impl Tcp {
     pub(crate) fn unbind(&mut self, addr: SocketAddr) {
         let exists = self.binds.remove(&addr);
 
-        assert!(exists.is_some(), "unknown bind {}", addr);
+        assert!(exists.is_some(), "unknown bind {addr}");
 
         tracing::info!(target: TRACING_TARGET, ?addr, protocol = %"TCP", "Unbind");
     }

--- a/src/net/tcp/listener.rs
+++ b/src/net/tcp/listener.rs
@@ -32,7 +32,7 @@ impl TcpListener {
             let host = world.current_host_mut();
 
             if !addr.ip().is_unspecified() {
-                panic!("{} is not supported", addr);
+                panic!("{addr} is not supported");
             }
 
             // Unspecified -> host's IP

--- a/src/net/udp.rs
+++ b/src/net/udp.rs
@@ -34,7 +34,7 @@ impl UdpSocket {
             let host = world.current_host_mut();
 
             if !addr.ip().is_unspecified() {
-                panic!("{} is not supported", addr);
+                panic!("{addr} is not supported");
             }
 
             // Unspecified -> host's IP

--- a/src/rt.rs
+++ b/src/rt.rs
@@ -78,7 +78,7 @@ impl Rt {
         let (tokio, local) = init();
 
         _ = mem::replace(&mut self.tokio, tokio);
-        _ = mem::replace(&mut self.local, local);
+        drop(mem::replace(&mut self.local, local));
     }
 }
 

--- a/src/sim.rs
+++ b/src/sim.rs
@@ -105,8 +105,9 @@ impl<'a> Sim<'a> {
         self.rts.insert(addr, Role::simulated(rt, host, handle));
     }
 
-    /// Crashes a host(s). Nothing will be running on the matched hosts after this method. You can
-    /// use [`Sim::bounce`] to start the hosts up again.
+    /// Crashes the resolved hosts. Nothing will be running on the matched hosts
+    /// after this method. You can use [`Sim::bounce`] to start the hosts up
+    /// again.
     pub fn crash(&mut self, addrs: impl ToIpAddrs) {
         self.run_with_hosts(addrs, |rt| match rt {
             Role::Client { .. } => panic!("can only bounce hosts, not clients"),
@@ -116,7 +117,7 @@ impl<'a> Sim<'a> {
         });
     }
 
-    /// Bounce a host(s). The software is restarted.
+    /// Bounces the resolved hosts. The software is restarted.
     pub fn bounce(&mut self, addrs: impl ToIpAddrs) {
         self.run_with_hosts(addrs, |rt| match rt {
             Role::Client { .. } => panic!("can only bounce hosts, not clients"),
@@ -131,7 +132,7 @@ impl<'a> Sim<'a> {
         });
     }
 
-    /// Run `f` with the host(s) at `addr` set on the world.
+    /// Run `f` with the resolved hosts at `addrs` set on the world.
     fn run_with_hosts(&mut self, addrs: impl ToIpAddrs, mut f: impl FnMut(&mut Role)) {
         let hosts = self.world.borrow_mut().lookup_many(addrs);
         for h in hosts {
@@ -145,7 +146,7 @@ impl<'a> Sim<'a> {
         self.world.borrow_mut().current = None;
     }
 
-    /// Lookup an ip address by host name.
+    /// Lookup an IP address by host name.
     pub fn lookup(&self, addr: impl ToIpAddr) -> IpAddr {
         self.world.borrow_mut().lookup(addr)
     }
@@ -162,7 +163,7 @@ impl<'a> Sim<'a> {
         )
     }
 
-    /// Lookup an ip address by host name.
+    /// Lookup IP addresses for resolved hosts.
     pub fn lookup_many(&self, addr: impl ToIpAddrs) -> Vec<IpAddr> {
         self.world.borrow_mut().lookup_many(addr)
     }
@@ -565,9 +566,9 @@ mod test {
 
         sim.run()?;
         assert_eq!(count.load(Ordering::SeqCst), 3);
-        sim.bounce(Regex::new("host-\\d").unwrap());
+        sim.bounce(Regex::new("host-[12]")?);
         sim.run()?;
-        assert_eq!(count.load(Ordering::SeqCst), 6);
+        assert_eq!(count.load(Ordering::SeqCst), 5);
 
         Ok(())
     }

--- a/src/sim.rs
+++ b/src/sim.rs
@@ -333,7 +333,6 @@ mod test {
         time::Duration,
     };
 
-    use regex::Regex;
     use std::future;
     use tokio::sync::Semaphore;
 
@@ -549,6 +548,7 @@ mod test {
     }
 
     #[test]
+    #[cfg(feature = "regex")]
     fn bounce_multiple_hosts_with_regex() -> Result {
         let mut sim = Builder::new().build();
 
@@ -566,7 +566,7 @@ mod test {
 
         sim.run()?;
         assert_eq!(count.load(Ordering::SeqCst), 3);
-        sim.bounce(Regex::new("host-[12]")?);
+        sim.bounce(regex::Regex::new("host-[12]")?);
         sim.run()?;
         assert_eq!(count.load(Ordering::SeqCst), 5);
 

--- a/src/sim.rs
+++ b/src/sim.rs
@@ -382,7 +382,7 @@ mod test {
             for client in 0..how_many {
                 let ct = ct.clone();
 
-                sim.client(format!("client-{}", client), async move {
+                sim.client(format!("client-{client}"), async move {
                     let ms = if run == client { 0 } else { 2 * tick_ms };
                     tokio::time::sleep(Duration::from_millis(ms)).await;
 

--- a/src/world.rs
+++ b/src/world.rs
@@ -1,5 +1,5 @@
 use crate::envelope::Protocol;
-use crate::{config, Dns, Host, ToIpAddr, Topology, TRACING_TARGET};
+use crate::{config, Dns, Host, ToIpAddr, ToIpAddrs, Topology, TRACING_TARGET};
 
 use indexmap::IndexMap;
 use rand::RngCore;
@@ -70,6 +70,10 @@ impl World {
 
     pub(crate) fn lookup(&mut self, host: impl ToIpAddr) -> IpAddr {
         self.dns.lookup(host)
+    }
+
+    pub(crate) fn lookup_many(&mut self, hosts: impl ToIpAddrs) -> Vec<IpAddr> {
+        self.dns.lookup_many(hosts)
     }
 
     pub(crate) fn hold(&mut self, a: IpAddr, b: IpAddr) {

--- a/tests/tcp.rs
+++ b/tests/tcp.rs
@@ -292,7 +292,7 @@ fn server_concurrency() -> Result {
     let how_many = 3;
 
     for i in 0..how_many {
-        sim.client(format!("client-{}", i), async move {
+        sim.client(format!("client-{i}"), async move {
             let mut s = TcpStream::connect(("server", PORT)).await?;
 
             s.write_u8(how_many).await?;

--- a/tests/udp.rs
+++ b/tests/udp.rs
@@ -188,7 +188,7 @@ fn bounce() -> Result {
     });
 
     for i in 0..3 {
-        sim.client(format!("client-{}", i), async move {
+        sim.client(format!("client-{i}"), async move {
             let sock = bind_to(PORT + i).await?;
 
             send_ping(&sock).await?;


### PR DESCRIPTION
This allows various host interactions via regex matches to reduce the effort to induce more complex interactions. While this has changed the explicit API contract in some cases, this should not affect most test cases as the `ToIpAddrs` trait implements `ToIpAddr` for all `T` that implement `ToIpAddr`.