### PR TITLE
Revert "Add support for loopback in TCP (#83)"

### DIFF
--- a/src/dns.rs
+++ b/src/dns.rs
@@ -1,10 +1,8 @@
 use indexmap::IndexMap;
 #[cfg(feature = "regex")]
 use regex::Regex;
-use std::net::{IpAddr, SocketAddr, Ipv4Addr, Ipv6Addr};
+use std::net::{IpAddr, SocketAddr};
 
-/// Each new registered host has an IP in a subnet 192.168.0.0/24.
-/// This is just a choice, can be changed in the future.
 pub struct Dns {
     next: u16,
     names: IndexMap<String, IpAddr>,
@@ -64,7 +62,7 @@ impl<'a> ToIpAddr for &'a str {
             let a = (host >> 8) as u8;
             let b = (host & 0xFF) as u8;
 
-            std::net::Ipv4Addr::new(192, 168, a, b).into()
+            std::net::Ipv4Addr::new(127, 0, a, b).into()
         })
     }
 }
@@ -103,17 +101,11 @@ impl ToSocketAddrs for (String, u16) {
     }
 }
 
-
 impl<'a> ToSocketAddrs for (&'a str, u16) {
     fn to_socket_addr(&self, dns: &Dns) -> SocketAddr {
-        // When IP address is passed directly as a str.
-        if let Ok(ip) = self.0.parse::<IpAddr>() {
-            return (ip, self.1).into();
-        }
-
         match dns.names.get(self.0) {
             Some(ip) => (*ip, self.1).into(),
-            None => panic!("no ip address found for a hostname: {}", self.0),
+            None => panic!("no hostname found for ip address"),
         }
     }
 }
