### PR TITLE
Add message duplication for udp

### DIFF
--- a/src/builder.rs
+++ b/src/builder.rs
@@ -29,6 +29,7 @@ impl Builder {
             link: config::Link {
                 latency: Some(config::Latency::default()),
                 message_loss: Some(config::MessageLoss::default()),
+                message_duplication: Some(config::MessageDupliaction::default()),
             },
         }
     }

--- a/src/config.rs
+++ b/src/config.rs
@@ -27,6 +27,9 @@ pub(crate) struct Link {
 
     /// How often sending a message works vs. the message getting dropped
     pub(crate) message_loss: Option<MessageLoss>,
+
+    /// How often a sent message is duplicated. Only applies to UDP.
+    pub(crate) message_duplication: Option<MessageDupliaction>,
 }
 
 /// Configure latency behavior between two hosts.
@@ -50,6 +53,13 @@ pub(crate) struct MessageLoss {
 
     /// Probability of a failed link returning
     pub(crate) repair_rate: f64,
+}
+
+/// Configure how often messages are duplicated
+#[derive(Clone)]
+pub(crate) struct MessageDupliaction {
+    /// Probability of a link duplicating messages. Only applies to UDP.
+    pub(crate) duplication_rate: f64,
 }
 
 impl Default for Config {
@@ -80,6 +90,18 @@ impl Link {
     pub(crate) fn message_loss_mut(&mut self) -> &mut MessageLoss {
         self.message_loss.as_mut().expect("`MessageLoss` missing")
     }
+
+    pub(crate) fn message_duplication(&self) -> &MessageDupliaction {
+        self.message_duplication
+            .as_ref()
+            .expect("`MessageDupliaction` missing")
+    }
+
+    pub(crate) fn message_duplication_mut(&mut self) -> &mut MessageDupliaction {
+        self.message_duplication
+            .as_mut()
+            .expect("`MessageDupliaction` missing")
+    }
 }
 
 impl Default for Latency {
@@ -97,6 +119,14 @@ impl Default for MessageLoss {
         MessageLoss {
             fail_rate: 0.0,
             repair_rate: 1.0,
+        }
+    }
+}
+
+impl Default for MessageDupliaction {
+    fn default() -> MessageDupliaction {
+        MessageDupliaction {
+            duplication_rate: 0.0,
         }
     }
 }

--- a/src/envelope.rs
+++ b/src/envelope.rs
@@ -18,7 +18,7 @@ pub enum Protocol {
 }
 
 /// UDP datagram.
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct Datagram(pub Bytes);
 
 /// This is a simplification of real TCP.

--- a/src/sim.rs
+++ b/src/sim.rs
@@ -258,6 +258,25 @@ impl<'a> Sim<'a> {
         });
     }
 
+    pub fn set_message_duplication_rate(&mut self, value: f64) {
+        self.world.borrow_mut().topology.set_duplication_rate(value);
+    }
+
+    pub fn set_link_message_duplication_rate(
+        &mut self,
+        a: impl ToIpAddrs,
+        b: impl ToIpAddrs,
+        value: f64,
+    ) {
+        let mut world = self.world.borrow_mut();
+        let a = world.lookup_many(a);
+        let b = world.lookup_many(b);
+
+        for_pairs(&a, &b, |a, b| {
+            world.topology.set_link_duplication_rate(a, b, value);
+        });
+    }
+
     /// Access a [`LinksIter`] to introspect inflight messages between hosts.
     pub fn links(&self, f: impl FnOnce(LinksIter)) {
         let top = &mut self.world.borrow_mut().topology;

--- a/src/top.rs
+++ b/src/top.rs
@@ -483,8 +483,8 @@ impl Link {
         rand: &mut dyn RngCore,
     ) -> bool {
         let config = self.config.message_duplication.as_ref().unwrap_or(global);
-        let repair_rate = config.duplication_rate;
-        repair_rate > 0.0 && rand.gen_bool(repair_rate)
+        let duplication_rate = config.duplication_rate;
+        duplication_rate > 0.0 && rand.gen_bool(duplication_rate)
     }
 
     fn delay(&self, global: &config::Latency, rand: &mut dyn RngCore) -> Duration {


### PR DESCRIPTION
Adds ability to configure message duplication.


Some questions: 
1. This should only apply to UDP right? It does not make sense for TCP.
2. Should I name it `udp_message_duplication` instead?
3. I was a little unsure where to put the duplication. In the end I thought it makes sense to put in `enqueue`. Do you think this is the right place?