### PR TITLE
Remove inconsistent address resolution

### DIFF
--- a/src/dns.rs
+++ b/src/dns.rs
@@ -1,7 +1,7 @@
 use indexmap::IndexMap;
 #[cfg(feature = "regex")]
 use regex::Regex;
-use std::net::{IpAddr, Ipv4Addr, Ipv6Addr, SocketAddr};
+use std::net::{IpAddr, Ipv4Addr, Ipv6Addr, SocketAddr, SocketAddrV4, SocketAddrV6};
 
 use crate::ip::IpVersionAddrIter;
 
@@ -66,6 +66,11 @@ impl ToIpAddr for String {
 
 impl<'a> ToIpAddr for &'a str {
     fn to_ip_addr(&self, dns: &mut Dns) -> IpAddr {
+        let ipaddr: Result<IpAddr, _> = self.parse();
+        if let Ok(ipaddr) = ipaddr {
+            return ipaddr;
+        }
+
         *dns.names
             .entry(self.to_string())
             .or_insert_with(|| dns.addrs.next())
@@ -75,6 +80,18 @@ impl<'a> ToIpAddr for &'a str {
 impl ToIpAddr for IpAddr {
     fn to_ip_addr(&self, _: &mut Dns) -> IpAddr {
         *self
+    }
+}
+
+impl ToIpAddr for Ipv4Addr {
+    fn to_ip_addr(&self, _: &mut Dns) -> IpAddr {
+        IpAddr::V4(*self)
+    }
+}
+
+impl ToIpAddr for Ipv6Addr {
+    fn to_ip_addr(&self, _: &mut Dns) -> IpAddr {
+        IpAddr::V6(*self)
     }
 }
 
@@ -123,6 +140,18 @@ impl<'a> ToSocketAddrs for (&'a str, u16) {
 impl ToSocketAddrs for SocketAddr {
     fn to_socket_addr(&self, _: &Dns) -> SocketAddr {
         *self
+    }
+}
+
+impl ToSocketAddrs for SocketAddrV4 {
+    fn to_socket_addr(&self, _: &Dns) -> SocketAddr {
+        SocketAddr::V4(*self)
+    }
+}
+
+impl ToSocketAddrs for SocketAddrV6 {
+    fn to_socket_addr(&self, _: &Dns) -> SocketAddr {
+        SocketAddr::V6(*self)
     }
 }
 
@@ -193,6 +222,7 @@ mod sealed {
 #[cfg(test)]
 mod tests {
     use crate::{dns::Dns, ip::IpVersionAddrIter, ToSocketAddrs};
+    use std::net::Ipv4Addr;
 
     #[test]
     fn parse_str() {
@@ -209,5 +239,22 @@ mod tests {
         );
         assert_eq!(ipv4_port.to_socket_addr(&dns), ipv4_port.parse().unwrap());
         assert_eq!(ipv6_port.to_socket_addr(&dns), ipv6_port.parse().unwrap());
+    }
+
+    #[test]
+    fn raw_value_parsing() {
+        let mut dns = Dns::new(IpVersionAddrIter::default());
+        let addr = dns.lookup(Ipv4Addr::new(192, 168, 2, 2));
+        assert_eq!(addr, Ipv4Addr::new(192, 168, 2, 2));
+
+        // This should be consistent
+        let addr = dns.lookup("192.168.3.3");
+        assert_eq!(addr, Ipv4Addr::new(192, 168, 3, 3));
+
+        // with this
+        let addr = "192.168.3.3:0".to_socket_addr(&dns);
+        assert_eq!(addr.ip(), Ipv4Addr::new(192, 168, 3, 3));
+
+        // but was not before
     }
 }

--- a/src/dns.rs
+++ b/src/dns.rs
@@ -66,8 +66,7 @@ impl ToIpAddr for String {
 
 impl<'a> ToIpAddr for &'a str {
     fn to_ip_addr(&self, dns: &mut Dns) -> IpAddr {
-        let ipaddr: Result<IpAddr, _> = self.parse();
-        if let Ok(ipaddr) = ipaddr {
+        if let Ok(ipaddr) = self.parse() {
             return ipaddr;
         }
 
@@ -243,18 +242,17 @@ mod tests {
 
     #[test]
     fn raw_value_parsing() {
+        // lookups of raw ip addrs should be consistent
+        // between to_ip_addr() and to_socket_addr()
+        // for &str and IpAddr
         let mut dns = Dns::new(IpVersionAddrIter::default());
         let addr = dns.lookup(Ipv4Addr::new(192, 168, 2, 2));
         assert_eq!(addr, Ipv4Addr::new(192, 168, 2, 2));
 
-        // This should be consistent
         let addr = dns.lookup("192.168.3.3");
         assert_eq!(addr, Ipv4Addr::new(192, 168, 3, 3));
 
-        // with this
         let addr = "192.168.3.3:0".to_socket_addr(&dns);
         assert_eq!(addr.ip(), Ipv4Addr::new(192, 168, 3, 3));
-
-        // but was not before
     }
 }

--- a/tests/tcp.rs
+++ b/tests/tcp.rs
@@ -731,15 +731,16 @@ fn bind_ipv6_version_missmatch() {
 #[test]
 fn ipv6_connectivity() -> Result {
     let mut sim = Builder::new().ip_version(IpVersion::V6).build();
-    sim.client("client", async move {
-        let stream = TcpStream::connect("server:80").await.unwrap();
-        let _ = stream;
-        Ok(())
-    });
     sim.client("server", async move {
         let list = TcpListener::bind(("::", 80)).await.unwrap();
         let _stream = list.accept().await.unwrap();
         Ok(())
     });
+    sim.client("client", async move {
+        let stream = TcpStream::connect("server:80").await.unwrap();
+        let _ = stream;
+        Ok(())
+    });
+
     sim.run()
 }

--- a/tests/udp.rs
+++ b/tests/udp.rs
@@ -397,17 +397,18 @@ fn bind_ipv6_version_missmatch() {
 #[test]
 fn ipv6_connectivity() -> Result {
     let mut sim = Builder::new().ip_version(IpVersion::V6).build();
-    sim.client("client", async move {
-        let sock = UdpSocket::bind(":::0").await.unwrap();
-        sock.send_to(&[1], "server:80").await.unwrap();
-        let _ = sock;
-        Ok(())
-    });
     sim.client("server", async move {
         let sock = UdpSocket::bind(":::80").await.unwrap();
         let mut buf = [0; 512];
         let _stream = sock.recv_from(&mut buf).await.unwrap();
         Ok(())
     });
+    sim.client("client", async move {
+        let sock = UdpSocket::bind(":::0").await.unwrap();
+        sock.send_to(&[1], "server:80").await.unwrap();
+        let _ = sock;
+        Ok(())
+    });
+
     sim.run()
 }


### PR DESCRIPTION
There is an inconsistency in address resolution / parsing.
The trait `ToIpAddr` interprets strings that can be parsed as an `IpAddr` as 
domain names instead of parsing the address. `ToSocketAddr` however will
parse the Ip part of the address if possible. To remove this inconsistency 
`ToIpAddr` will now always interpret strings that can be parse to a `IpAddr` as `IpAddr`.

# Example

Without this change:
```rust
use turmoil::{*, net::*};

fn main() -> Result {
    let mut sim = Builder::new().build();
    sim.client("192.168.42.42", async move {
        let addr = UdpSocket::bind("0.0.0.0:0").await.unwrap().local_addr().unwrap();
        // addr will be 192.168.0.1:<port>, interpreting the clients name as a domain addr
        Ok(())
    });
    sim.client("192.168.57.57".parse::<IpAddr>().unwrap(), async move {
        let addr = UdpSocket::bind("0.0.0.0:0").await.unwrap().local_addr().unwrap();
        // addr will be 192.168.57.57:<port>, respecting the provided parameter
        Ok(())
    });
   
   // The problem is even more pronounced with lookups
   sim.client("x", async move {
        // lookups will use the ip->ip dns entry
        assert_eq!(lookup("192.168.42.42"), Ipv4Addr::new(192,168,0,1));
       
       // ToSocketAddr however not use dns but rather parse the raw ip part
       // Thus this will panic, since the link `x->192.168.42.42`does not exits
       let stream = TcpStream::connect("192.168.42.42:80").await?;
       Ok(()) 
   });

  sim.run()
}
```

On a site note, `ToIpAddr` was not implemented for `Ipv4Addr` and `Ipv6Addr` which 
was problematic since APIs with `impl ToIpAddr` could not use `.into()` due to missing 
type inference. Same goes for `ToSocketAddr` with `SocketAddrV4` and `SocketAddrV6` respectivly
(Tokio's `ToSocketAddr` does is implemented for these types)
