### PR TITLE
Make socket buffer capacity configurable

### DIFF
--- a/src/builder.rs
+++ b/src/builder.rs
@@ -91,6 +91,16 @@ impl Builder {
         self
     }
 
+    pub fn tcp_capacity(&mut self, value: usize) -> &mut Self {
+        self.config.tcp_capacity = value;
+        self
+    }
+
+    pub fn udp_capacity(&mut self, value: usize) -> &mut Self {
+        self.config.udp_capacity = value;
+        self
+    }
+
     pub fn build<'a>(&self) -> Sim<'a> {
         self.build_with_rng(Box::new(rand::rngs::SmallRng::from_entropy()))
     }

--- a/src/config.rs
+++ b/src/config.rs
@@ -11,6 +11,12 @@ pub(crate) struct Config {
 
     /// When the simulation starts
     pub(crate) epoch: SystemTime,
+
+    /// Max size of the tcp receive buffer
+    pub(crate) tcp_capacity: usize,
+
+    /// Max size of the udp receive buffer
+    pub(crate) udp_capacity: usize,
 }
 
 /// Configures link behavior.
@@ -52,6 +58,8 @@ impl Default for Config {
             duration: Duration::from_secs(10),
             tick: Duration::from_millis(1),
             epoch: SystemTime::now(),
+            tcp_capacity: 64,
+            udp_capacity: 64,
         }
     }
 }

--- a/src/host.rs
+++ b/src/host.rs
@@ -275,7 +275,7 @@ impl StreamSocket {
     // Buffer and re-order received segments by `seq` as the network may deliver
     // them out of order.
     fn buffer(&mut self, seq: u64, segment: SequencedSegment) -> Result<(), Protocol> {
-        use mpsc::error::TrySendError::Closed;
+        use mpsc::error::TrySendError::*;
 
         let exists = self.buf.insert(seq, segment);
 
@@ -287,7 +287,7 @@ impl StreamSocket {
             let segment = self.buf.remove(&self.recv_seq).unwrap();
             self.sender.try_send(segment).map_err(|e| match e {
                 Closed(_) => Protocol::Tcp(Segment::Rst),
-                _ => panic!("{} socket buffer full", self.local_addr),
+                Full(_) => panic!("{} socket buffer full", self.local_addr),
             })?;
         }
 

--- a/src/sim.rs
+++ b/src/sim.rs
@@ -70,7 +70,7 @@ impl<'a> Sim<'a> {
             let world = RefCell::get_mut(&mut self.world);
 
             // Register host state with the world
-            world.register(addr);
+            world.register(addr, &self.config);
         }
 
         let rt = World::enter(&self.world, || Rt::client(client));
@@ -95,7 +95,7 @@ impl<'a> Sim<'a> {
             let world = RefCell::get_mut(&mut self.world);
 
             // Register host state with the world
-            world.register(addr);
+            world.register(addr, &self.config);
         }
 
         let rt = World::enter(&self.world, || Rt::host(host));

--- a/src/world.rs
+++ b/src/world.rs
@@ -1,3 +1,4 @@
+use crate::config::Config;
 use crate::envelope::Protocol;
 use crate::ip::IpVersionAddrIter;
 use crate::{config, Dns, Host, ToIpAddr, ToIpAddrs, Topology, TRACING_TARGET};
@@ -98,7 +99,7 @@ impl World {
     }
 
     /// Register a new host with the simulation.
-    pub(crate) fn register(&mut self, addr: IpAddr) {
+    pub(crate) fn register(&mut self, addr: IpAddr, config: &Config) {
         assert!(
             !self.hosts.contains_key(&addr),
             "already registered host for the given ip address"
@@ -112,7 +113,10 @@ impl World {
         }
 
         // Initialize host state
-        self.hosts.insert(addr, Host::new(addr));
+        self.hosts.insert(
+            addr,
+            Host::new(addr, config.tcp_capacity, config.udp_capacity),
+        );
     }
 
     /// Send `message` from `src` to `dst`. Delivery is asynchronous and not


### PR DESCRIPTION
Behavior stays the same for now, but the values can at least be modified for chatty use cases.