### PR TITLE
Filter out equal `IpAddr`s for regex matching

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -129,7 +129,7 @@ const TRACING_TARGET: &str = "turmoil";
 pub(crate) fn for_pairs(a: &Vec<IpAddr>, b: &Vec<IpAddr>, mut f: impl FnMut(IpAddr, IpAddr)) {
     for first in a {
         for second in b {
-            // skip for the host
+            // skip for the same host
             if first != second {
                 f(*first, *second)
             }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -129,7 +129,10 @@ const TRACING_TARGET: &str = "turmoil";
 pub(crate) fn for_pairs(a: &Vec<IpAddr>, b: &Vec<IpAddr>, mut f: impl FnMut(IpAddr, IpAddr)) {
     for first in a {
         for second in b {
-            f(*first, *second)
+            // skip for the host
+            if first != second {
+                f(*first, *second)
+            }
         }
     }
 }


### PR DESCRIPTION
Applying a "hold all" panics as the resolution does not take into
account equal `IpAddrs`s.

This fixes #115.
