### PR TITLE
 Add support for custom IP networks

### DIFF
--- a/src/builder.rs
+++ b/src/builder.rs
@@ -1,4 +1,4 @@
-use crate::{ip::IpNetwork, *};
+use crate::{ip::IpSubnet, *};
 
 use rand::{RngCore, SeedableRng};
 use std::time::{Duration, SystemTime};
@@ -9,7 +9,7 @@ pub struct Builder {
 
     config: Config,
 
-    ip_network: IpNetwork,
+    subnet: IpSubnet,
 
     link: config::Link,
 }
@@ -25,7 +25,7 @@ impl Builder {
         Self {
             rng: None,
             config: Config::default(),
-            ip_network: IpNetwork::default(),
+            subnet: IpSubnet::default(),
             link: config::Link {
                 latency: Some(config::Latency::default()),
                 message_loss: Some(config::MessageLoss::default()),
@@ -52,8 +52,8 @@ impl Builder {
     }
 
     /// Which kind of network should be simulated.
-    pub fn ip_network(&mut self, value: impl Into<IpNetwork>) -> &mut Self {
-        self.ip_network = value.into();
+    pub fn ip_network(&mut self, value: impl Into<IpSubnet>) -> &mut Self {
+        self.subnet = value.into();
         self
     }
 
@@ -106,7 +106,7 @@ impl Builder {
     }
 
     pub fn build_with_rng<'a>(&self, rng: Box<dyn RngCore>) -> Sim<'a> {
-        let world = World::new(self.link.clone(), rng, self.ip_network);
+        let world = World::new(self.link.clone(), rng, self.subnet);
         Sim::new(self.config.clone(), world)
     }
 }

--- a/src/builder.rs
+++ b/src/builder.rs
@@ -1,4 +1,4 @@
-use crate::*;
+use crate::{ip::IpNetwork, *};
 
 use rand::{RngCore, SeedableRng};
 use std::time::{Duration, SystemTime};
@@ -9,7 +9,7 @@ pub struct Builder {
 
     config: Config,
 
-    ip_version: IpVersion,
+    ip_network: IpNetwork,
 
     link: config::Link,
 }
@@ -25,7 +25,7 @@ impl Builder {
         Self {
             rng: None,
             config: Config::default(),
-            ip_version: IpVersion::default(),
+            ip_network: IpNetwork::default(),
             link: config::Link {
                 latency: Some(config::Latency::default()),
                 message_loss: Some(config::MessageLoss::default()),
@@ -52,8 +52,8 @@ impl Builder {
     }
 
     /// Which kind of network should be simulated.
-    pub fn ip_version(&mut self, value: IpVersion) -> &mut Self {
-        self.ip_version = value;
+    pub fn ip_network(&mut self, value: impl Into<IpNetwork>) -> &mut Self {
+        self.ip_network = value.into();
         self
     }
 
@@ -106,7 +106,7 @@ impl Builder {
     }
 
     pub fn build_with_rng<'a>(&self, rng: Box<dyn RngCore>) -> Sim<'a> {
-        let world = World::new(self.link.clone(), rng, self.ip_version.iter());
+        let world = World::new(self.link.clone(), rng, self.ip_network.iter());
         Sim::new(self.config.clone(), world)
     }
 }

--- a/src/builder.rs
+++ b/src/builder.rs
@@ -52,7 +52,7 @@ impl Builder {
     }
 
     /// Which kind of network should be simulated.
-    pub fn ip_network(&mut self, value: impl Into<IpSubnet>) -> &mut Self {
+    pub fn ip_subnet(&mut self, value: impl Into<IpSubnet>) -> &mut Self {
         self.subnet = value.into();
         self
     }

--- a/src/builder.rs
+++ b/src/builder.rs
@@ -106,7 +106,7 @@ impl Builder {
     }
 
     pub fn build_with_rng<'a>(&self, rng: Box<dyn RngCore>) -> Sim<'a> {
-        let world = World::new(self.link.clone(), rng, self.ip_network.iter());
+        let world = World::new(self.link.clone(), rng, self.ip_network);
         Sim::new(self.config.clone(), world)
     }
 }

--- a/src/dns.rs
+++ b/src/dns.rs
@@ -3,7 +3,7 @@ use indexmap::IndexMap;
 use regex::Regex;
 use std::net::{IpAddr, Ipv4Addr, Ipv6Addr, SocketAddr, SocketAddrV4, SocketAddrV6};
 
-use crate::ip::IpNetworkIter;
+use crate::ip::IpSubnetIter;
 
 /// Each new host has an IP in the subnet defined by the
 /// ip version of the simulation.
@@ -11,7 +11,7 @@ use crate::ip::IpNetworkIter;
 /// Ipv4 simulations use the subnet 192.168.0.0/16.
 /// Ipv6 simulations use the link local subnet fe80:::/64
 pub struct Dns {
-    addrs: IpNetworkIter,
+    addrs: IpSubnetIter,
     names: IndexMap<String, IpAddr>,
 }
 
@@ -34,7 +34,7 @@ pub trait ToSocketAddrs: sealed::Sealed {
 }
 
 impl Dns {
-    pub(crate) fn new(addrs: IpNetworkIter) -> Dns {
+    pub(crate) fn new(addrs: IpSubnetIter) -> Dns {
         Dns {
             addrs,
             names: IndexMap::new(),
@@ -219,12 +219,12 @@ mod sealed {
 
 #[cfg(test)]
 mod tests {
-    use crate::{dns::Dns, ip::IpNetwork, ToSocketAddrs};
+    use crate::{dns::Dns, ip::IpSubnet, ToSocketAddrs};
     use std::net::Ipv4Addr;
 
     #[test]
     fn parse_str() {
-        let mut dns = Dns::new(IpNetwork::default().iter());
+        let mut dns = Dns::new(IpSubnet::default().iter());
         let generated_addr = dns.lookup("foo");
 
         let hostname_port = "foo:5000".to_socket_addr(&dns);
@@ -244,7 +244,7 @@ mod tests {
         // lookups of raw ip addrs should be consistent
         // between to_ip_addr() and to_socket_addr()
         // for &str and IpAddr
-        let mut dns = Dns::new(IpNetwork::default().iter());
+        let mut dns = Dns::new(IpSubnet::default().iter());
         let addr = dns.lookup(Ipv4Addr::new(192, 168, 2, 2));
         assert_eq!(addr, Ipv4Addr::new(192, 168, 2, 2));
 

--- a/src/dns.rs
+++ b/src/dns.rs
@@ -3,7 +3,7 @@ use indexmap::IndexMap;
 use regex::Regex;
 use std::net::{IpAddr, Ipv4Addr, Ipv6Addr, SocketAddr, SocketAddrV4, SocketAddrV6};
 
-use crate::ip::IpVersionAddrIter;
+use crate::ip::IpNetworkIter;
 
 /// Each new host has an IP in the subnet defined by the
 /// ip version of the simulation.
@@ -11,7 +11,7 @@ use crate::ip::IpVersionAddrIter;
 /// Ipv4 simulations use the subnet 192.168.0.0/16.
 /// Ipv6 simulations use the link local subnet fe80:::/64
 pub struct Dns {
-    addrs: IpVersionAddrIter,
+    addrs: IpNetworkIter,
     names: IndexMap<String, IpAddr>,
 }
 
@@ -34,7 +34,7 @@ pub trait ToSocketAddrs: sealed::Sealed {
 }
 
 impl Dns {
-    pub(crate) fn new(addrs: IpVersionAddrIter) -> Dns {
+    pub(crate) fn new(addrs: IpNetworkIter) -> Dns {
         Dns {
             addrs,
             names: IndexMap::new(),
@@ -219,12 +219,12 @@ mod sealed {
 
 #[cfg(test)]
 mod tests {
-    use crate::{dns::Dns, ip::IpVersionAddrIter, ToSocketAddrs};
+    use crate::{dns::Dns, ip::IpNetwork, ToSocketAddrs};
     use std::net::Ipv4Addr;
 
     #[test]
     fn parse_str() {
-        let mut dns = Dns::new(IpVersionAddrIter::default());
+        let mut dns = Dns::new(IpNetwork::default().iter());
         let generated_addr = dns.lookup("foo");
 
         let hostname_port = "foo:5000".to_socket_addr(&dns);
@@ -244,7 +244,7 @@ mod tests {
         // lookups of raw ip addrs should be consistent
         // between to_ip_addr() and to_socket_addr()
         // for &str and IpAddr
-        let mut dns = Dns::new(IpVersionAddrIter::default());
+        let mut dns = Dns::new(IpNetwork::default().iter());
         let addr = dns.lookup(Ipv4Addr::new(192, 168, 2, 2));
         assert_eq!(addr, Ipv4Addr::new(192, 168, 2, 2));
 

--- a/src/ip.rs
+++ b/src/ip.rs
@@ -27,8 +27,8 @@ pub struct Ipv6Network {
 impl IpNetwork {
     pub(crate) fn iter(&self) -> IpNetworkIter {
         match self {
-            IpNetwork::V4(v4) => IpNetworkIter::V4(v4.clone(), 1),
-            IpNetwork::V6(v6) => IpNetworkIter::V6(v6.clone(), 1),
+            IpNetwork::V4(v4) => IpNetworkIter::V4(*v4, 1),
+            IpNetwork::V6(v6) => IpNetworkIter::V6(*v6, 1),
         }
     }
 

--- a/src/ip.rs
+++ b/src/ip.rs
@@ -1,60 +1,132 @@
 use std::net::{IpAddr, Ipv4Addr, Ipv6Addr};
 
-/// The kinds of networks that can be simulated in turmoil
-#[derive(Debug, Clone, PartialEq, Eq, Default)]
-pub enum IpVersion {
-    /// An Ipv4 network with an address space of 192.168.0.0/16
-    #[default]
-    V4,
-    /// An local area Ipv6 network with an address space of fe80::/64
-    V6,
+/// The address layout of the underlying network.
+///
+/// The default value is an Ipv4 subnet with addresses
+/// in the range `192.168.0.0/16`.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum IpNetwork {
+    /// An Ipv4 capable network, with a given subnet address range.
+    V4(Ipv4Network),
+    /// An Ipv6 capable network, with a given subnet address range.
+    V6(Ipv6Network),
 }
 
-impl IpVersion {
-    pub(crate) fn iter(&self) -> IpVersionAddrIter {
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Ipv4Network {
+    prefix: Ipv4Addr,
+    mask: Ipv4Addr,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Ipv6Network {
+    prefix: Ipv6Addr,
+    mask: Ipv6Addr,
+}
+
+impl IpNetwork {
+    pub(crate) fn iter(&self) -> IpNetworkIter {
         match self {
-            Self::V4 => IpVersionAddrIter::V4(1),
-            Self::V6 => IpVersionAddrIter::V6(1),
+            IpNetwork::V4(v4) => IpNetworkIter::V4(v4.clone(), 1),
+            IpNetwork::V6(v6) => IpNetworkIter::V6(v6.clone(), 1),
         }
     }
 }
 
-#[derive(Debug)]
-pub(crate) enum IpVersionAddrIter {
-    /// the next ip addr without the network prefix, as u32
-    V4(u32),
-    /// the next ip addr without the network prefix, as u128
-    V6(u128),
-}
-
-impl Default for IpVersionAddrIter {
-    fn default() -> Self {
-        Self::V4(1)
+impl Ipv4Network {
+    /// A new instance of `Ipv4Network`.
+    ///
+    /// The provided prefix is truncated according to the
+    /// prefixlen.
+    ///
+    /// # Panics
+    ///
+    /// This function panic if the prefixlen exceeds 32.
+    pub fn new(prefix: Ipv4Addr, prefixlen: usize) -> Ipv4Network {
+        assert!(
+            prefixlen <= 32,
+            "prefix lengths greater than 32 are not possible in Ipv4 networks"
+        );
+        let mask = Ipv4Addr::from(!(u32::MAX >> prefixlen));
+        let prefix = Ipv4Addr::from(u32::from(prefix) & u32::from(mask));
+        Ipv4Network { prefix, mask }
     }
 }
 
-impl IpVersionAddrIter {
+impl Ipv6Network {
+    /// A new instance of `Ipv6Network`.
+    ///
+    /// The provided prefix is truncated according to the
+    /// prefixlen.
+    ///
+    /// # Panics
+    ///
+    /// This function panic if the prefixlen exceeds 128.
+    pub fn new(prefix: Ipv6Addr, prefixlen: usize) -> Ipv6Network {
+        assert!(
+            prefixlen <= 128,
+            "prefix lengths greater than 128 are not possible in Ipv6 networks"
+        );
+        let mask = Ipv6Addr::from(!(u128::MAX >> prefixlen));
+        let prefix = Ipv6Addr::from(u128::from(prefix) & u128::from(mask));
+        Ipv6Network { prefix, mask }
+    }
+}
+
+impl Default for IpNetwork {
+    fn default() -> Self {
+        IpNetwork::V4(Ipv4Network::default())
+    }
+}
+
+impl Default for Ipv4Network {
+    fn default() -> Self {
+        Ipv4Network::new(Ipv4Addr::new(192, 168, 0, 0), 16)
+    }
+}
+
+impl Default for Ipv6Network {
+    fn default() -> Self {
+        Ipv6Network::new(
+            Ipv6Addr::from(0xfe80_0000_0000_0000_0000_0000_0000_0000),
+            64,
+        )
+    }
+}
+
+impl From<Ipv4Network> for IpNetwork {
+    fn from(value: Ipv4Network) -> Self {
+        IpNetwork::V4(value)
+    }
+}
+
+impl From<Ipv6Network> for IpNetwork {
+    fn from(value: Ipv6Network) -> Self {
+        IpNetwork::V6(value)
+    }
+}
+
+pub(crate) enum IpNetworkIter {
+    V4(Ipv4Network, u32),
+    V6(Ipv6Network, u128),
+}
+
+impl IpNetworkIter {
     pub(crate) fn next(&mut self) -> IpAddr {
         match self {
-            Self::V4(next) => {
+            Self::V4(net, next) => {
                 let host = *next;
                 *next = next.wrapping_add(1);
 
-                let a = (host >> 8) as u8;
-                let b = (host & 0xFF) as u8;
-
-                IpAddr::V4(Ipv4Addr::new(192, 168, a, b))
+                let host_masked = host & !u32::from(net.mask);
+                IpAddr::V4(Ipv4Addr::from(u32::from(net.prefix) | host_masked))
             }
-            Self::V6(next) => {
+            Self::V6(net, next) => {
                 let host = *next;
                 *next = next.wrapping_add(1);
 
-                let a = ((host >> 48) & 0xffff) as u16;
-                let b = ((host >> 32) & 0xffff) as u16;
-                let c = ((host >> 16) & 0xffff) as u16;
-                let d = (host & 0xffff) as u16;
-
-                IpAddr::V6(Ipv6Addr::new(0xfe80, 0, 0, 0, a, b, c, d))
+                let host_masked = host & !u128::from(net.mask);
+                IpAddr::V6(Ipv6Addr::from(u128::from(net.prefix) | host_masked))
             }
         }
     }
@@ -62,11 +134,12 @@ impl IpVersionAddrIter {
 
 #[cfg(test)]
 mod tests {
-    use crate::{lookup, Builder, IpVersion, Result};
+    use super::Ipv6Network;
+    use crate::{lookup, Builder, Ipv4Network, Result};
     use std::net::{IpAddr, Ipv4Addr, Ipv6Addr};
 
     #[test]
-    fn ip_version_v4() -> Result {
+    fn default_ipv4() -> Result {
         let mut sim = Builder::new().build();
         sim.client("client", async move {
             assert_eq!(lookup("client"), IpAddr::V4(Ipv4Addr::new(192, 168, 0, 1)));
@@ -88,8 +161,8 @@ mod tests {
     }
 
     #[test]
-    fn ip_version_v6() -> Result {
-        let mut sim = Builder::new().ip_version(IpVersion::V6).build();
+    fn default_ipv6() -> Result {
+        let mut sim = Builder::new().ip_network(Ipv6Network::default()).build();
         sim.client("client", async move {
             assert_eq!(
                 lookup("client"),
@@ -111,6 +184,53 @@ mod tests {
             sim.lookup("server"),
             IpAddr::V6(Ipv6Addr::new(0xfe80, 0, 0, 0, 0, 0, 0, 2))
         );
+
+        sim.run()
+    }
+
+    #[test]
+    fn custom_ipv4() -> Result {
+        let mut sim = Builder::new()
+            .ip_network(Ipv4Network::new(Ipv4Addr::new(10, 1, 3, 0), 24))
+            .build();
+
+        sim.client("a", async move {
+            assert_eq!(lookup("a"), Ipv4Addr::new(10, 1, 3, 1));
+            Ok(())
+        });
+        sim.client("b", async move {
+            assert_eq!(lookup("b"), Ipv4Addr::new(10, 1, 3, 2));
+            Ok(())
+        });
+        sim.client("c", async move {
+            assert_eq!(lookup("c"), Ipv4Addr::new(10, 1, 3, 3));
+            Ok(())
+        });
+
+        sim.run()
+    }
+
+    #[test]
+    fn custom_ipv6() -> Result {
+        let mut sim = Builder::new()
+            .ip_network(Ipv6Network::new(
+                Ipv6Addr::new(0x2001, 0, 0, 0, 0, 0, 0, 0),
+                64,
+            ))
+            .build();
+
+        sim.client("a", async move {
+            assert_eq!(lookup("a"), Ipv6Addr::new(0x2001, 0, 0, 0, 0, 0, 0, 1));
+            Ok(())
+        });
+        sim.client("b", async move {
+            assert_eq!(lookup("b"), Ipv6Addr::new(0x2001, 0, 0, 0, 0, 0, 0, 2));
+            Ok(())
+        });
+        sim.client("c", async move {
+            assert_eq!(lookup("c"), Ipv6Addr::new(0x2001, 0, 0, 0, 0, 0, 0, 3));
+            Ok(())
+        });
 
         sim.run()
     }

--- a/src/ip.rs
+++ b/src/ip.rs
@@ -181,7 +181,7 @@ mod tests {
 
     #[test]
     fn default_ipv6() -> Result {
-        let mut sim = Builder::new().ip_network(Ipv6Subnet::default()).build();
+        let mut sim = Builder::new().ip_subnet(Ipv6Subnet::default()).build();
         sim.client("client", async move {
             assert_eq!(
                 lookup("client"),
@@ -210,7 +210,7 @@ mod tests {
     #[test]
     fn custom_ipv4() -> Result {
         let mut sim = Builder::new()
-            .ip_network(Ipv4Subnet::new(Ipv4Addr::new(10, 1, 3, 0), 24))
+            .ip_subnet(Ipv4Subnet::new(Ipv4Addr::new(10, 1, 3, 0), 24))
             .build();
 
         sim.client("a", async move {
@@ -232,7 +232,7 @@ mod tests {
     #[test]
     fn custom_ipv6() -> Result {
         let mut sim = Builder::new()
-            .ip_network(Ipv6Subnet::new(
+            .ip_subnet(Ipv6Subnet::new(
                 Ipv6Addr::new(0x2001, 0, 0, 0, 0, 0, 0, 0),
                 64,
             ))
@@ -258,7 +258,7 @@ mod tests {
     #[should_panic = "node address is not contained within the available subnet"]
     fn subnet_denies_invalid_addr_v4() {
         let mut sim = Builder::new()
-            .ip_network(Ipv4Subnet::new(Ipv4Addr::new(1, 2, 3, 4), 16))
+            .ip_subnet(Ipv4Subnet::new(Ipv4Addr::new(1, 2, 3, 4), 16))
             .build();
 
         sim.client("30.0.0.0", async move { Ok(()) });
@@ -269,7 +269,7 @@ mod tests {
     #[should_panic = "node address is not contained within the available subnet"]
     fn subnet_denies_invalid_addr_v6() {
         let mut sim = Builder::new()
-            .ip_network(Ipv6Subnet::new(
+            .ip_subnet(Ipv6Subnet::new(
                 Ipv6Addr::new(0xfc00, 0, 0, 0, 0, 0, 0, 0),
                 64,
             ))

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -105,7 +105,7 @@ pub use host::elapsed;
 use host::Host;
 
 mod ip;
-pub use ip::{IpNetwork, Ipv4Network, Ipv6Network};
+pub use ip::{IpSubnet, Ipv4Subnet, Ipv6Subnet};
 
 pub mod net;
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -105,7 +105,7 @@ pub use host::elapsed;
 use host::Host;
 
 mod ip;
-pub use ip::IpVersion;
+pub use ip::{IpNetwork, Ipv4Network, Ipv6Network};
 
 pub mod net;
 

--- a/src/world.rs
+++ b/src/world.rs
@@ -1,6 +1,6 @@
 use crate::config::Config;
 use crate::envelope::Protocol;
-use crate::ip::IpVersionAddrIter;
+use crate::ip::IpNetworkIter;
 use crate::{config, Dns, Host, ToIpAddr, ToIpAddrs, Topology, TRACING_TARGET};
 
 use indexmap::IndexMap;
@@ -33,11 +33,7 @@ scoped_thread_local!(static CURRENT: RefCell<World>);
 
 impl World {
     /// Initialize a new world.
-    pub(crate) fn new(
-        link: config::Link,
-        rng: Box<dyn RngCore>,
-        addrs: IpVersionAddrIter,
-    ) -> World {
+    pub(crate) fn new(link: config::Link, rng: Box<dyn RngCore>, addrs: IpNetworkIter) -> World {
         World {
             hosts: IndexMap::new(),
             topology: Topology::new(link),

--- a/src/world.rs
+++ b/src/world.rs
@@ -1,6 +1,6 @@
 use crate::config::Config;
 use crate::envelope::Protocol;
-use crate::{config, Dns, Host, IpNetwork, ToIpAddr, ToIpAddrs, Topology, TRACING_TARGET};
+use crate::{config, Dns, Host, IpSubnet, ToIpAddr, ToIpAddrs, Topology, TRACING_TARGET};
 
 use indexmap::IndexMap;
 use rand::RngCore;
@@ -12,7 +12,7 @@ use std::time::Duration;
 /// Tracks all the state for the simulated world.
 pub(crate) struct World {
     /// Defines the available address range of the simulation.
-    pub(crate) ip_net: IpNetwork,
+    pub(crate) subnet: IpSubnet,
 
     /// Tracks all individual hosts
     pub(crate) hosts: IndexMap<IpAddr, Host>,
@@ -35,9 +35,9 @@ scoped_thread_local!(static CURRENT: RefCell<World>);
 
 impl World {
     /// Initialize a new world.
-    pub(crate) fn new(link: config::Link, rng: Box<dyn RngCore>, ip_net: IpNetwork) -> World {
+    pub(crate) fn new(link: config::Link, rng: Box<dyn RngCore>, ip_net: IpSubnet) -> World {
         World {
-            ip_net,
+            subnet: ip_net,
             hosts: IndexMap::new(),
             topology: Topology::new(link),
             dns: Dns::new(ip_net.iter()),
@@ -104,7 +104,7 @@ impl World {
             "already registered host for the given ip address"
         );
         assert!(
-            self.ip_net.contains(addr),
+            self.subnet.contains(addr),
             "node address is not contained within the available subnet"
         );
 

--- a/tests/tcp.rs
+++ b/tests/tcp.rs
@@ -13,7 +13,7 @@ use tokio::{
 };
 use turmoil::{
     net::{TcpListener, TcpStream},
-    Builder, IpNetwork, Ipv4Network, Ipv6Network, Result,
+    Builder, IpSubnet, Ipv4Subnet, Ipv6Subnet, Result,
 };
 
 const PORT: u16 = 1738;
@@ -686,7 +686,7 @@ fn split() -> Result {
 
 #[test]
 fn bind_ipv4_socket() -> Result {
-    let mut sim = Builder::new().ip_network(Ipv4Network::default()).build();
+    let mut sim = Builder::new().ip_network(Ipv4Subnet::default()).build();
     sim.client("client", async move {
         let sock = bind_to_v4(0).await?;
         assert!(sock.local_addr().unwrap().is_ipv4());
@@ -697,7 +697,7 @@ fn bind_ipv4_socket() -> Result {
 
 #[test]
 fn bind_ipv6_socket() -> Result {
-    let mut sim = Builder::new().ip_network(Ipv6Network::default()).build();
+    let mut sim = Builder::new().ip_network(Ipv6Subnet::default()).build();
     sim.client("client", async move {
         let sock = bind_to_v6(0).await?;
         assert!(sock.local_addr().unwrap().is_ipv6());
@@ -709,7 +709,7 @@ fn bind_ipv6_socket() -> Result {
 #[test]
 #[should_panic]
 fn bind_ipv4_version_missmatch() {
-    let mut sim = Builder::new().ip_network(Ipv6Network::default()).build();
+    let mut sim = Builder::new().ip_network(Ipv6Subnet::default()).build();
     sim.client("client", async move {
         let _sock = bind_to_v4(0).await?;
         Ok(())
@@ -720,7 +720,7 @@ fn bind_ipv4_version_missmatch() {
 #[test]
 #[should_panic]
 fn bind_ipv6_version_missmatch() {
-    let mut sim = Builder::new().ip_network(Ipv4Network::default()).build();
+    let mut sim = Builder::new().ip_network(Ipv4Subnet::default()).build();
     sim.client("client", async move {
         let _sock = bind_to_v6(0).await?;
         Ok(())
@@ -730,7 +730,7 @@ fn bind_ipv6_version_missmatch() {
 
 #[test]
 fn ipv6_connectivity() -> Result {
-    let mut sim = Builder::new().ip_network(Ipv6Network::default()).build();
+    let mut sim = Builder::new().ip_network(Ipv6Subnet::default()).build();
     sim.client("server", async move {
         let list = TcpListener::bind(("::", 80)).await.unwrap();
         let _stream = list.accept().await.unwrap();
@@ -770,7 +770,7 @@ fn bind_addr_in_use() -> Result {
 }
 
 fn run_localhost_test(
-    ip_version: IpNetwork,
+    ip_version: IpSubnet,
     bind_addr: SocketAddr,
     connect_addr: SocketAddr,
 ) -> Result {
@@ -805,28 +805,28 @@ fn run_localhost_test(
 fn loopback_to_wildcard_v4() -> Result {
     let bind_addr = SocketAddr::new(Ipv4Addr::UNSPECIFIED.into(), 1234);
     let connect_addr = SocketAddr::from((Ipv4Addr::LOCALHOST, 1234));
-    run_localhost_test(Ipv4Network::default().into(), bind_addr, connect_addr)
+    run_localhost_test(Ipv4Subnet::default().into(), bind_addr, connect_addr)
 }
 
 #[test]
 fn loopback_to_localhost_v4() -> Result {
     let bind_addr = SocketAddr::new(Ipv4Addr::LOCALHOST.into(), 1234);
     let connect_addr = SocketAddr::from((Ipv4Addr::LOCALHOST, 1234));
-    run_localhost_test(Ipv4Network::default().into(), bind_addr, connect_addr)
+    run_localhost_test(Ipv4Subnet::default().into(), bind_addr, connect_addr)
 }
 
 #[test]
 fn loopback_to_wildcard_v6() -> Result {
     let bind_addr = SocketAddr::new(Ipv6Addr::UNSPECIFIED.into(), 1234);
     let connect_addr = SocketAddr::from((Ipv6Addr::LOCALHOST, 1234));
-    run_localhost_test(Ipv6Network::default().into(), bind_addr, connect_addr)
+    run_localhost_test(Ipv6Subnet::default().into(), bind_addr, connect_addr)
 }
 
 #[test]
 fn loopback_to_localhost_v6() -> Result {
     let bind_addr = SocketAddr::new(Ipv6Addr::LOCALHOST.into(), 1234);
     let connect_addr = SocketAddr::from((Ipv6Addr::LOCALHOST, 1234));
-    run_localhost_test(Ipv6Network::default().into(), bind_addr, connect_addr)
+    run_localhost_test(Ipv6Subnet::default().into(), bind_addr, connect_addr)
 }
 
 #[test]

--- a/tests/tcp.rs
+++ b/tests/tcp.rs
@@ -13,7 +13,7 @@ use tokio::{
 };
 use turmoil::{
     net::{TcpListener, TcpStream},
-    Builder, IpVersion, Result,
+    Builder, IpNetwork, Ipv4Network, Ipv6Network, Result,
 };
 
 const PORT: u16 = 1738;
@@ -686,7 +686,7 @@ fn split() -> Result {
 
 #[test]
 fn bind_ipv4_socket() -> Result {
-    let mut sim = Builder::new().ip_version(IpVersion::V4).build();
+    let mut sim = Builder::new().ip_network(Ipv4Network::default()).build();
     sim.client("client", async move {
         let sock = bind_to_v4(0).await?;
         assert!(sock.local_addr().unwrap().is_ipv4());
@@ -697,7 +697,7 @@ fn bind_ipv4_socket() -> Result {
 
 #[test]
 fn bind_ipv6_socket() -> Result {
-    let mut sim = Builder::new().ip_version(IpVersion::V6).build();
+    let mut sim = Builder::new().ip_network(Ipv6Network::default()).build();
     sim.client("client", async move {
         let sock = bind_to_v6(0).await?;
         assert!(sock.local_addr().unwrap().is_ipv6());
@@ -709,7 +709,7 @@ fn bind_ipv6_socket() -> Result {
 #[test]
 #[should_panic]
 fn bind_ipv4_version_missmatch() {
-    let mut sim = Builder::new().ip_version(IpVersion::V6).build();
+    let mut sim = Builder::new().ip_network(Ipv6Network::default()).build();
     sim.client("client", async move {
         let _sock = bind_to_v4(0).await?;
         Ok(())
@@ -720,7 +720,7 @@ fn bind_ipv4_version_missmatch() {
 #[test]
 #[should_panic]
 fn bind_ipv6_version_missmatch() {
-    let mut sim = Builder::new().ip_version(IpVersion::V4).build();
+    let mut sim = Builder::new().ip_network(Ipv4Network::default()).build();
     sim.client("client", async move {
         let _sock = bind_to_v6(0).await?;
         Ok(())
@@ -730,7 +730,7 @@ fn bind_ipv6_version_missmatch() {
 
 #[test]
 fn ipv6_connectivity() -> Result {
-    let mut sim = Builder::new().ip_version(IpVersion::V6).build();
+    let mut sim = Builder::new().ip_network(Ipv6Network::default()).build();
     sim.client("server", async move {
         let list = TcpListener::bind(("::", 80)).await.unwrap();
         let _stream = list.accept().await.unwrap();
@@ -770,11 +770,11 @@ fn bind_addr_in_use() -> Result {
 }
 
 fn run_localhost_test(
-    ip_version: IpVersion,
+    ip_version: IpNetwork,
     bind_addr: SocketAddr,
     connect_addr: SocketAddr,
 ) -> Result {
-    let mut sim = Builder::new().ip_version(ip_version).build();
+    let mut sim = Builder::new().ip_network(ip_version).build();
     let expected = [0, 1, 7, 3, 8];
     sim.client("client", async move {
         let listener = TcpListener::bind(bind_addr).await?;
@@ -805,28 +805,28 @@ fn run_localhost_test(
 fn loopback_to_wildcard_v4() -> Result {
     let bind_addr = SocketAddr::new(Ipv4Addr::UNSPECIFIED.into(), 1234);
     let connect_addr = SocketAddr::from((Ipv4Addr::LOCALHOST, 1234));
-    run_localhost_test(IpVersion::V4, bind_addr, connect_addr)
+    run_localhost_test(Ipv4Network::default().into(), bind_addr, connect_addr)
 }
 
 #[test]
 fn loopback_to_localhost_v4() -> Result {
     let bind_addr = SocketAddr::new(Ipv4Addr::LOCALHOST.into(), 1234);
     let connect_addr = SocketAddr::from((Ipv4Addr::LOCALHOST, 1234));
-    run_localhost_test(IpVersion::V4, bind_addr, connect_addr)
+    run_localhost_test(Ipv4Network::default().into(), bind_addr, connect_addr)
 }
 
 #[test]
 fn loopback_to_wildcard_v6() -> Result {
     let bind_addr = SocketAddr::new(Ipv6Addr::UNSPECIFIED.into(), 1234);
     let connect_addr = SocketAddr::from((Ipv6Addr::LOCALHOST, 1234));
-    run_localhost_test(IpVersion::V6, bind_addr, connect_addr)
+    run_localhost_test(Ipv6Network::default().into(), bind_addr, connect_addr)
 }
 
 #[test]
 fn loopback_to_localhost_v6() -> Result {
     let bind_addr = SocketAddr::new(Ipv6Addr::LOCALHOST.into(), 1234);
     let connect_addr = SocketAddr::from((Ipv6Addr::LOCALHOST, 1234));
-    run_localhost_test(IpVersion::V6, bind_addr, connect_addr)
+    run_localhost_test(Ipv6Network::default().into(), bind_addr, connect_addr)
 }
 
 #[test]

--- a/tests/tcp.rs
+++ b/tests/tcp.rs
@@ -686,7 +686,7 @@ fn split() -> Result {
 
 #[test]
 fn bind_ipv4_socket() -> Result {
-    let mut sim = Builder::new().ip_network(Ipv4Subnet::default()).build();
+    let mut sim = Builder::new().ip_subnet(Ipv4Subnet::default()).build();
     sim.client("client", async move {
         let sock = bind_to_v4(0).await?;
         assert!(sock.local_addr().unwrap().is_ipv4());
@@ -697,7 +697,7 @@ fn bind_ipv4_socket() -> Result {
 
 #[test]
 fn bind_ipv6_socket() -> Result {
-    let mut sim = Builder::new().ip_network(Ipv6Subnet::default()).build();
+    let mut sim = Builder::new().ip_subnet(Ipv6Subnet::default()).build();
     sim.client("client", async move {
         let sock = bind_to_v6(0).await?;
         assert!(sock.local_addr().unwrap().is_ipv6());
@@ -709,7 +709,7 @@ fn bind_ipv6_socket() -> Result {
 #[test]
 #[should_panic]
 fn bind_ipv4_version_missmatch() {
-    let mut sim = Builder::new().ip_network(Ipv6Subnet::default()).build();
+    let mut sim = Builder::new().ip_subnet(Ipv6Subnet::default()).build();
     sim.client("client", async move {
         let _sock = bind_to_v4(0).await?;
         Ok(())
@@ -720,7 +720,7 @@ fn bind_ipv4_version_missmatch() {
 #[test]
 #[should_panic]
 fn bind_ipv6_version_missmatch() {
-    let mut sim = Builder::new().ip_network(Ipv4Subnet::default()).build();
+    let mut sim = Builder::new().ip_subnet(Ipv4Subnet::default()).build();
     sim.client("client", async move {
         let _sock = bind_to_v6(0).await?;
         Ok(())
@@ -730,7 +730,7 @@ fn bind_ipv6_version_missmatch() {
 
 #[test]
 fn ipv6_connectivity() -> Result {
-    let mut sim = Builder::new().ip_network(Ipv6Subnet::default()).build();
+    let mut sim = Builder::new().ip_subnet(Ipv6Subnet::default()).build();
     sim.client("server", async move {
         let list = TcpListener::bind(("::", 80)).await.unwrap();
         let _stream = list.accept().await.unwrap();
@@ -774,7 +774,7 @@ fn run_localhost_test(
     bind_addr: SocketAddr,
     connect_addr: SocketAddr,
 ) -> Result {
-    let mut sim = Builder::new().ip_network(ip_version).build();
+    let mut sim = Builder::new().ip_subnet(ip_version).build();
     let expected = [0, 1, 7, 3, 8];
     sim.client("client", async move {
         let listener = TcpListener::bind(bind_addr).await?;

--- a/tests/udp.rs
+++ b/tests/udp.rs
@@ -11,7 +11,7 @@ use tokio::{sync::oneshot, time::timeout};
 use turmoil::{
     lookup,
     net::{self, UdpSocket},
-    Builder, IpNetwork, Ipv4Network, Ipv6Network, Result,
+    Builder, IpSubnet, Ipv4Subnet, Ipv6Subnet, Result,
 };
 
 const PORT: u16 = 1738;
@@ -358,7 +358,7 @@ fn bulk_transfer() -> Result {
 
 #[test]
 fn bind_ipv4_socket() -> Result {
-    let mut sim = Builder::new().ip_network(Ipv4Network::default()).build();
+    let mut sim = Builder::new().ip_network(Ipv4Subnet::default()).build();
     sim.client("client", async move {
         let sock = bind_to_v4(0).await?;
         assert!(sock.local_addr().unwrap().is_ipv4());
@@ -369,7 +369,7 @@ fn bind_ipv4_socket() -> Result {
 
 #[test]
 fn bind_ipv6_socket() -> Result {
-    let mut sim = Builder::new().ip_network(Ipv6Network::default()).build();
+    let mut sim = Builder::new().ip_network(Ipv6Subnet::default()).build();
     sim.client("client", async move {
         let sock = bind_to_v6(0).await?;
         assert!(sock.local_addr().unwrap().is_ipv6());
@@ -381,7 +381,7 @@ fn bind_ipv6_socket() -> Result {
 #[test]
 #[should_panic]
 fn bind_ipv4_version_missmatch() {
-    let mut sim = Builder::new().ip_network(Ipv6Network::default()).build();
+    let mut sim = Builder::new().ip_network(Ipv6Subnet::default()).build();
     sim.client("client", async move {
         let _sock = bind_to_v4(0).await?;
         Ok(())
@@ -392,7 +392,7 @@ fn bind_ipv4_version_missmatch() {
 #[test]
 #[should_panic]
 fn bind_ipv6_version_missmatch() {
-    let mut sim = Builder::new().ip_network(Ipv4Network::default()).build();
+    let mut sim = Builder::new().ip_network(Ipv4Subnet::default()).build();
     sim.client("client", async move {
         let _sock = bind_to_v6(0).await?;
         Ok(())
@@ -402,7 +402,7 @@ fn bind_ipv6_version_missmatch() {
 
 #[test]
 fn ipv6_connectivity() -> Result {
-    let mut sim = Builder::new().ip_network(Ipv6Network::default()).build();
+    let mut sim = Builder::new().ip_network(Ipv6Subnet::default()).build();
     sim.client("server", async move {
         let sock = UdpSocket::bind(":::80").await.unwrap();
         let mut buf = [0; 512];
@@ -445,7 +445,7 @@ fn bind_addr_in_use() -> Result {
 }
 
 fn run_localhost_test(
-    ip_version: IpNetwork,
+    ip_version: IpSubnet,
     bind_addr: SocketAddr,
     connect_addr: SocketAddr,
 ) -> Result {
@@ -483,28 +483,28 @@ fn run_localhost_test(
 fn loopback_to_wildcard_v4() -> Result {
     let bind_addr = SocketAddr::new(Ipv4Addr::UNSPECIFIED.into(), 1234);
     let connect_addr = SocketAddr::from((Ipv4Addr::LOCALHOST, 1234));
-    run_localhost_test(Ipv4Network::default().into(), bind_addr, connect_addr)
+    run_localhost_test(Ipv4Subnet::default().into(), bind_addr, connect_addr)
 }
 
 #[test]
 fn loopback_to_localhost_v4() -> Result {
     let bind_addr = SocketAddr::new(Ipv4Addr::LOCALHOST.into(), 1234);
     let connect_addr = SocketAddr::from((Ipv4Addr::LOCALHOST, 1234));
-    run_localhost_test(Ipv4Network::default().into(), bind_addr, connect_addr)
+    run_localhost_test(Ipv4Subnet::default().into(), bind_addr, connect_addr)
 }
 
 #[test]
 fn loopback_to_wildcard_v6() -> Result {
     let bind_addr = SocketAddr::new(Ipv6Addr::UNSPECIFIED.into(), 1234);
     let connect_addr = SocketAddr::from((Ipv6Addr::LOCALHOST, 1234));
-    run_localhost_test(Ipv6Network::default().into(), bind_addr, connect_addr)
+    run_localhost_test(Ipv6Subnet::default().into(), bind_addr, connect_addr)
 }
 
 #[test]
 fn loopback_to_localhost_v6() -> Result {
     let bind_addr = SocketAddr::new(Ipv6Addr::LOCALHOST.into(), 1234);
     let connect_addr = SocketAddr::from((Ipv6Addr::LOCALHOST, 1234));
-    run_localhost_test(Ipv6Network::default().into(), bind_addr, connect_addr)
+    run_localhost_test(Ipv6Subnet::default().into(), bind_addr, connect_addr)
 }
 
 #[test]

--- a/tests/udp.rs
+++ b/tests/udp.rs
@@ -358,7 +358,7 @@ fn bulk_transfer() -> Result {
 
 #[test]
 fn bind_ipv4_socket() -> Result {
-    let mut sim = Builder::new().ip_network(Ipv4Subnet::default()).build();
+    let mut sim = Builder::new().ip_subnet(Ipv4Subnet::default()).build();
     sim.client("client", async move {
         let sock = bind_to_v4(0).await?;
         assert!(sock.local_addr().unwrap().is_ipv4());
@@ -369,7 +369,7 @@ fn bind_ipv4_socket() -> Result {
 
 #[test]
 fn bind_ipv6_socket() -> Result {
-    let mut sim = Builder::new().ip_network(Ipv6Subnet::default()).build();
+    let mut sim = Builder::new().ip_subnet(Ipv6Subnet::default()).build();
     sim.client("client", async move {
         let sock = bind_to_v6(0).await?;
         assert!(sock.local_addr().unwrap().is_ipv6());
@@ -381,7 +381,7 @@ fn bind_ipv6_socket() -> Result {
 #[test]
 #[should_panic]
 fn bind_ipv4_version_missmatch() {
-    let mut sim = Builder::new().ip_network(Ipv6Subnet::default()).build();
+    let mut sim = Builder::new().ip_subnet(Ipv6Subnet::default()).build();
     sim.client("client", async move {
         let _sock = bind_to_v4(0).await?;
         Ok(())
@@ -392,7 +392,7 @@ fn bind_ipv4_version_missmatch() {
 #[test]
 #[should_panic]
 fn bind_ipv6_version_missmatch() {
-    let mut sim = Builder::new().ip_network(Ipv4Subnet::default()).build();
+    let mut sim = Builder::new().ip_subnet(Ipv4Subnet::default()).build();
     sim.client("client", async move {
         let _sock = bind_to_v6(0).await?;
         Ok(())
@@ -402,7 +402,7 @@ fn bind_ipv6_version_missmatch() {
 
 #[test]
 fn ipv6_connectivity() -> Result {
-    let mut sim = Builder::new().ip_network(Ipv6Subnet::default()).build();
+    let mut sim = Builder::new().ip_subnet(Ipv6Subnet::default()).build();
     sim.client("server", async move {
         let sock = UdpSocket::bind(":::80").await.unwrap();
         let mut buf = [0; 512];
@@ -449,7 +449,7 @@ fn run_localhost_test(
     bind_addr: SocketAddr,
     connect_addr: SocketAddr,
 ) -> Result {
-    let mut sim = Builder::new().ip_network(ip_version).build();
+    let mut sim = Builder::new().ip_subnet(ip_version).build();
     let expected = [0, 1, 7, 3, 8];
     sim.client("client", async move {
         let socket = UdpSocket::bind(bind_addr).await?;

--- a/tests/udp.rs
+++ b/tests/udp.rs
@@ -11,7 +11,7 @@ use tokio::{sync::oneshot, time::timeout};
 use turmoil::{
     lookup,
     net::{self, UdpSocket},
-    Builder, IpVersion, Result,
+    Builder, IpNetwork, Ipv4Network, Ipv6Network, Result,
 };
 
 const PORT: u16 = 1738;
@@ -358,7 +358,7 @@ fn bulk_transfer() -> Result {
 
 #[test]
 fn bind_ipv4_socket() -> Result {
-    let mut sim = Builder::new().ip_version(IpVersion::V4).build();
+    let mut sim = Builder::new().ip_network(Ipv4Network::default()).build();
     sim.client("client", async move {
         let sock = bind_to_v4(0).await?;
         assert!(sock.local_addr().unwrap().is_ipv4());
@@ -369,7 +369,7 @@ fn bind_ipv4_socket() -> Result {
 
 #[test]
 fn bind_ipv6_socket() -> Result {
-    let mut sim = Builder::new().ip_version(IpVersion::V6).build();
+    let mut sim = Builder::new().ip_network(Ipv6Network::default()).build();
     sim.client("client", async move {
         let sock = bind_to_v6(0).await?;
         assert!(sock.local_addr().unwrap().is_ipv6());
@@ -381,7 +381,7 @@ fn bind_ipv6_socket() -> Result {
 #[test]
 #[should_panic]
 fn bind_ipv4_version_missmatch() {
-    let mut sim = Builder::new().ip_version(IpVersion::V6).build();
+    let mut sim = Builder::new().ip_network(Ipv6Network::default()).build();
     sim.client("client", async move {
         let _sock = bind_to_v4(0).await?;
         Ok(())
@@ -392,7 +392,7 @@ fn bind_ipv4_version_missmatch() {
 #[test]
 #[should_panic]
 fn bind_ipv6_version_missmatch() {
-    let mut sim = Builder::new().ip_version(IpVersion::V4).build();
+    let mut sim = Builder::new().ip_network(Ipv4Network::default()).build();
     sim.client("client", async move {
         let _sock = bind_to_v6(0).await?;
         Ok(())
@@ -402,7 +402,7 @@ fn bind_ipv6_version_missmatch() {
 
 #[test]
 fn ipv6_connectivity() -> Result {
-    let mut sim = Builder::new().ip_version(IpVersion::V6).build();
+    let mut sim = Builder::new().ip_network(Ipv6Network::default()).build();
     sim.client("server", async move {
         let sock = UdpSocket::bind(":::80").await.unwrap();
         let mut buf = [0; 512];
@@ -445,11 +445,11 @@ fn bind_addr_in_use() -> Result {
 }
 
 fn run_localhost_test(
-    ip_version: IpVersion,
+    ip_version: IpNetwork,
     bind_addr: SocketAddr,
     connect_addr: SocketAddr,
 ) -> Result {
-    let mut sim = Builder::new().ip_version(ip_version).build();
+    let mut sim = Builder::new().ip_network(ip_version).build();
     let expected = [0, 1, 7, 3, 8];
     sim.client("client", async move {
         let socket = UdpSocket::bind(bind_addr).await?;
@@ -483,28 +483,28 @@ fn run_localhost_test(
 fn loopback_to_wildcard_v4() -> Result {
     let bind_addr = SocketAddr::new(Ipv4Addr::UNSPECIFIED.into(), 1234);
     let connect_addr = SocketAddr::from((Ipv4Addr::LOCALHOST, 1234));
-    run_localhost_test(IpVersion::V4, bind_addr, connect_addr)
+    run_localhost_test(Ipv4Network::default().into(), bind_addr, connect_addr)
 }
 
 #[test]
 fn loopback_to_localhost_v4() -> Result {
     let bind_addr = SocketAddr::new(Ipv4Addr::LOCALHOST.into(), 1234);
     let connect_addr = SocketAddr::from((Ipv4Addr::LOCALHOST, 1234));
-    run_localhost_test(IpVersion::V4, bind_addr, connect_addr)
+    run_localhost_test(Ipv4Network::default().into(), bind_addr, connect_addr)
 }
 
 #[test]
 fn loopback_to_wildcard_v6() -> Result {
     let bind_addr = SocketAddr::new(Ipv6Addr::UNSPECIFIED.into(), 1234);
     let connect_addr = SocketAddr::from((Ipv6Addr::LOCALHOST, 1234));
-    run_localhost_test(IpVersion::V6, bind_addr, connect_addr)
+    run_localhost_test(Ipv6Network::default().into(), bind_addr, connect_addr)
 }
 
 #[test]
 fn loopback_to_localhost_v6() -> Result {
     let bind_addr = SocketAddr::new(Ipv6Addr::LOCALHOST.into(), 1234);
     let connect_addr = SocketAddr::from((Ipv6Addr::LOCALHOST, 1234));
-    run_localhost_test(IpVersion::V6, bind_addr, connect_addr)
+    run_localhost_test(Ipv6Network::default().into(), bind_addr, connect_addr)
 }
 
 #[test]


### PR DESCRIPTION
This PR adds support for custom IP networks instead of just `192.168.0.0/16` or `fe80::/64`.
Applications may behave differently, based on the bound IP addresses, especially with Ipv6 addresses.
`fe80::` link-local-addresses may be treated differently than `ffc0::` unicast-local or `200x::` unicast-global
in some applications.

Therefore the parameter `IpVersion` (renamed to `IpNetwork`) was extended to support custom subnets
as a parameter. Default cfg remains `Ipv4 192.168.0.0./16`.

Changes:
- `IpVersion` renamed to `IpNetwork`
- added enum variants `V4(Ipv4Network)` and `V6(Ipv6Network)`
- `Builder::ip_version` renamed to `Builder::ip_network`
- address iterator changed to reflect new parameters 

Open Questions:
- If a node is created with a static address aka. not using the address iterator, should the address be checked, to guarantee, it's in the specified subnet? Or should all addresses be allowed?
- A globally available function that returns the nodes IpAddress may be useful, to retrieve the nodes identity, even deep in application code. Opinions?