### PR TITLE
Add support for localhost binding in TCP (#79)

### DIFF
--- a/src/dns.rs
+++ b/src/dns.rs
@@ -208,7 +208,7 @@ mod tests {
 
         assert_eq!(
             hostname_port,
-            format!("{}:5000", generated_addr).parse().unwrap()
+            format!("{generated_addr}:5000").parse().unwrap()
         );
         assert_eq!(ipv4_port.to_socket_addr(&dns), ipv4_port.parse().unwrap());
         assert_eq!(ipv6_port.to_socket_addr(&dns), ipv6_port.parse().unwrap());

--- a/src/dns.rs
+++ b/src/dns.rs
@@ -106,7 +106,7 @@ impl ToSocketAddrs for (String, u16) {
 
 impl<'a> ToSocketAddrs for (&'a str, u16) {
     fn to_socket_addr(&self, dns: &Dns) -> SocketAddr {
-        // When IP address is passed directly as a hostname.
+        // When IP address is passed directly as a str.
         if let Ok(ip) = self.0.parse::<IpAddr>() {
             return (ip, self.1).into();
         }

--- a/src/host.rs
+++ b/src/host.rs
@@ -332,12 +332,11 @@ impl Tcp {
 
                 let ipv4_unspec: SocketAddr = (Ipv4Addr::UNSPECIFIED, dst.port()).into();
                 let ipv6_unspec: SocketAddr = (Ipv6Addr::UNSPECIFIED, dst.port()).into();
-
                 let socket = if self.binds.contains_key(&dst) {
                     self.binds.get_mut(&dst)
-                } else if self.binds.contains_key(&ipv4_unspec) {
+                } else if dst.ip().is_ipv4() && self.binds.contains_key(&ipv4_unspec) {
                     self.binds.get_mut(&ipv4_unspec)
-                } else if self.binds.contains_key(&ipv6_unspec) {
+                } else if dst.ip().is_ipv6() && self.binds.contains_key(&ipv6_unspec) {
                     self.binds.get_mut(&ipv6_unspec)
                 } else {
                     None

--- a/src/host.rs
+++ b/src/host.rs
@@ -8,7 +8,7 @@ use indexmap::IndexMap;
 use std::collections::VecDeque;
 use std::fmt::Display;
 use std::io;
-use std::net::{IpAddr, SocketAddr};
+use std::net::{IpAddr, Ipv4Addr, Ipv6Addr, SocketAddr};
 use std::sync::Arc;
 use tokio::sync::{mpsc, Notify};
 use tokio::time::{Duration, Instant};
@@ -191,7 +191,7 @@ struct ServerSocket {
     notify: Arc<Notify>,
 
     /// Pending connections for the TcpListener to accept
-    deque: VecDeque<(Syn, SocketAddr)>,
+    deque: VecDeque<(Syn, SocketAddr, SocketAddr)>,
 }
 
 struct StreamSocket {
@@ -308,7 +308,7 @@ impl Tcp {
         rx
     }
 
-    pub(crate) fn accept(&mut self, addr: SocketAddr) -> Option<(Syn, SocketAddr)> {
+    pub(crate) fn accept(&mut self, addr: SocketAddr) -> Option<(Syn, SocketAddr, SocketAddr)> {
         self.binds[&addr].deque.pop_front()
     }
 
@@ -329,12 +329,26 @@ impl Tcp {
             Segment::Syn(syn) => {
                 // If bound, queue the syn; else we drop the syn triggering
                 // connection refused on the client.
-                if let Some(b) = self.binds.get_mut(&dst) {
+
+                let ipv4_unspec: SocketAddr = (Ipv4Addr::UNSPECIFIED, dst.port()).into();
+                let ipv6_unspec: SocketAddr = (Ipv6Addr::UNSPECIFIED, dst.port()).into();
+
+                let socket = if self.binds.contains_key(&dst) {
+                    self.binds.get_mut(&dst)
+                } else if self.binds.contains_key(&ipv4_unspec) {
+                    self.binds.get_mut(&ipv4_unspec)
+                } else if self.binds.contains_key(&ipv6_unspec) {
+                    self.binds.get_mut(&ipv6_unspec)
+                } else {
+                    None
+                };
+
+                if let Some(b) = socket {
                     if b.deque.len() == self.server_socket_capacity {
                         todo!("{} server socket buffer full", dst);
                     }
 
-                    b.deque.push_back((syn, src));
+                    b.deque.push_back((syn, src, dst));
                     b.notify.notify_one();
                 }
             }

--- a/src/host.rs
+++ b/src/host.rs
@@ -283,6 +283,13 @@ impl Tcp {
     }
 
     pub(crate) fn bind(&mut self, addr: SocketAddr) -> io::Result<TcpListener> {
+        if !addr.ip().is_loopback() && !addr.ip().is_unspecified() {
+            return Err(io::Error::new(
+                io::ErrorKind::AddrNotAvailable,
+                addr.to_string(),
+            ));
+        }
+        
         let notify = Arc::new(Notify::new());
         let sock = ServerSocket {
             notify: notify.clone(),

--- a/src/net/tcp/listener.rs
+++ b/src/net/tcp/listener.rs
@@ -29,10 +29,13 @@ impl TcpListener {
     ///
     /// The returned listener is ready for accepting connections.
     ///
-    /// If you bind to the 0.0.0.0, you're effectivly binding to the generated IP address of the host.
-    /// Each host gets an IP from 192.168.0.0/24 subnet.
-    /// You can bind to `localhost`, which translates to 127.0.0.1.
-    /// It allows for the TCP socket to be only visible within a host and reachable *only* via localhost IPv4/IPv6 addresses.
+    /// If you bind to the 0.0.0.0, you're effectivly binding to the generated
+    /// IP address of the host. Each host gets an IP from 192.168.0.0/24 subnet.
+    /// 
+    /// You can bind to `localhost`, which translates to 127.0.0.1. Binding
+    /// directly 127.0.0.1 or ::1 is also possible. It allows for the TCP socket
+    /// to be only visible within a host and reachable *only* via localhost
+    /// IPv4/IPv6 addresses.
     pub async fn bind<A: ToSocketAddrs>(addr: A) -> Result<TcpListener> {
         World::current(|world| {
             let mut addr = addr.to_socket_addr(&world.dns);

--- a/src/net/tcp/listener.rs
+++ b/src/net/tcp/listener.rs
@@ -31,19 +31,16 @@ impl TcpListener {
     ///
     /// If you bind to the 0.0.0.0, you're effectivly binding to the generated
     /// IP address of the host. Each host gets an IP from 192.168.0.0/24 subnet.
-    /// 
+    ///
     /// You can bind to loopback interfaces: 127.0.0.1 or ::1. It allows for the
     /// TCP socket to be only visible within a host and reachable *only* via
     /// loopback IPv4/IPv6 addresses.
     pub async fn bind<A: ToSocketAddrs>(addr: A) -> Result<TcpListener> {
         World::current(|world| {
-            let mut addr = addr.to_socket_addr(&world.dns);
+            let addr = addr.to_socket_addr(&world.dns);
             let host = world.current_host_mut();
 
-            // Unspecified -> host's IP
-            if addr.ip().is_unspecified() {
-                addr.set_ip(host.addr);
-            } else if addr.ip() != host.addr && !addr.ip().is_loopback() {
+            if addr.ip() != host.addr && !addr.ip().is_loopback() && !addr.ip().is_unspecified() {
                 return Err(io::Error::new(
                     io::ErrorKind::AddrNotAvailable,
                     addr.to_string(),
@@ -63,20 +60,20 @@ impl TcpListener {
         loop {
             let maybe_accept = World::current(|world| {
                 let host = world.current_host_mut();
-                let (syn, origin) = host.tcp.accept(self.local_addr)?;
+                let (syn, origin, destination) = host.tcp.accept(self.local_addr)?;
 
-                tracing::trace!(target: TRACING_TARGET, dst = ?origin, src = ?self.local_addr, protocol = %"TCP SYN", "Recv");
+                tracing::trace!(target: TRACING_TARGET, dst = ?origin, src = ?destination, protocol = %"TCP SYN", "Recv");
 
                 // Send SYN-ACK -> origin. If Ok we proceed (acts as the ACK),
                 // else we return early to avoid host mutations.
                 let ack = syn.ack.send(());
-                tracing::trace!(target: TRACING_TARGET, src = ?self.local_addr, dst = ?origin, protocol = %"TCP SYN-ACK", "Send");
+                tracing::trace!(target: TRACING_TARGET, src = ?origin, dst = ?destination, protocol = %"TCP SYN-ACK", "Send");
 
                 if ack.is_err() {
                     return None;
                 }
 
-                let pair = SocketPair::new(self.local_addr, origin);
+                let pair = SocketPair::new(destination, origin);
                 let rx = host.tcp.new_stream(pair);
 
                 Some((TcpStream::new(pair, rx), origin))

--- a/src/net/tcp/listener.rs
+++ b/src/net/tcp/listener.rs
@@ -1,5 +1,5 @@
 use std::{
-    io::{self, Result},
+    io::Result,
     net::SocketAddr,
     sync::Arc,
 };
@@ -39,13 +39,6 @@ impl TcpListener {
         World::current(|world| {
             let addr = addr.to_socket_addr(&world.dns);
             let host = world.current_host_mut();
-
-            if addr.ip() != host.addr && !addr.ip().is_loopback() && !addr.ip().is_unspecified() {
-                return Err(io::Error::new(
-                    io::ErrorKind::AddrNotAvailable,
-                    addr.to_string(),
-                ));
-            }
 
             host.tcp.bind(addr)
         })

--- a/src/net/tcp/listener.rs
+++ b/src/net/tcp/listener.rs
@@ -30,8 +30,7 @@ impl TcpListener {
     /// The returned listener is ready for accepting connections.
     ///
     /// If you bind to the 0.0.0.0, you're effectivly binding to the generated IP address of the host.
-    /// See the Dns class for the current IP assignment.
-    ///
+    /// Each host gets an IP from 192.168.0.0/24 subnet.
     /// You can bind to `localhost`, which translates to 127.0.0.1.
     /// It allows for the TCP socket to be only visible within a host and reachable *only* via localhost IPv4/IPv6 addresses.
     pub async fn bind<A: ToSocketAddrs>(addr: A) -> Result<TcpListener> {

--- a/src/net/tcp/listener.rs
+++ b/src/net/tcp/listener.rs
@@ -1,4 +1,8 @@
-use std::{io::Result, net::SocketAddr, sync::Arc};
+use std::{
+    io::{self, Result},
+    net::SocketAddr,
+    sync::Arc,
+};
 
 use tokio::sync::Notify;
 
@@ -25,18 +29,25 @@ impl TcpListener {
     ///
     /// The returned listener is ready for accepting connections.
     ///
-    /// Only 0.0.0.0 is currently supported.
+    /// If you bind to the 0.0.0.0, you're effectivly binding to the generated IP address of the host.
+    /// See the Dns class for the current IP assignment.
+    ///
+    /// You can bind to `localhost`, which translates to 127.0.0.1.
+    /// It allows for the TCP socket to be only visible within a host and reachable *only* via localhost IPv4/IPv6 addresses.
     pub async fn bind<A: ToSocketAddrs>(addr: A) -> Result<TcpListener> {
         World::current(|world| {
             let mut addr = addr.to_socket_addr(&world.dns);
             let host = world.current_host_mut();
 
-            if !addr.ip().is_unspecified() {
-                panic!("{addr} is not supported");
-            }
-
             // Unspecified -> host's IP
-            addr.set_ip(host.addr);
+            if addr.ip().is_unspecified() {
+                addr.set_ip(host.addr);
+            } else if addr.ip() != host.addr && !addr.ip().is_loopback() {
+                return Err(io::Error::new(
+                    io::ErrorKind::AddrNotAvailable,
+                    addr.to_string(),
+                ));
+            }
 
             host.tcp.bind(addr)
         })

--- a/src/net/tcp/listener.rs
+++ b/src/net/tcp/listener.rs
@@ -32,10 +32,9 @@ impl TcpListener {
     /// If you bind to the 0.0.0.0, you're effectivly binding to the generated
     /// IP address of the host. Each host gets an IP from 192.168.0.0/24 subnet.
     /// 
-    /// You can bind to `localhost`, which translates to 127.0.0.1. Binding
-    /// directly 127.0.0.1 or ::1 is also possible. It allows for the TCP socket
-    /// to be only visible within a host and reachable *only* via localhost
-    /// IPv4/IPv6 addresses.
+    /// You can bind to loopback interfaces: 127.0.0.1 or ::1. It allows for the
+    /// TCP socket to be only visible within a host and reachable *only* via
+    /// loopback IPv4/IPv6 addresses.
     pub async fn bind<A: ToSocketAddrs>(addr: A) -> Result<TcpListener> {
         World::current(|world| {
             let mut addr = addr.to_socket_addr(&world.dns);

--- a/src/net/tcp/stream.rs
+++ b/src/net/tcp/stream.rs
@@ -1,7 +1,7 @@
 use std::{
     fmt::Debug,
     io::{self, Result},
-    net::{SocketAddr},
+    net::SocketAddr,
     pin::Pin,
     sync::Arc,
     task::{ready, Context, Poll},

--- a/src/net/tcp/stream.rs
+++ b/src/net/tcp/stream.rs
@@ -1,7 +1,7 @@
 use std::{
     fmt::Debug,
     io::{self, Result},
-    net::SocketAddr,
+    net::{SocketAddr},
     pin::Pin,
     sync::Arc,
     task::{ready, Context, Poll},

--- a/src/sim.rs
+++ b/src/sim.rs
@@ -537,10 +537,10 @@ mod test {
 
         assert!(!sim.step()?);
 
-        sim.links(|mut l| {
-            while let Some(a_to_b) = l.next() {
+        sim.links(|l| {
+            for a_to_b in l {
                 a_to_b.deliver_all();
-            }            
+            }          
         });
 
         assert!(sim.step()?);

--- a/src/sim.rs
+++ b/src/sim.rs
@@ -538,8 +538,9 @@ mod test {
         assert!(!sim.step()?);
 
         sim.links(|mut l| {
-            let a_to_b = l.next().unwrap();
-            a_to_b.deliver_all();
+            while let Some(a_to_b) = l.next() {
+                a_to_b.deliver_all();
+            }            
         });
 
         assert!(sim.step()?);

--- a/src/top.rs
+++ b/src/top.rs
@@ -285,11 +285,10 @@ impl Topology {
     }
 
     fn validate(a: IpAddr, b: IpAddr) -> Pair {
-        let pair = Pair::new(a, b);
-        if let Interface::Loopback = pair.interface {
+        if let Interface::Loopback = Pair::new(a, b).interface {
             panic!("can't perform topology operations on localhost interfaces")
         } else {
-            pair
+            Pair::new(a, b)
         }
     }
 }

--- a/src/world.rs
+++ b/src/world.rs
@@ -101,8 +101,7 @@ impl World {
 
         tracing::info!(target: TRACING_TARGET, hostname = ?self.dns.reverse(addr), ?addr, "New");
 
-        // Handles connections within a host
-        self.topology.register(addr, addr);
+        // Handles connections within a host on loopback interfaces.
         self.topology.register(Ipv4Addr::LOCALHOST.into(), addr);
         self.topology.register(Ipv6Addr::LOCALHOST.into(), addr);
 

--- a/src/world.rs
+++ b/src/world.rs
@@ -101,7 +101,7 @@ impl World {
 
         tracing::info!(target: TRACING_TARGET, hostname = ?self.dns.reverse(addr), ?addr, "New");
 
-        // // Handles connection within a host
+        // Handles connections within a host
         self.topology.register(addr, addr);
         self.topology.register(Ipv4Addr::LOCALHOST.into(), addr);
         self.topology.register(Ipv6Addr::LOCALHOST.into(), addr);

--- a/src/world.rs
+++ b/src/world.rs
@@ -5,7 +5,7 @@ use indexmap::IndexMap;
 use rand::RngCore;
 use scoped_tls::scoped_thread_local;
 use std::cell::RefCell;
-use std::net::{IpAddr, SocketAddr, Ipv4Addr};
+use std::net::{IpAddr, SocketAddr, Ipv4Addr, Ipv6Addr};
 use std::time::Duration;
 
 /// Tracks all the state for the simulated world.
@@ -101,10 +101,11 @@ impl World {
 
         tracing::info!(target: TRACING_TARGET, hostname = ?self.dns.reverse(addr), ?addr, "New");
 
-        // Handles connection within a host
+        // // Handles connection within a host
         self.topology.register(addr, addr);
-        // Handles both IPv4 and IPv6
         self.topology.register(Ipv4Addr::LOCALHOST.into(), addr);
+        self.topology.register(Ipv6Addr::LOCALHOST.into(), addr);
+
 
         // Register links between the new host and all existing hosts
         for existing in self.hosts.keys() {

--- a/tests/tcp.rs
+++ b/tests/tcp.rs
@@ -27,12 +27,31 @@ async fn bind() -> std::result::Result<TcpListener, std::io::Error> {
 }
 
 #[test]
+fn connects_within_a_host() -> Result {
+    let mut sim = Builder::new().build();
+
+    sim.client("server", async {
+        let listener = bind().await?;
+        tokio::spawn(async move {
+            loop {
+                let _ = listener.accept().await;
+            }
+        });
+
+        TcpStream::connect(("server", PORT))
+            .await?;
+        Ok(())
+    });
+
+    sim.run()
+}
+
+#[test]
 fn connects_within_a_localhost() -> Result {
     let mut sim = Builder::new().build();
 
     sim.client("server", async {
         let listener = TcpListener::bind((IpAddr::from(Ipv4Addr::LOCALHOST), PORT)).await?;
-
         tokio::spawn(async move {
             loop {
                 let _ = listener.accept().await;

--- a/tests/tcp.rs
+++ b/tests/tcp.rs
@@ -96,6 +96,26 @@ fn sends_data_within_a_localhost() -> Result {
 }
 
 #[test]
+fn connects_to_localhost_bind_to_any() -> Result {
+    let mut sim = Builder::new().build();
+
+    sim.client("server", async {
+        let listener = TcpListener::bind((Ipv4Addr::UNSPECIFIED, PORT)).await?;
+
+        tokio::spawn(async move {
+            let _ = listener.accept().await;
+        });
+
+        _ = TcpStream::connect((Ipv4Addr::LOCALHOST, PORT)).await?;
+
+        Ok(())
+    });
+
+    sim.run()
+}
+
+
+#[test]
 fn doesnt_allow_connection_outside_localhost() -> Result {
     let mut sim = Builder::new().build();
 

--- a/tests/tcp.rs
+++ b/tests/tcp.rs
@@ -64,6 +64,11 @@ fn connects_within_a_localhost() -> Result {
         TcpStream::connect(("127.0.0.1", PORT))
             .await?;
 
+        assert_error_kind(
+            TcpStream::connect(("::1", PORT)).await,
+            io::ErrorKind::ConnectionRefused,
+        );
+        
         Ok(())
     });
 
@@ -78,6 +83,11 @@ fn connects_within_a_localhost() -> Result {
 
         TcpStream::connect(("::1", PORT))
             .await?;
+
+        assert_error_kind(
+            TcpStream::connect(("localhost", PORT)).await,
+            io::ErrorKind::ConnectionRefused,
+        );
 
         Ok(())
     });

--- a/tests/tcp.rs
+++ b/tests/tcp.rs
@@ -76,7 +76,7 @@ fn sends_data_within_a_localhost() -> Result {
 
     sim.client("server", async {
         let listener = TcpListener::bind((Ipv4Addr::LOCALHOST, PORT)).await?;
-        tokio::spawn(async move {
+        let h = tokio::spawn(async move {
             if let Ok((mut stream, _)) = listener.accept().await {
                 let _ = stream.write_u8(1).await;
                 assert_eq!(2, stream.read_u8().await.unwrap());
@@ -87,6 +87,8 @@ fn sends_data_within_a_localhost() -> Result {
 
         assert_eq!(1, stream.read_u8().await?);
         stream.write_u8(2).await?;
+        
+        h.await?;
         Ok(())
     });
 

--- a/tests/tcp.rs
+++ b/tests/tcp.rs
@@ -23,7 +23,7 @@ fn assert_error_kind<T>(res: io::Result<T>, kind: io::ErrorKind) {
 }
 
 async fn bind() -> std::result::Result<TcpListener, std::io::Error> {
-    TcpListener::bind((IpAddr::from(Ipv4Addr::UNSPECIFIED), PORT)).await
+    TcpListener::bind((Ipv4Addr::UNSPECIFIED, PORT)).await
 }
 
 #[test]
@@ -38,8 +38,7 @@ fn connects_within_a_host() -> Result {
             }
         });
 
-        TcpStream::connect(("server", PORT))
-            .await?;
+        TcpStream::connect(("server", PORT)).await?;
         Ok(())
     });
 
@@ -51,29 +50,25 @@ fn connects_within_a_localhost() -> Result {
     let mut sim = Builder::new().build();
 
     sim.client("server", async {
-        let listener = TcpListener::bind((IpAddr::from(Ipv4Addr::LOCALHOST), PORT)).await?;
+        let listener = TcpListener::bind((Ipv4Addr::LOCALHOST, PORT)).await?;
         tokio::spawn(async move {
             loop {
                 let _ = listener.accept().await;
             }
         });
 
-        TcpStream::connect(("localhost", PORT))
-            .await?;
-
-        TcpStream::connect(("127.0.0.1", PORT))
-            .await?;
+        TcpStream::connect((Ipv4Addr::LOCALHOST, PORT)).await?;
 
         assert_error_kind(
-            TcpStream::connect(("::1", PORT)).await,
+            TcpStream::connect((Ipv6Addr::LOCALHOST, PORT)).await,
             io::ErrorKind::ConnectionRefused,
         );
-        
+
         Ok(())
     });
 
     sim.client("serveripv6", async {
-        let listener = TcpListener::bind((IpAddr::from(Ipv6Addr::LOCALHOST), PORT)).await?;
+        let listener = TcpListener::bind((Ipv6Addr::LOCALHOST, PORT)).await?;
 
         tokio::spawn(async move {
             loop {
@@ -81,11 +76,10 @@ fn connects_within_a_localhost() -> Result {
             }
         });
 
-        TcpStream::connect(("::1", PORT))
-            .await?;
+        TcpStream::connect((Ipv6Addr::LOCALHOST, PORT)).await?;
 
         assert_error_kind(
-            TcpStream::connect(("localhost", PORT)).await,
+            TcpStream::connect((Ipv4Addr::LOCALHOST, PORT)).await,
             io::ErrorKind::ConnectionRefused,
         );
 
@@ -100,7 +94,7 @@ fn doesnt_allow_connection_outside_localhost() -> Result {
     let mut sim = Builder::new().build();
 
     sim.host("server", || async {
-        let listener = TcpListener::bind((IpAddr::from(Ipv4Addr::LOCALHOST), PORT)).await?;
+        let listener = TcpListener::bind((Ipv4Addr::LOCALHOST, PORT)).await?;
 
         loop {
             let _ = listener.accept().await;
@@ -114,7 +108,7 @@ fn doesnt_allow_connection_outside_localhost() -> Result {
         );
 
         assert_error_kind(
-            TcpStream::connect(("localhost", PORT)).await,
+            TcpStream::connect((Ipv4Addr::LOCALHOST, PORT)).await,
             io::ErrorKind::ConnectionRefused,
         );
 

--- a/tests/tcp.rs
+++ b/tests/tcp.rs
@@ -110,12 +110,6 @@ fn doesnt_allow_connection_outside_localhost() -> Result {
             TcpStream::connect(("server", PORT)).await,
             io::ErrorKind::ConnectionRefused,
         );
-
-        assert_error_kind(
-            TcpStream::connect((Ipv4Addr::LOCALHOST, PORT)).await,
-            io::ErrorKind::ConnectionRefused,
-        );
-
         Ok(())
     });
 


### PR DESCRIPTION
Implementation proposal for #79 .
It does not use topology under the hood, skips the chain.
The messages are not queued like in the topology, but are delivered to hosts directly.

If the approach is acceptable, I can add an another CR for UDP.