### PR TITLE
Fix reverse dns lookups on static binds

### DIFF
--- a/src/dns.rs
+++ b/src/dns.rs
@@ -49,12 +49,11 @@ impl Dns {
         addrs.to_ip_addrs(self)
     }
 
-    pub(crate) fn reverse(&self, addr: IpAddr) -> String {
+    pub(crate) fn reverse(&self, addr: IpAddr) -> Option<&str> {
         self.names
             .iter()
             .find(|(_, a)| **a == addr)
-            .map(|(name, _)| name.to_string())
-            .unwrap_or_else(|| addr.to_string())
+            .map(|(name, _)| name.as_str())
     }
 }
 

--- a/src/dns.rs
+++ b/src/dns.rs
@@ -49,12 +49,12 @@ impl Dns {
         addrs.to_ip_addrs(self)
     }
 
-    pub(crate) fn reverse(&self, addr: IpAddr) -> &str {
+    pub(crate) fn reverse(&self, addr: IpAddr) -> String {
         self.names
             .iter()
             .find(|(_, a)| **a == addr)
-            .map(|(name, _)| name)
-            .expect("no hostname found for ip address")
+            .map(|(name, _)| name.to_string())
+            .unwrap_or_else(|| addr.to_string())
     }
 }
 

--- a/src/sim.rs
+++ b/src/sim.rs
@@ -158,10 +158,7 @@ impl<'a> Sim<'a> {
     pub fn reverse_lookup_pair(&self, pair: (IpAddr, IpAddr)) -> (String, String) {
         let world = self.world.borrow();
 
-        (
-            world.dns.reverse(pair.0).to_owned(),
-            world.dns.reverse(pair.1).to_owned(),
-        )
+        (world.dns.reverse(pair.0), world.dns.reverse(pair.1))
     }
 
     /// Lookup IP addresses for resolved hosts.

--- a/src/sim.rs
+++ b/src/sim.rs
@@ -158,7 +158,18 @@ impl<'a> Sim<'a> {
     pub fn reverse_lookup_pair(&self, pair: (IpAddr, IpAddr)) -> (String, String) {
         let world = self.world.borrow();
 
-        (world.dns.reverse(pair.0), world.dns.reverse(pair.1))
+        (
+            world
+                .dns
+                .reverse(pair.0)
+                .expect("no hostname found for ip address")
+                .to_owned(),
+            world
+                .dns
+                .reverse(pair.1)
+                .expect("no hostname found for ip address")
+                .to_owned(),
+        )
     }
 
     /// Lookup IP addresses for resolved hosts.

--- a/tests/dns.rs
+++ b/tests/dns.rs
@@ -1,0 +1,12 @@
+use std::net::Ipv4Addr;
+use turmoil::*;
+
+// This test is not in src/dns.rs since it initalizes a tracing subscriber
+// which will presist, and effect other tests in the same file.
+#[test]
+fn tracing_subscriber_does_not_crash_direct_binds() -> Result {
+    tracing_subscriber::fmt().init();
+    let mut sim = Builder::new().build();
+    sim.client(Ipv4Addr::new(192, 168, 42, 42), async move { Ok(()) });
+    sim.run()
+}

--- a/tests/dns.rs
+++ b/tests/dns.rs
@@ -2,7 +2,7 @@ use std::net::Ipv4Addr;
 use turmoil::*;
 
 // This test is not in src/dns.rs since it initalizes a tracing subscriber
-// which will presist, and effect other tests in the same file.
+// which will persist, and effect other tests in the same file.
 #[test]
 fn tracing_subscriber_does_not_crash_direct_binds() -> Result {
     tracing_subscriber::fmt().init();


### PR DESCRIPTION
Turmoil supports the creation of clients/hosts bound to any address that `impl ToIpAddr`.
This allows for then creation of nodes, bound to static IP addresses. Such nodes
will not appear in the internal mappings of `Dns`, since they have no hostname.

`Dns::reverse` however expects that all nodes (all inputs would be more correct) are contained
in the dns mapping. If this assumption is broken, `Dns::reverse` panics. This means that any use of
`Dns::reverse` in combination with a statically bound address will panic. 

The problem: If a tracing subscriber is active, internal traces will attempt to use `Dns::reverse` once
when the node is initialized, thus crashing the simulation (world.rs:107).

## Solutions
I See three solutions:

### A (currently implemented)
If a reverse lookup does not find any entry in the dns mapping, it returns the input address as a `String`.
This would keep API changes small (`&str` to `String`). However all input addresses that have not appeared 
in the mapping would be handled this way, not just statically bound addresses.

### B
Add static binds to dns mapping. We could implement node creation in a way, that a dns entry
mapping the stringified  static address to the real static address is created. This would not
change the `Dns::reverse`, but major changes in address resolution / node creation would be nessecary.

### C
Change the API of `Dns::reverse` to reflect the failable nature of such lookups. By changing the return type to either 
`Option<&str>` or `Result<&str>` we could deal with failing lookups without panicking. This would be the most expressiv
option, but it would change the public API of `Dns::reverse` and `Sim::reverse_lookup_pair`. 