### PR TITLE
Tracing improvments

### DIFF
--- a/src/host.rs
+++ b/src/host.rs
@@ -12,7 +12,6 @@ use std::net::{IpAddr, SocketAddr};
 use std::sync::Arc;
 use tokio::sync::{mpsc, Notify};
 use tokio::time::{Duration, Instant};
-use tracing::Span;
 
 /// A host in the simulated network.
 ///
@@ -29,9 +28,6 @@ pub(crate) struct Host {
     /// L4 Transmission Control Protocol (TCP).
     pub(crate) tcp: Tcp,
 
-    /// A span indicating the current scope (clone of corresponding span in Rt)
-    pub(crate) span: Span,
-
     /// Ports 49152..=65535 for client connections.
     /// https://www.rfc-editor.org/rfc/rfc6335#section-6
     next_ephemeral_port: u16,
@@ -44,13 +40,12 @@ pub(crate) struct Host {
 }
 
 impl Host {
-    pub(crate) fn new(addr: IpAddr, span: Span, tcp_capacity: usize, udp_capacity: usize) -> Host {
+    pub(crate) fn new(addr: IpAddr, tcp_capacity: usize, udp_capacity: usize) -> Host {
         Host {
             addr,
             udp: Udp::new(udp_capacity),
             tcp: Tcp::new(tcp_capacity),
             next_ephemeral_port: 49152,
-            span,
             elapsed: Duration::ZERO,
             now: None,
         }
@@ -102,19 +97,17 @@ impl Host {
     // key problem is that the Host doesn't actually send messages, rather the
     // World is borrowed, and it sends.
     pub(crate) fn receive_from_network(&mut self, envelope: Envelope) -> Result<(), Protocol> {
-        self.span.in_scope(|| {
-            let Envelope { src, dst, message } = envelope;
+        let Envelope { src, dst, message } = envelope;
 
-            tracing::trace!(target: TRACING_TARGET, ?dst, ?src, protocol = %message, "Delivered");
+        tracing::trace!(target: TRACING_TARGET, ?dst, ?src, protocol = %message, "Delivered");
 
-            match message {
-                Protocol::Tcp(segment) => self.tcp.receive_from_network(src, dst, segment),
-                Protocol::Udp(datagram) => {
-                    self.udp.receive_from_network(src, dst, datagram);
-                    Ok(())
-                }
+        match message {
+            Protocol::Tcp(segment) => self.tcp.receive_from_network(src, dst, segment),
+            Protocol::Udp(datagram) => {
+                self.udp.receive_from_network(src, dst, datagram);
+                Ok(())
             }
-        })
+        }
     }
 
     pub(crate) fn tick(&mut self, duration: Duration) {
@@ -432,12 +425,7 @@ mod test {
 
     #[test]
     fn recycle_ports() -> Result {
-        let mut host = Host::new(
-            std::net::Ipv4Addr::UNSPECIFIED.into(),
-            tracing::span!(tracing::Level::INFO, "node"),
-            1,
-            1,
-        );
+        let mut host = Host::new(std::net::Ipv4Addr::UNSPECIFIED.into(), 1, 1);
 
         host.udp.bind((host.addr, 65534).into())?;
         host.udp.bind((host.addr, 65535).into())?;

--- a/src/host.rs
+++ b/src/host.rs
@@ -30,7 +30,7 @@ pub(crate) struct Host {
     pub(crate) tcp: Tcp,
 
     /// A span indicating the current scope (clone of corresponding span in Rt)
-    span: Span,
+    pub(crate) span: Span,
 
     /// Ports 49152..=65535 for client connections.
     /// https://www.rfc-editor.org/rfc/rfc6335#section-6

--- a/src/host.rs
+++ b/src/host.rs
@@ -99,7 +99,7 @@ impl Host {
     pub(crate) fn receive_from_network(&mut self, envelope: Envelope) -> Result<(), Protocol> {
         let Envelope { src, dst, message } = envelope;
 
-        tracing::trace!(target: TRACING_TARGET, ?dst, ?src, protocol = %message, "Delivered");
+        tracing::trace!(target: TRACING_TARGET, ?src, ?dst, protocol = %message, "Delivered");
 
         match message {
             Protocol::Tcp(segment) => self.tcp.receive_from_network(src, dst, segment),
@@ -171,7 +171,7 @@ impl Udp {
     fn receive_from_network(&mut self, src: SocketAddr, dst: SocketAddr, datagram: Datagram) {
         if let Some(bind) = self.binds.get_mut(&dst.port()) {
             if !matches(bind.bind_addr, dst) {
-                tracing::trace!(target: TRACING_TARGET, ?dst, ?src, protocol = %Protocol::Udp(datagram), "Dropped (Addr not bound)");
+                tracing::trace!(target: TRACING_TARGET, ?src, ?dst, protocol = %Protocol::Udp(datagram), "Dropped (Addr not bound)");
                 return;
             }
             if let Err(err) = bind.queue.try_send((datagram, src)) {
@@ -180,10 +180,10 @@ impl Udp {
                 //       require a different channel implementation.
                 match err {
                     mpsc::error::TrySendError::Full((datagram, _)) => {
-                        tracing::trace!(target: TRACING_TARGET, ?dst, ?src, protocol = %Protocol::Udp(datagram), "Dropped (Full buffer)");
+                        tracing::trace!(target: TRACING_TARGET, ?src, ?dst, protocol = %Protocol::Udp(datagram), "Dropped (Full buffer)");
                     }
                     mpsc::error::TrySendError::Closed((datagram, _)) => {
-                        tracing::trace!(target: TRACING_TARGET, ?dst, ?src, protocol = %Protocol::Udp(datagram), "Dropped (Receiver closed)");
+                        tracing::trace!(target: TRACING_TARGET, ?src, ?dst, protocol = %Protocol::Udp(datagram), "Dropped (Receiver closed)");
                     }
                 }
             }

--- a/src/net/tcp/listener.rs
+++ b/src/net/tcp/listener.rs
@@ -62,7 +62,7 @@ impl TcpListener {
                 let host = world.current_host_mut();
                 let (syn, origin) = host.tcp.accept(self.local_addr)?;
 
-                tracing::trace!(target: TRACING_TARGET, dst = ?origin, src = ?self.local_addr, protocol = %"TCP SYN", "Recv");
+                tracing::trace!(target: TRACING_TARGET, src = ?origin, dst = ?self.local_addr, protocol = %"TCP SYN", "Recv");
 
                 // Send SYN-ACK -> origin. If Ok we proceed (acts as the ACK),
                 // else we return early to avoid host mutations.

--- a/src/net/udp.rs
+++ b/src/net/udp.rs
@@ -205,7 +205,7 @@ impl UdpSocket {
             .try_recv_from(buf)
             .expect("queue should be ready after readable yields");
 
-        tracing::trace!(target: TRACING_TARGET, dst = ?self.local_addr, src = ?origin, protocol = %datagram, "Recv");
+        tracing::trace!(target: TRACING_TARGET, src = ?origin, dst = ?self.local_addr, protocol = %datagram, "Recv");
 
         Ok((limit, origin))
     }
@@ -231,7 +231,7 @@ impl UdpSocket {
             io::Error::new(io::ErrorKind::WouldBlock, "socket receive queue is empty")
         })?;
 
-        tracing::trace!(target: TRACING_TARGET, dst = ?self.local_addr, src = ?origin, protocol = %datagram, "Recv");
+        tracing::trace!(target: TRACING_TARGET, src = ?origin, dst = ?self.local_addr, protocol = %datagram, "Recv");
 
         Ok((limit, origin))
     }

--- a/src/rt.rs
+++ b/src/rt.rs
@@ -42,7 +42,7 @@ pub(crate) struct Rt<'a> {
     /// Local task set used for running !Send tasks.
     local: LocalSet,
 
-    /// A tracing span representing the current context for a tracing subscriber.
+    /// A user readable name to identify the node.
     pub(crate) nodename: Arc<str>,
 
     /// Optional handle to a host's software. When software finishes, the handle is

--- a/src/sim.rs
+++ b/src/sim.rs
@@ -80,7 +80,7 @@ impl<'a> Sim<'a> {
             let world = RefCell::get_mut(&mut self.world);
 
             // Register host state with the world
-            world.register(addr, &self.config);
+            world.register(addr, &nodename, &self.config);
         }
 
         let rt = World::enter(&self.world, || Rt::client(nodename, client));
@@ -113,7 +113,7 @@ impl<'a> Sim<'a> {
             let world = RefCell::get_mut(&mut self.world);
 
             // Register host state with the world
-            world.register(addr, &self.config);
+            world.register(addr, &nodename, &self.config);
         }
 
         let rt = World::enter(&self.world, || Rt::host(nodename, host));

--- a/src/top.rs
+++ b/src/top.rs
@@ -383,6 +383,8 @@ impl Link {
         rand: &mut dyn RngCore,
         host: &mut Host,
     ) {
+        let _guard = host.span.clone().entered();
+
         let deliverable = self
             .deliverable
             .entry(host.addr)

--- a/src/top.rs
+++ b/src/top.rs
@@ -297,7 +297,7 @@ impl Link {
         dst: SocketAddr,
         message: Protocol,
     ) {
-        tracing::trace!(target: TRACING_TARGET, ?src, ?dst, protocol = %message, "Send");
+        tracing::trace!(target: TRACING_TARGET, ?src, ?dst, protocol = %message, "Send (2)");
 
         self.rand_partition_or_repair(global_config, rand);
         self.enqueue(global_config, rand, src, dst, message);
@@ -383,8 +383,6 @@ impl Link {
         rand: &mut dyn RngCore,
         host: &mut Host,
     ) {
-        let _guard = host.span.clone().entered();
-
         let deliverable = self
             .deliverable
             .entry(host.addr)

--- a/src/top.rs
+++ b/src/top.rs
@@ -297,7 +297,7 @@ impl Link {
         dst: SocketAddr,
         message: Protocol,
     ) {
-        tracing::trace!(target: TRACING_TARGET, ?src, ?dst, protocol = %message, "Send (2)");
+        tracing::trace!(target: TRACING_TARGET, ?src, ?dst, protocol = %message, "Send");
 
         self.rand_partition_or_repair(global_config, rand);
         self.enqueue(global_config, rand, src, dst, message);

--- a/src/world.rs
+++ b/src/world.rs
@@ -9,7 +9,6 @@ use scoped_tls::scoped_thread_local;
 use std::cell::RefCell;
 use std::net::{IpAddr, SocketAddr};
 use std::time::Duration;
-use tracing::Span;
 
 /// Tracks all the state for the simulated world.
 pub(crate) struct World {
@@ -100,7 +99,7 @@ impl World {
     }
 
     /// Register a new host with the simulation.
-    pub(crate) fn register(&mut self, addr: IpAddr, span: Span, config: &Config) {
+    pub(crate) fn register(&mut self, addr: IpAddr, config: &Config) {
         assert!(
             !self.hosts.contains_key(&addr),
             "already registered host for the given ip address"
@@ -116,7 +115,7 @@ impl World {
         // Initialize host state
         self.hosts.insert(
             addr,
-            Host::new(addr, span, config.tcp_capacity, config.udp_capacity),
+            Host::new(addr, config.tcp_capacity, config.udp_capacity),
         );
     }
 

--- a/src/world.rs
+++ b/src/world.rs
@@ -99,13 +99,13 @@ impl World {
     }
 
     /// Register a new host with the simulation.
-    pub(crate) fn register(&mut self, addr: IpAddr, config: &Config) {
+    pub(crate) fn register(&mut self, addr: IpAddr, nodename: &str, config: &Config) {
         assert!(
             !self.hosts.contains_key(&addr),
             "already registered host for the given ip address"
         );
 
-        tracing::info!(target: TRACING_TARGET, hostname = ?self.dns.reverse(addr), ?addr, "New");
+        tracing::info!(target: TRACING_TARGET, nodename, ?addr, "New");
 
         // Register links between the new host and all existing hosts
         for existing in self.hosts.keys() {

--- a/src/world.rs
+++ b/src/world.rs
@@ -9,6 +9,7 @@ use scoped_tls::scoped_thread_local;
 use std::cell::RefCell;
 use std::net::{IpAddr, SocketAddr};
 use std::time::Duration;
+use tracing::Span;
 
 /// Tracks all the state for the simulated world.
 pub(crate) struct World {
@@ -99,7 +100,7 @@ impl World {
     }
 
     /// Register a new host with the simulation.
-    pub(crate) fn register(&mut self, addr: IpAddr, config: &Config) {
+    pub(crate) fn register(&mut self, addr: IpAddr, span: Span, config: &Config) {
         assert!(
             !self.hosts.contains_key(&addr),
             "already registered host for the given ip address"
@@ -115,7 +116,7 @@ impl World {
         // Initialize host state
         self.hosts.insert(
             addr,
-            Host::new(addr, config.tcp_capacity, config.udp_capacity),
+            Host::new(addr, span, config.tcp_capacity, config.udp_capacity),
         );
     }
 


### PR DESCRIPTION
Some improvements to tracing with turmoil:
- All nodes now have a node-span, to add information about the currently active node to all tracing events
- These spans are stored in `Rt` and `Host` to cover all codepaths that may emit events
- All internal tracing events now share a common structure (`src`,`dst`, ..., `msg`)
- `src` now always represents the source of the packet, the tracing record was about  (`src` of SYN is client, `src` of SYN-ACK is server)