### PR TITLE
Add support for loopback

### DIFF
--- a/src/net/tcp/stream.rs
+++ b/src/net/tcp/stream.rs
@@ -282,9 +282,17 @@ fn send_loopback(src: SocketAddr, dst: SocketAddr, message: Protocol) {
     tokio::spawn(async move {
         sleep(Duration::from_micros(1)).await;
         World::current(|world| {
-            let _ = world
-                .current_host_mut()
-                .receive_from_network(Envelope { src, dst, message });
+            let result =
+                world
+                    .current_host_mut()
+                    .receive_from_network(Envelope { src, dst, message });
+            if let Err(rst) = result {
+                let _ = world.current_host_mut().receive_from_network(Envelope {
+                    src: dst,
+                    dst: src,
+                    message: rst,
+                });
+            }
         })
     });
 }

--- a/src/net/tcp/stream.rs
+++ b/src/net/tcp/stream.rs
@@ -282,12 +282,10 @@ fn send_loopback(src: SocketAddr, dst: SocketAddr, message: Protocol) {
     tokio::spawn(async move {
         sleep(Duration::from_micros(1)).await;
         World::current(|world| {
-            let result =
-                world
-                    .current_host_mut()
-                    .receive_from_network(Envelope { src, dst, message });
-            if let Err(rst) = result {
-                let _ = world.current_host_mut().receive_from_network(Envelope {
+            if let Err(rst) = world
+                .current_host_mut()
+                .receive_from_network(Envelope { src, dst, message }) {
+                _ = world.current_host_mut().receive_from_network(Envelope {
                     src: dst,
                     dst: src,
                     message: rst,

--- a/src/net/udp.rs
+++ b/src/net/udp.rs
@@ -1,8 +1,11 @@
 use bytes::Bytes;
-use tokio::sync::{mpsc, Mutex};
+use tokio::{
+    sync::{mpsc, Mutex},
+    time::sleep,
+};
 
 use crate::{
-    envelope::{Datagram, Protocol},
+    envelope::{Datagram, Envelope, Protocol},
     ToSocketAddrs, World, TRACING_TARGET,
 };
 
@@ -10,6 +13,7 @@ use std::{
     cmp,
     io::{self, Result},
     net::SocketAddr,
+    time::Duration,
 };
 
 /// A simulated UDP socket.
@@ -97,13 +101,13 @@ impl UdpSocket {
     /// to this listener. The port allocated can be queried via the `local_addr`
     /// method.
     ///
-    /// Only `0.0.0.0` or `::` are currently supported.
+    /// Only `0.0.0.0`, `::`, or localhost are currently supported.
     pub async fn bind<A: ToSocketAddrs>(addr: A) -> Result<UdpSocket> {
         World::current(|world| {
             let mut addr = addr.to_socket_addr(&world.dns);
             let host = world.current_host_mut();
 
-            if !addr.ip().is_unspecified() {
+            if !addr.ip().is_unspecified() && !addr.ip().is_loopback() {
                 panic!("{addr} is not supported");
             }
 
@@ -111,8 +115,6 @@ impl UdpSocket {
                 panic!("ip version mismatch: {:?} host: {:?}", addr, host.addr)
             }
 
-            // Unspecified -> host's IP
-            addr.set_ip(host.addr);
             if addr.port() == 0 {
                 addr.set_port(host.assign_ephemeral_port());
             }
@@ -143,13 +145,7 @@ impl UdpSocket {
     pub async fn send_to<A: ToSocketAddrs>(&self, buf: &[u8], target: A) -> Result<usize> {
         World::current(|world| {
             let dst = target.to_socket_addr(&world.dns);
-
-            world.send_message(
-                self.local_addr,
-                dst,
-                Protocol::Udp(Datagram(Bytes::copy_from_slice(buf))),
-            );
-
+            self.send(world, dst, Datagram(Bytes::copy_from_slice(buf)));
             Ok(buf.len())
         })
     }
@@ -171,13 +167,7 @@ impl UdpSocket {
     pub fn try_send_to<A: ToSocketAddrs>(&self, buf: &[u8], target: A) -> Result<usize> {
         World::current(|world| {
             let dst = target.to_socket_addr(&world.dns);
-
-            world.send_message(
-                self.local_addr,
-                dst,
-                Protocol::Udp(Datagram(Bytes::copy_from_slice(buf))),
-            );
-
+            self.send(world, dst, Datagram(Bytes::copy_from_slice(buf)));
             Ok(buf.len())
         })
     }
@@ -286,6 +276,35 @@ impl UdpSocket {
     pub fn local_addr(&self) -> Result<SocketAddr> {
         Ok(self.local_addr)
     }
+
+    fn send(&self, world: &mut World, dst: SocketAddr, packet: Datagram) {
+        let msg = Protocol::Udp(packet);
+
+        let mut src = self.local_addr;
+        if dst.ip().is_loopback() {
+            src.set_ip(dst.ip());
+        }
+        if src.ip().is_unspecified() {
+            src.set_ip(world.current_host_mut().addr);
+        }
+
+        if dst.ip().is_loopback() {
+            send_loopback(src, dst, msg);
+        } else {
+            world.send_message(src, dst, msg);
+        }
+    }
+}
+
+fn send_loopback(src: SocketAddr, dst: SocketAddr, message: Protocol) {
+    tokio::spawn(async move {
+        sleep(Duration::from_micros(1)).await;
+        World::current(|world| {
+            let _ = world
+                .current_host_mut()
+                .receive_from_network(Envelope { src, dst, message });
+        })
+    });
 }
 
 impl Drop for UdpSocket {

--- a/src/net/udp.rs
+++ b/src/net/udp.rs
@@ -300,9 +300,10 @@ fn send_loopback(src: SocketAddr, dst: SocketAddr, message: Protocol) {
     tokio::spawn(async move {
         sleep(Duration::from_micros(1)).await;
         World::current(|world| {
-            let _ = world
+            world
                 .current_host_mut()
-                .receive_from_network(Envelope { src, dst, message });
+                .receive_from_network(Envelope { src, dst, message })
+                .expect("UDP does not get feedback on delivery errors");
         })
     });
 }

--- a/tests/tcp.rs
+++ b/tests/tcp.rs
@@ -1,10 +1,5 @@
 use std::{
-<<<<<<< HEAD
     assert_eq, assert_ne, io,
-=======
-    assert_eq, assert_ne,
-    io::{self},
->>>>>>> c7e07f2 (Add support for loopback)
     net::{IpAddr, Ipv4Addr, Ipv6Addr, SocketAddr},
     rc::Rc,
     time::Duration,

--- a/tests/tcp.rs
+++ b/tests/tcp.rs
@@ -1,6 +1,6 @@
 use std::{
-    io,
-    net::{IpAddr, Ipv4Addr, Ipv6Addr},
+    assert_eq, assert_ne, io,
+    net::{IpAddr, Ipv4Addr, Ipv6Addr, SocketAddr},
     rc::Rc,
     time::Duration,
 };
@@ -9,6 +9,7 @@ use std::future;
 use tokio::{
     io::{AsyncReadExt, AsyncWriteExt},
     sync::{oneshot, Notify},
+    task::JoinHandle,
     time::timeout,
 };
 use turmoil::{
@@ -766,5 +767,119 @@ fn bind_addr_in_use() -> Result {
         Ok(())
     });
 
+    sim.run()
+}
+
+fn run_localhost_test(
+    ip_version: IpVersion,
+    bind_addr: SocketAddr,
+    connect_addr: SocketAddr,
+) -> Result {
+    let mut sim = Builder::new().ip_version(ip_version).build();
+    let expected = [0, 1, 7, 3, 8];
+    sim.client("client", async move {
+        let listener = TcpListener::bind(bind_addr).await?;
+
+        let _: JoinHandle<io::Result<()>> = tokio::spawn(async move {
+            let (mut socket, socket_addr) = listener.accept().await?;
+            socket.write_all(&expected).await.unwrap();
+
+            assert_eq!(socket_addr.ip(), connect_addr.ip());
+            assert_eq!(socket.local_addr()?.ip(), connect_addr.ip());
+            assert_eq!(socket.peer_addr()?.ip(), connect_addr.ip());
+
+            Ok(())
+        });
+
+        let mut socket = TcpStream::connect(connect_addr).await?;
+        let mut actual = [0; 5];
+        socket.read_exact(&mut actual).await?;
+
+        assert_eq!(expected, actual);
+        assert_eq!(socket.local_addr()?.ip(), connect_addr.ip());
+        assert_eq!(socket.peer_addr()?.ip(), connect_addr.ip());
+
+        Ok(())
+    });
+    sim.run()
+}
+
+#[test]
+fn loopback_to_wildcard_v4() -> Result {
+    let bind_addr = SocketAddr::new(Ipv4Addr::UNSPECIFIED.into(), 1234);
+    let connect_addr = SocketAddr::from((Ipv4Addr::LOCALHOST, 1234));
+    run_localhost_test(IpVersion::V4, bind_addr, connect_addr)
+}
+
+#[test]
+fn loopback_to_localhost_v4() -> Result {
+    let bind_addr = SocketAddr::new(Ipv4Addr::LOCALHOST.into(), 1234);
+    let connect_addr = SocketAddr::from((Ipv4Addr::LOCALHOST, 1234));
+    run_localhost_test(IpVersion::V4, bind_addr, connect_addr)
+}
+
+#[test]
+fn loopback_to_wildcard_v6() -> Result {
+    let bind_addr = SocketAddr::new(Ipv6Addr::UNSPECIFIED.into(), 1234);
+    let connect_addr = SocketAddr::from((Ipv6Addr::LOCALHOST, 1234));
+    run_localhost_test(IpVersion::V6, bind_addr, connect_addr)
+}
+
+#[test]
+fn loopback_to_localhost_v6() -> Result {
+    let bind_addr = SocketAddr::new(Ipv6Addr::LOCALHOST.into(), 1234);
+    let connect_addr = SocketAddr::from((Ipv6Addr::LOCALHOST, 1234));
+    run_localhost_test(IpVersion::V6, bind_addr, connect_addr)
+}
+
+#[test]
+fn remote_to_localhost_refused() -> Result {
+    let mut sim = Builder::new().build();
+
+    let (stop, wait) = oneshot::channel();
+    sim.client("server", async move {
+        let bind_addr = SocketAddr::new(Ipv4Addr::LOCALHOST.into(), 1234);
+        let _listener = TcpListener::bind(bind_addr).await?;
+        wait.await.unwrap();
+        Ok(())
+    });
+
+    sim.client("client", async move {
+        let result = TcpStream::connect(("server", 1234)).await;
+        assert_error_kind(result, io::ErrorKind::ConnectionRefused);
+        stop.send(()).unwrap();
+        Ok(())
+    });
+
+    sim.run()
+}
+
+/// Since localhost is special cased to not route through the topology, this
+/// test validates that the world still steps forward even if a client ping
+/// pongs back and forth over localhost.
+#[test]
+fn localhost_ping_pong() -> Result {
+    let mut sim = Builder::new().build();
+    sim.client("client", async move {
+        let listener = TcpListener::bind((Ipv4Addr::LOCALHOST, 1234)).await?;
+
+        let _: JoinHandle<io::Result<()>> = tokio::spawn(async move {
+            let (mut socket, _) = listener.accept().await?;
+
+            let payload = turmoil::elapsed().as_nanos();
+            socket.write_u128(payload).await.unwrap();
+            let response = socket.read_u128().await?;
+            assert_ne!(payload, response);
+
+            Ok(())
+        });
+
+        let mut socket = TcpStream::connect((Ipv4Addr::LOCALHOST, 1234)).await?;
+        let response = socket.read_u128().await?;
+        let now = turmoil::elapsed().as_nanos();
+        assert_ne!(response, now);
+
+        Ok(())
+    });
     sim.run()
 }

--- a/tests/udp.rs
+++ b/tests/udp.rs
@@ -6,7 +6,8 @@ use std::{
     sync::{atomic::AtomicUsize, atomic::Ordering},
     time::Duration,
 };
-use tokio::{sync::oneshot, time::timeout};
+
+use tokio::{sync::oneshot, task::JoinHandle, time::timeout};
 use turmoil::{
     lookup,
     net::{self, UdpSocket},
@@ -440,5 +441,124 @@ fn bind_addr_in_use() -> Result {
         Ok(())
     });
 
+    sim.run()
+}
+
+fn run_localhost_test(
+    ip_version: IpVersion,
+    bind_addr: SocketAddr,
+    connect_addr: SocketAddr,
+) -> Result {
+    let mut sim = Builder::new().ip_version(ip_version).build();
+    let expected = [0, 1, 7, 3, 8];
+    sim.client("client", async move {
+        let socket = UdpSocket::bind(bind_addr).await?;
+
+        let _: JoinHandle<io::Result<()>> = tokio::spawn(async move {
+            let mut buf = [0; 5];
+            let (_, peer) = socket.recv_from(&mut buf).await?;
+
+            assert_eq!(expected, buf);
+            assert_eq!(peer.ip(), connect_addr.ip());
+            assert_eq!(socket.local_addr()?.ip(), bind_addr.ip());
+
+            socket.send_to(&expected, peer).await?;
+
+            Ok(())
+        });
+
+        let mut buf = [0; 5];
+        let bind_addr = SocketAddr::new(bind_addr.ip(), 0);
+        let socket = UdpSocket::bind(bind_addr).await?;
+        socket.send_to(&expected, connect_addr).await?;
+        let (_, peer) = socket.recv_from(&mut buf).await?;
+
+        assert_eq!(expected, buf);
+        assert_eq!(peer.ip(), connect_addr.ip());
+
+        Ok(())
+    });
+    sim.run()
+}
+
+#[test]
+fn loopback_to_wildcard_v4() -> Result {
+    let bind_addr = SocketAddr::new(Ipv4Addr::UNSPECIFIED.into(), 1234);
+    let connect_addr = SocketAddr::from((Ipv4Addr::LOCALHOST, 1234));
+    run_localhost_test(IpVersion::V4, bind_addr, connect_addr)
+}
+
+#[test]
+fn loopback_to_localhost_v4() -> Result {
+    let bind_addr = SocketAddr::new(Ipv4Addr::LOCALHOST.into(), 1234);
+    let connect_addr = SocketAddr::from((Ipv4Addr::LOCALHOST, 1234));
+    run_localhost_test(IpVersion::V4, bind_addr, connect_addr)
+}
+
+#[test]
+fn loopback_to_wildcard_v6() -> Result {
+    let bind_addr = SocketAddr::new(Ipv6Addr::UNSPECIFIED.into(), 1234);
+    let connect_addr = SocketAddr::from((Ipv6Addr::LOCALHOST, 1234));
+    run_localhost_test(IpVersion::V6, bind_addr, connect_addr)
+}
+
+#[test]
+fn loopback_to_localhost_v6() -> Result {
+    let bind_addr = SocketAddr::new(Ipv6Addr::LOCALHOST.into(), 1234);
+    let connect_addr = SocketAddr::from((Ipv6Addr::LOCALHOST, 1234));
+    run_localhost_test(IpVersion::V6, bind_addr, connect_addr)
+}
+
+#[test]
+fn remote_to_localhost_dropped() -> Result {
+    let mut sim = Builder::new().build();
+
+    sim.client("server", async move {
+        let bind_addr = UdpSocket::bind((Ipv4Addr::LOCALHOST, 1234)).await?;
+        let mut buf = [0; 4];
+
+        let result = timeout(Duration::from_secs(1), bind_addr.recv_from(&mut buf)).await;
+        assert!(result.is_err());
+        Ok(())
+    });
+
+    sim.client("client", async move {
+        let socket = UdpSocket::bind((Ipv4Addr::UNSPECIFIED, 1234)).await?;
+        socket.send_to(&[0], ("server", 1234)).await?;
+        Ok(())
+    });
+
+    sim.run()
+}
+
+/// Since localhost is special cased to not route through the topology, this
+/// test validates that the world still steps forward even if a client ping
+/// pongs back and forth over localhost.
+#[test]
+fn localhost_ping_pong() -> Result {
+    let mut sim = Builder::new().build();
+    sim.client("client", async move {
+        let server = SocketAddr::from((Ipv4Addr::LOCALHOST, 1234));
+        let socket = UdpSocket::bind(server).await?;
+
+        let _: JoinHandle<io::Result<()>> = tokio::spawn(async move {
+            let mut buffer = [0; 16];
+            let (_, peer) = socket.recv_from(&mut buffer).await?;
+
+            let buffer = turmoil::elapsed().as_nanos().to_be_bytes();
+            socket.send_to(&buffer, peer).await?;
+            Ok(())
+        });
+
+        let socket = UdpSocket::bind((Ipv4Addr::LOCALHOST, 0)).await?;
+        let start = turmoil::elapsed().as_nanos();
+        socket.send_to(&start.to_be_bytes(), server).await?;
+
+        let mut buffer = [0; 16];
+        socket.recv_from(&mut buffer).await?;
+        assert_ne!(start, u128::from_be_bytes(buffer));
+
+        Ok(())
+    });
     sim.run()
 }


### PR DESCRIPTION
This changes adds UDP and TCP support for loopback. Packets sent over loopback
do not flow through the topology, instead they are sent directly from the host
back to itself - somewhat modeling how the real world works. The affects of
this implementation are that network manipulation APIs do not work on loopback
traffic. However, this approach gets incrementally closer towards full loopback
support and unblocks most use cases.

The implementation is a bit of hack. I think where we want to get to is full 
support for multiple interfaces. For example, hosts should be allowed to have 
both an v4 and v6 ip addr. This will require a bit of a lift due to how hosts 
are identified by an IP address.