### PR TITLE
Refactor TCP localhost communication

### DIFF
--- a/src/envelope.rs
+++ b/src/envelope.rs
@@ -1,10 +1,14 @@
-use std::{fmt::Display, net::SocketAddr};
+use std::{fmt::Display, net::{SocketAddr, IpAddr}};
 
 use bytes::Bytes;
 use tokio::sync::oneshot;
 
 #[derive(Debug)]
 pub(crate) struct Envelope {
+    /// Each host is uniquely identified by an generated IPv4 address.
+    /// Sender field allows to identify the host when src/dst addresses don't.
+    /// Example: 127.0.0.1 <-> 127.0.0.1 communication.
+    pub(crate) sender: IpAddr,
     pub(crate) src: SocketAddr,
     pub(crate) dst: SocketAddr,
     pub(crate) message: Protocol,

--- a/src/host.rs
+++ b/src/host.rs
@@ -96,9 +96,9 @@ impl Host {
     // key problem is that the Host doesn't actually send messages, rather the
     // World is borrowed, and it sends.
     pub(crate) fn receive_from_network(&mut self, envelope: Envelope) -> Result<(), Protocol> {
-        let Envelope { src, dst, message } = envelope;
+        let Envelope { src, dst, message, sender } = envelope;
 
-        tracing::trace!(target: TRACING_TARGET, ?dst, ?src, protocol = %message, "Delivered");
+        tracing::trace!(target: TRACING_TARGET, ?dst, ?src, protocol = %message, ?sender, "Delivered");
 
         match message {
             Protocol::Tcp(segment) => self.tcp.receive_from_network(src, dst, segment),

--- a/src/net/tcp/listener.rs
+++ b/src/net/tcp/listener.rs
@@ -29,9 +29,9 @@ impl TcpListener {
     ///
     /// The returned listener is ready for accepting connections.
     ///
-    /// Supports binding to IPv4/IPv6 interfaces:
-    /// - Unspecified: 0.0.0.0, :: 
-    /// - Loopback: 127.0.0.1, ::1
+    /// Supports binding to IPv4 interfaces:
+    /// - Unspecified: 0.0.0.0
+    /// - Loopback: 127.0.0.1
     /// Binding directly to an IP address other than loopback is unsupported.
     pub async fn bind<A: ToSocketAddrs>(addr: A) -> Result<TcpListener> {
         World::current(|world| {

--- a/src/net/tcp/listener.rs
+++ b/src/net/tcp/listener.rs
@@ -29,12 +29,10 @@ impl TcpListener {
     ///
     /// The returned listener is ready for accepting connections.
     ///
-    /// If you bind to the 0.0.0.0, you're effectivly binding to the generated
-    /// IP address of the host. Each host gets an IP from 192.168.0.0/24 subnet.
-    ///
-    /// You can bind to loopback interfaces: 127.0.0.1 or ::1. It allows for the
-    /// TCP socket to be only visible within a host and reachable *only* via
-    /// loopback IPv4/IPv6 addresses.
+    /// Supports binding to IPv4/IPv6 interfaces:
+    /// - Unspecified: 0.0.0.0, :: 
+    /// - Loopback: 127.0.0.1, ::1
+    /// Binding directly to an IP address other than loopback is unsupported.
     pub async fn bind<A: ToSocketAddrs>(addr: A) -> Result<TcpListener> {
         World::current(|world| {
             let addr = addr.to_socket_addr(&world.dns);

--- a/src/net/tcp/stream.rs
+++ b/src/net/tcp/stream.rs
@@ -1,7 +1,7 @@
 use std::{
     fmt::Debug,
     io::{self, Result},
-    net::{Ipv6Addr, SocketAddr},
+    net::SocketAddr,
     pin::Pin,
     sync::Arc,
     task::{ready, Context, Poll},
@@ -58,19 +58,11 @@ impl TcpStream {
 
         let (pair, rx) = World::current(|world| {
             let dst = addr.to_socket_addr(&world.dns);
-            assert!(
-                !dst.is_ipv6() || dst.ip().is_loopback(),
-                "communication to IPv6 addresses outside loopback is not supported"
-            );
 
             let syn = Segment::Syn(Syn { ack });
 
             let host = world.current_host_mut();
-            let local_addr = if dst.is_ipv6() {
-                (Ipv6Addr::LOCALHOST, host.assign_ephemeral_port()).into()
-            } else {
-                (host.addr, host.assign_ephemeral_port()).into()
-            };
+            let local_addr = (host.addr, host.assign_ephemeral_port()).into();
 
             let pair = SocketPair::new(local_addr, dst);
             let rx = host.tcp.new_stream(pair);

--- a/src/top.rs
+++ b/src/top.rs
@@ -7,7 +7,7 @@ use indexmap::IndexMap;
 use rand::{Rng, RngCore};
 use rand_distr::{Distribution, Exp};
 use std::collections::VecDeque;
-use std::net::{IpAddr, Ipv4Addr, Ipv6Addr, SocketAddr};
+use std::net::{IpAddr, Ipv4Addr, SocketAddr};
 use std::time::Duration;
 use tokio::time::Instant;
 
@@ -250,11 +250,7 @@ impl Topology {
         message: Protocol,
     ) {
         let link = if src.ip() == dst.ip() {
-            if src.is_ipv4() {
-                &mut self.links[&Pair::new(Ipv4Addr::LOCALHOST.into(), sender)]
-            } else {
-                &mut self.links[&Pair::new(Ipv6Addr::LOCALHOST.into(), sender)]
-            }
+            &mut self.links[&Pair::new(Ipv4Addr::LOCALHOST.into(), sender)]
         } else {
             &mut self.links[&Pair::new(src.ip(), dst.ip())]
         };

--- a/src/world.rs
+++ b/src/world.rs
@@ -119,7 +119,7 @@ impl World {
     /// Delivery between hosts is asynchronous and not guaranteed.
     pub(crate) fn send_message(&mut self, src: SocketAddr, dst: SocketAddr, message: Protocol) {
         self.topology
-            .enqueue_message(&mut self.rng, src, dst, message);
+            .enqueue_message(&mut self.rng, self.current.expect("Sending a message requires a sender host."), src, dst, message);
     }
 
     /// Tick the host at `addr` by `duration`.

--- a/src/world.rs
+++ b/src/world.rs
@@ -5,7 +5,7 @@ use indexmap::IndexMap;
 use rand::RngCore;
 use scoped_tls::scoped_thread_local;
 use std::cell::RefCell;
-use std::net::{IpAddr, SocketAddr, Ipv4Addr, Ipv6Addr};
+use std::net::{IpAddr, SocketAddr, Ipv4Addr};
 use std::time::Duration;
 
 /// Tracks all the state for the simulated world.
@@ -103,8 +103,6 @@ impl World {
 
         // Handles connections within a host on loopback interfaces.
         self.topology.register(Ipv4Addr::LOCALHOST.into(), addr);
-        self.topology.register(Ipv6Addr::LOCALHOST.into(), addr);
-
 
         // Register links between the new host and all existing hosts
         for existing in self.hosts.keys() {

--- a/tests/tcp.rs
+++ b/tests/tcp.rs
@@ -1,6 +1,6 @@
 use std::{
     io,
-    net::{IpAddr, Ipv4Addr, Ipv6Addr},
+    net::{IpAddr, Ipv4Addr},
     rc::Rc,
     time::Duration,
 };
@@ -39,15 +39,9 @@ fn connects_within_a_localhost() -> Result {
         });
 
         TcpStream::connect((Ipv4Addr::LOCALHOST, PORT)).await?;
-
-        assert_error_kind(
-            TcpStream::connect((Ipv6Addr::LOCALHOST, PORT)).await,
-            io::ErrorKind::ConnectionRefused,
-        );
-
         Ok(())
     });
-    
+
     sim.run()
 }
 

--- a/tests/tcp.rs
+++ b/tests/tcp.rs
@@ -47,26 +47,7 @@ fn connects_within_a_localhost() -> Result {
 
         Ok(())
     });
-
-    sim.client("serveripv6", async {
-        let listener = TcpListener::bind((Ipv6Addr::LOCALHOST, PORT)).await?;
-
-        tokio::spawn(async move {
-            loop {
-                let _ = listener.accept().await;
-            }
-        });
-
-        TcpStream::connect((Ipv6Addr::LOCALHOST, PORT)).await?;
-
-        assert_error_kind(
-            TcpStream::connect((Ipv4Addr::LOCALHOST, PORT)).await,
-            io::ErrorKind::ConnectionRefused,
-        );
-
-        Ok(())
-    });
-
+    
     sim.run()
 }
 


### PR DESCRIPTION
Related, #79, #83 

#83 introduced TCP support for loopback, as it is correct for IPv4, it was coincidentally working for IPv6 for some cases.
It was working in the test, but conceptually was wrong. Something send from a localhost IPv6 interface, was treated in the code as sent from IPv4 interface.

If you bind to an unspecified interface, conceptually a message sent from it has to be sent from some interface.
Each host has a IPv4 address generated, but it does not have an IPv6 address, so besides ::1 there is no choice.
I leave IPv6 communication  as further issue to be investigated and implemented.

Another major change is with World.send_message requiring a host to be present.
Every communication has to go through the topology, but topology based solely ip_addresses, e.g. 127.0.0.1 <-> 127.0.0.1 cannot determine what host is the target. In the previous CR it was worked around, by relying on the assumption that always one of the IP addresses won't be localhost.
