### PR TITLE
feat: add local_addr to net::UdpSocket

### DIFF
--- a/src/net/udp.rs
+++ b/src/net/udp.rs
@@ -78,6 +78,27 @@ impl UdpSocket {
 
         Ok((limit, origin))
     }
+
+    /// Returns the local address that this socket is bound to.
+    ///
+    /// # Example
+    ///
+    /// ```no_run
+    /// use turmoil::net::UdpSocket;
+    /// # use std::{io, net::SocketAddr};
+    ///
+    /// # #[tokio::main]
+    /// # async fn main() -> io::Result<()> {
+    /// let addr = "0.0.0.0:8080".parse::<SocketAddr>().unwrap();
+    /// let sock = UdpSocket::bind(addr).await?;
+    /// // the address the socket is bound to
+    /// let local_addr = sock.local_addr()?;
+    /// # Ok(())
+    /// # }
+    /// ```
+    pub fn local_addr(&self) -> Result<SocketAddr> {
+        Ok(self.local_addr)
+    }
 }
 
 impl Drop for UdpSocket {


### PR DESCRIPTION
I'm working on integrating turmoil with s2n-quic and needed a way to query the address that the socket is bound to. This is available on the [`tokio::net::UdpSocket`](https://docs.rs/tokio/latest/tokio/net/struct.UdpSocket.html#method.local_addr).