### PR TITLE
Add network topology introspection

### DIFF
--- a/src/envelope.rs
+++ b/src/envelope.rs
@@ -10,14 +10,16 @@ pub(crate) struct Envelope {
     pub(crate) message: Protocol,
 }
 
+/// Supported network protocols.
 #[derive(Debug)]
-pub(crate) enum Protocol {
+pub enum Protocol {
     Tcp(Segment),
     Udp(Datagram),
 }
 
+/// UDP datagram.
 #[derive(Debug)]
-pub(crate) struct Datagram(pub Bytes);
+pub struct Datagram(pub Bytes);
 
 /// This is a simplification of real TCP.
 ///
@@ -25,7 +27,7 @@ pub(crate) struct Datagram(pub Bytes);
 /// scenarios, but we skip a ton of complexity (e.g. checksums, flow control,
 /// etc) because said complexity isn't useful in tests.
 #[derive(Debug)]
-pub(crate) enum Segment {
+pub enum Segment {
     Syn(Syn),
     Data(u64, Bytes),
     Fin(u64),
@@ -33,7 +35,7 @@ pub(crate) enum Segment {
 }
 
 #[derive(Debug)]
-pub(crate) struct Syn {
+pub struct Syn {
     pub(crate) ack: oneshot::Sender<()>,
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -16,6 +16,7 @@ pub use dns::{ToIpAddr, ToSocketAddrs};
 
 mod envelope;
 use envelope::Envelope;
+pub use envelope::{Datagram, Protocol, Segment};
 
 mod error;
 pub use error::Result;
@@ -37,6 +38,7 @@ pub use sim::Sim;
 
 mod top;
 use top::Topology;
+pub use top::{LinkIter, LinksIter, SentRef};
 
 mod world;
 use world::World;

--- a/src/sim.rs
+++ b/src/sim.rs
@@ -1,4 +1,4 @@
-use crate::{Config, Result, Role, Rt, ToIpAddr, World};
+use crate::{Config, LinksIter, Result, Role, Rt, ToIpAddr, World};
 
 use indexmap::IndexMap;
 use std::cell::RefCell;
@@ -148,6 +148,18 @@ impl<'a> Sim<'a> {
         self.world.borrow_mut().lookup(addr)
     }
 
+    /// Resolve host names for an [`IpAddr`] pair.
+    ///
+    /// Useful when interactiong with network [links](#method.links).
+    pub fn reverse_lookup_pair(&self, pair: (IpAddr, IpAddr)) -> (String, String) {
+        let world = self.world.borrow();
+
+        (
+            world.dns.reverse(pair.0).to_owned(),
+            world.dns.reverse(pair.1).to_owned(),
+        )
+    }
+
     /// Set the max message latency
     pub fn set_max_message_latency(&self, value: Duration) {
         self.world
@@ -190,6 +202,13 @@ impl<'a> Sim<'a> {
         let b = world.lookup(b);
 
         world.topology.set_link_fail_rate(a, b, value);
+    }
+
+    /// Access a [`LinksIter`] to introspect inflight messages between hosts.
+    pub fn links(&self, f: impl FnOnce(LinksIter)) {
+        let top = &mut self.world.borrow_mut().topology;
+
+        f(top.iter_mut())
     }
 
     /// Run the simulation to completion.
@@ -305,7 +324,11 @@ mod test {
     use std::future;
     use tokio::sync::Semaphore;
 
-    use crate::{elapsed, Builder, Result};
+    use crate::{
+        elapsed, hold,
+        net::{TcpListener, TcpStream},
+        Builder, Result,
+    };
 
     #[test]
     fn client_error() {
@@ -478,5 +501,37 @@ mod test {
         });
 
         assert!(sim.run().is_err());
+    }
+
+    #[test]
+    fn manual_message_delivery() -> Result {
+        let mut sim = Builder::new().build();
+
+        sim.host("a", || async {
+            let l = TcpListener::bind("0.0.0.0:1234").await?;
+
+            _ = l.accept().await?;
+
+            Ok(())
+        });
+
+        sim.client("b", async {
+            hold("a", "b");
+
+            _ = TcpStream::connect("a:1234").await?;
+
+            Ok(())
+        });
+
+        assert!(!sim.step()?);
+
+        sim.links(|mut l| {
+            let a_to_b = l.next().unwrap();
+            a_to_b.deliver_all();
+        });
+
+        assert!(sim.step()?);
+
+        Ok(())
     }
 }

--- a/src/sim.rs
+++ b/src/sim.rs
@@ -150,7 +150,7 @@ impl<'a> Sim<'a> {
 
     /// Resolve host names for an [`IpAddr`] pair.
     ///
-    /// Useful when interactiong with network [links](#method.links).
+    /// Useful when interacting with network [links](#method.links).
     pub fn reverse_lookup_pair(&self, pair: (IpAddr, IpAddr)) -> (String, String) {
         let world = self.world.borrow();
 

--- a/src/top.rs
+++ b/src/top.rs
@@ -12,7 +12,7 @@ use std::time::Duration;
 use tokio::time::Instant;
 
 /// Describes the network topology.
-pub struct Topology {
+pub(crate) struct Topology {
     config: config::Link,
 
     /// Specific configuration overrides between specific hosts.


### PR DESCRIPTION
The sim now supports iterating each host pair's network link, as well
as each message that is currently "in flight" on the network.
    
Link and message metadata is exposed. We can also now force delivery
of messages.
    
In combination with the step capabilities that were recently added we
now have the ability to run more complex test scenarios.