@@ -125,18 +117,6 @@ impl ToSocketAddrs for SocketAddr {
 }
 
 impl ToSocketAddrs for (IpAddr, u16) {
-    fn to_socket_addr(&self, _: &Dns) -> SocketAddr {
-        (*self).into()
-    }
-}
-
-impl ToSocketAddrs for (Ipv4Addr, u16) {
-    fn to_socket_addr(&self, _: &Dns) -> SocketAddr {
-        (*self).into()
-    }
-}
-
-impl ToSocketAddrs for (Ipv6Addr, u16) {
     fn to_socket_addr(&self, _: &Dns) -> SocketAddr {
         (*self).into()
     }
@@ -195,17 +175,9 @@ mod tests {
     #[test]
     fn parse_str() {
         let mut dns = Dns::new();
-        let generated_addr = dns.lookup("foo");
+        dns.names.insert("foo".into(), "127.0.0.1".parse().unwrap());
+        let s = "foo:5000".to_socket_addr(&dns);
 
-        let hostname_port = "foo:5000".to_socket_addr(&dns);
-        let ipv4_port = "127.0.0.1:5000";
-        let ipv6_port = "[::1]:5000";
-
-        assert_eq!(
-            hostname_port,
-            format!("{generated_addr}:5000").parse().unwrap()
-        );
-        assert_eq!(ipv4_port.to_socket_addr(&dns), ipv4_port.parse().unwrap());
-        assert_eq!(ipv6_port.to_socket_addr(&dns), ipv6_port.parse().unwrap());
+        assert_eq!(s, "127.0.0.1:5000".parse().unwrap());
     }
 }

--- a/src/host.rs
+++ b/src/host.rs
@@ -8,7 +8,7 @@ use indexmap::IndexMap;
 use std::collections::VecDeque;
 use std::fmt::Display;
 use std::io;
-use std::net::{IpAddr, Ipv4Addr, Ipv6Addr, SocketAddr};
+use std::net::{IpAddr, SocketAddr};
 use std::sync::Arc;
 use tokio::sync::{mpsc, Notify};
 use tokio::time::{Duration, Instant};
@@ -191,7 +191,7 @@ struct ServerSocket {
     notify: Arc<Notify>,
 
     /// Pending connections for the TcpListener to accept
-    deque: VecDeque<(Syn, SocketAddr, SocketAddr)>,
+    deque: VecDeque<(Syn, SocketAddr)>,
 }
 
 struct StreamSocket {
@@ -283,13 +283,6 @@ impl Tcp {
     }
 
     pub(crate) fn bind(&mut self, addr: SocketAddr) -> io::Result<TcpListener> {
-        if !addr.ip().is_loopback() && !addr.ip().is_unspecified() {
-            return Err(io::Error::new(
-                io::ErrorKind::AddrNotAvailable,
-                addr.to_string(),
-            ));
-        }
-        
         let notify = Arc::new(Notify::new());
         let sock = ServerSocket {
             notify: notify.clone(),
@@ -315,7 +308,7 @@ impl Tcp {
         rx
     }
 
-    pub(crate) fn accept(&mut self, addr: SocketAddr) -> Option<(Syn, SocketAddr, SocketAddr)> {
+    pub(crate) fn accept(&mut self, addr: SocketAddr) -> Option<(Syn, SocketAddr)> {
         self.binds[&addr].deque.pop_front()
     }
 
@@ -336,25 +329,12 @@ impl Tcp {
             Segment::Syn(syn) => {
                 // If bound, queue the syn; else we drop the syn triggering
                 // connection refused on the client.
-
-                let ipv4_unspec: SocketAddr = (Ipv4Addr::UNSPECIFIED, dst.port()).into();
-                let ipv6_unspec: SocketAddr = (Ipv6Addr::UNSPECIFIED, dst.port()).into();
-                let socket = if self.binds.contains_key(&dst) {
-                    self.binds.get_mut(&dst)
-                } else if dst.ip().is_ipv4() && self.binds.contains_key(&ipv4_unspec) {
-                    self.binds.get_mut(&ipv4_unspec)
-                } else if dst.ip().is_ipv6() && self.binds.contains_key(&ipv6_unspec) {
-                    self.binds.get_mut(&ipv6_unspec)
-                } else {
-                    None
-                };
-
-                if let Some(b) = socket {
+                if let Some(b) = self.binds.get_mut(&dst) {
                     if b.deque.len() == self.server_socket_capacity {
                         todo!("{} server socket buffer full", dst);
                     }
 
-                    b.deque.push_back((syn, src, dst));
+                    b.deque.push_back((syn, src));
                     b.notify.notify_one();
                 }
             }

--- a/src/sim.rs
+++ b/src/sim.rs
@@ -567,10 +567,9 @@ mod test {
 
         assert!(!sim.step()?);
 
-        sim.links(|l| {
-            for a_to_b in l {
-                a_to_b.deliver_all();
-            }          
+        sim.links(|mut l| {
+            let a_to_b = l.next().unwrap();
+            a_to_b.deliver_all();
         });
 
         assert!(sim.step()?);

--- a/src/top.rs
+++ b/src/top.rs
@@ -26,43 +26,18 @@ pub(crate) struct Topology {
 
 /// This type is used as the key in the [`Topology::links`] map. See [`new`]
 /// which orders the addrs, such that this type uniquely identifies the link
-/// between two hosts on the network. 
-/// If one of the interfaces is loopback, it is always first in the pair.
+/// between two hosts on the network.
 #[derive(Debug, Clone, Hash, Eq, PartialEq)]
-struct Pair {
-    a: IpAddr,
-    b: IpAddr,
-    interface: Interface,
-}
+struct Pair(IpAddr, IpAddr);
 
 impl Pair {
     fn new(a: IpAddr, b: IpAddr) -> Pair {
         assert_ne!(a, b);
 
-        if a.is_loopback() {
-            Pair {
-                a,
-                b,
-                interface: Interface::Loopback,
-            }
-        } else if b.is_loopback() {
-            Pair {
-                a: b,
-                b: a,
-                interface: Interface::Loopback,
-            }
-        } else if a < b {
-            Pair {
-                a,
-                b,
-                interface: Interface::External,
-            }
+        if a < b {
+            Pair(a, b)
         } else {
-            Pair {
-                a: b,
-                b: a,
-                interface: Interface::External,
-            }
+            Pair(b, a)
         }
     }
 }
@@ -76,7 +51,8 @@ pub struct LinksIter<'a> {
 /// An iterator for the link, providing access to sent messages that have not
 /// yet been delivered.
 pub struct LinkIter<'a> {
-    p: Pair,
+    a: IpAddr,
+    b: IpAddr,
     now: Instant,
     iter: std::collections::vec_deque::IterMut<'a, Sent>,
 }
@@ -85,7 +61,7 @@ impl<'a> LinkIter<'a> {
     /// The [`IpAddr`] pair for the link. Always ordered to uniquely identify
     /// the link.
     pub fn pair(&self) -> (IpAddr, IpAddr) {
-        (self.p.a, self.p.b)
+        (self.a, self.b)
     }
 
     /// Schedule all messages on the link for delivery the next time the
@@ -131,7 +107,8 @@ impl<'a> Iterator for LinksIter<'a> {
         let (pair, link) = self.iter.next()?;
 
         Some(LinkIter {
-            p: pair.clone(),
+            a: pair.0,
+            b: pair.1,
             now: link.now,
             iter: link.sent.iter_mut(),
         })
@@ -151,14 +128,6 @@ impl<'a> Iterator for LinkIter<'a> {
             sent,
         })
     }
-}
-
-/// Network interface kind.
-/// Differentiates the semantics of loopback and host-to-host communication.
-#[derive(Debug, Clone, Hash, Eq, PartialEq)]
-enum Interface {
-    Loopback,
-    External,
 }
 
 /// A two-way link between two hosts on the network.
@@ -255,26 +224,26 @@ impl Topology {
     // Move messages from any network links to the `dst` host.
     pub(crate) fn deliver_messages(&mut self, rand: &mut dyn RngCore, dst: &mut Host) {
         for (pair, link) in &mut self.links {
-            if pair.a == dst.addr || pair.b == dst.addr {
+            if pair.0 == dst.addr || pair.1 == dst.addr {
                 link.deliver_messages(&self.config, rand, dst);
             }
         }
     }
 
     pub(crate) fn hold(&mut self, a: IpAddr, b: IpAddr) {
-        self.links[&Topology::validate(a, b)].hold();
+        self.links[&Pair::new(a, b)].hold();
     }
 
     pub(crate) fn release(&mut self, a: IpAddr, b: IpAddr) {
-        self.links[&Topology::validate(a, b)].release();
+        self.links[&Pair::new(a, b)].release();
     }
 
     pub(crate) fn partition(&mut self, a: IpAddr, b: IpAddr) {
-        self.links[&Topology::validate(a, b)].explicit_partition();
+        self.links[&Pair::new(a, b)].explicit_partition();
     }
 
     pub(crate) fn repair(&mut self, a: IpAddr, b: IpAddr) {
-        self.links[&Topology::validate(a, b)].explicit_repair();
+        self.links[&Pair::new(a, b)].explicit_repair();
     }
 
     pub(crate) fn tick_by(&mut self, duration: Duration) {
@@ -287,14 +256,6 @@ impl Topology {
     pub(crate) fn iter_mut(&mut self) -> LinksIter {
         LinksIter {
             iter: self.links.iter_mut(),
-        }
-    }
-
-    fn validate(a: IpAddr, b: IpAddr) -> Pair {
-        if let Interface::Loopback = Pair::new(a, b).interface {
-            panic!("can't perform topology operations on localhost interfaces")
-        } else {
-            Pair::new(a, b)
         }
     }
 }
@@ -403,24 +364,10 @@ impl Link {
                         dst: sent.dst,
                         message: sent.protocol,
                     };
-
-                    // If the communication is localhost, use a real ip address
-                    // of the host, instead of a localhost address to deliver a
-                    // message. One of them is guaranteed not to be a loopback
-                    // address.
-                    let ip_addr = if sent.src.ip().is_loopback() {
-                        sent.dst.ip()
-                    } else if sent.dst.ip().is_loopback() {
-                        sent.src.ip()
-                    } else {
-                        sent.dst.ip()
-                    };
-
                     self.deliverable
-                        .entry(ip_addr)
+                        .entry(sent.dst.ip())
                         .or_default()
                         .push_back(envelope);
-
                     deliverable += 1;
                 }
             }

--- a/src/world.rs
+++ b/src/world.rs
@@ -1,11 +1,11 @@
-use crate::envelope::{Protocol};
+use crate::envelope::Protocol;
 use crate::{config, Dns, Host, ToIpAddr, ToIpAddrs, Topology, TRACING_TARGET};
 
 use indexmap::IndexMap;
 use rand::RngCore;
 use scoped_tls::scoped_thread_local;
 use std::cell::RefCell;
-use std::net::{IpAddr, SocketAddr, Ipv4Addr, Ipv6Addr};
+use std::net::{IpAddr, SocketAddr};
 use std::time::Duration;
 
 /// Tracks all the state for the simulated world.
@@ -101,11 +101,6 @@ impl World {
 
         tracing::info!(target: TRACING_TARGET, hostname = ?self.dns.reverse(addr), ?addr, "New");
 
-        // Handles connections within a host on loopback interfaces.
-        self.topology.register(Ipv4Addr::LOCALHOST.into(), addr);
-        self.topology.register(Ipv6Addr::LOCALHOST.into(), addr);
-
-
         // Register links between the new host and all existing hosts
         for existing in self.hosts.keys() {
             self.topology.register(*existing, addr);
@@ -115,8 +110,8 @@ impl World {
         self.hosts.insert(addr, Host::new(addr));
     }
 
-    /// Send `message` from `src` to `dst`.
-    /// Delivery between hosts is asynchronous and not guaranteed.
+    /// Send `message` from `src` to `dst`. Delivery is asynchronous and not
+    /// guaranteed.
     pub(crate) fn send_message(&mut self, src: SocketAddr, dst: SocketAddr, message: Protocol) {
         self.topology
             .enqueue_message(&mut self.rng, src, dst, message);

--- a/tests/tcp.rs
+++ b/tests/tcp.rs
@@ -1,6 +1,6 @@
 use std::{
     io,
-    net::{IpAddr, Ipv4Addr, Ipv6Addr},
+    net::{IpAddr, Ipv4Addr},
     rc::Rc,
     time::Duration,
 };
@@ -23,119 +23,7 @@ fn assert_error_kind<T>(res: io::Result<T>, kind: io::ErrorKind) {
 }
 
 async fn bind() -> std::result::Result<TcpListener, std::io::Error> {
-    TcpListener::bind((Ipv4Addr::UNSPECIFIED, PORT)).await
-}
-
-#[test]
-fn connects_within_a_localhost() -> Result {
-    let mut sim = Builder::new().build();
-
-    sim.client("server", async {
-        let listener = TcpListener::bind((Ipv4Addr::LOCALHOST, PORT)).await?;
-        tokio::spawn(async move {
-            loop {
-                let _ = listener.accept().await;
-            }
-        });
-
-        TcpStream::connect((Ipv4Addr::LOCALHOST, PORT)).await?;
-
-        assert_error_kind(
-            TcpStream::connect((Ipv6Addr::LOCALHOST, PORT)).await,
-            io::ErrorKind::ConnectionRefused,
-        );
-
-        Ok(())
-    });
-
-    sim.client("serveripv6", async {
-        let listener = TcpListener::bind((Ipv6Addr::LOCALHOST, PORT)).await?;
-
-        tokio::spawn(async move {
-            loop {
-                let _ = listener.accept().await;
-            }
-        });
-
-        TcpStream::connect((Ipv6Addr::LOCALHOST, PORT)).await?;
-
-        assert_error_kind(
-            TcpStream::connect((Ipv4Addr::LOCALHOST, PORT)).await,
-            io::ErrorKind::ConnectionRefused,
-        );
-
-        Ok(())
-    });
-
-    sim.run()
-}
-
-#[test]
-fn sends_data_within_a_localhost() -> Result {
-    let mut sim = Builder::new().build();
-
-    sim.client("server", async {
-        let listener = TcpListener::bind((Ipv4Addr::LOCALHOST, PORT)).await?;
-        let h = tokio::spawn(async move {
-            if let Ok((mut stream, _)) = listener.accept().await {
-                let _ = stream.write_u8(1).await;
-                assert_eq!(2, stream.read_u8().await.unwrap());
-            }
-        });
-
-        let mut stream = TcpStream::connect((Ipv4Addr::LOCALHOST, PORT)).await?;
-
-        assert_eq!(1, stream.read_u8().await?);
-        stream.write_u8(2).await?;
-        
-        h.await?;
-        Ok(())
-    });
-
-    sim.run()
-}
-
-#[test]
-fn connects_to_localhost_bind_to_any() -> Result {
-    let mut sim = Builder::new().build();
-
-    sim.client("server", async {
-        let listener = TcpListener::bind((Ipv4Addr::UNSPECIFIED, PORT)).await?;
-
-        tokio::spawn(async move {
-            let _ = listener.accept().await;
-        });
-
-        _ = TcpStream::connect((Ipv4Addr::LOCALHOST, PORT)).await?;
-
-        Ok(())
-    });
-
-    sim.run()
-}
-
-
-#[test]
-fn doesnt_allow_connection_outside_localhost() -> Result {
-    let mut sim = Builder::new().build();
-
-    sim.host("server", || async {
-        let listener = TcpListener::bind((Ipv4Addr::LOCALHOST, PORT)).await?;
-
-        loop {
-            let _ = listener.accept().await;
-        }
-    });
-
-    sim.client("client", async {
-        assert_error_kind(
-            TcpStream::connect(("server", PORT)).await,
-            io::ErrorKind::ConnectionRefused,
-        );
-        Ok(())
-    });
-
-    sim.run()
+    TcpListener::bind((IpAddr::from(Ipv4Addr::UNSPECIFIED), PORT)).await
 }
 
 #[test]


### PR DESCRIPTION
This reverts commit feca39de88fa3313b1f5c33ced3ace221c6a2b82.

After discussion with @mcches, we established that:
a) IPv6 is supported by conicidence, is partially completed, we don't want to ship that.
b) There is a bug which treats localhost communication as non-localhost.
c) We don't want to introduce localhost communication into a router (top.rs) and want to keep it local to the host, as an OS would.

This will be rewritten, connected to #79 