### PR TITLE
Extend loopback workaround

### DIFF
--- a/src/host.rs
+++ b/src/host.rs
@@ -417,6 +417,11 @@ pub fn matches(bind: SocketAddr, dst: SocketAddr) -> bool {
     bind == dst
 }
 
+/// Returns whether loopback is supported from src to dst
+pub(crate) fn is_loopback(src: SocketAddr, dst: SocketAddr) -> bool {
+    dst.ip().is_loopback() || src.ip() == dst.ip()
+}
+
 #[cfg(test)]
 mod test {
     use crate::{Host, Result};

--- a/src/host.rs
+++ b/src/host.rs
@@ -417,8 +417,9 @@ pub fn matches(bind: SocketAddr, dst: SocketAddr) -> bool {
     bind == dst
 }
 
-/// Returns whether loopback is supported from src to dst
-pub(crate) fn is_loopback(src: SocketAddr, dst: SocketAddr) -> bool {
+/// Returns true if loopback is supported between two addresses, or
+/// if the IPs are the same (in which case turmoil treats it like loopback)
+pub(crate) fn is_same(src: SocketAddr, dst: SocketAddr) -> bool {
     dst.ip().is_loopback() || src.ip() == dst.ip()
 }
 

--- a/src/net/tcp/stream.rs
+++ b/src/net/tcp/stream.rs
@@ -17,7 +17,7 @@ use tokio::{
 
 use crate::{
     envelope::{Envelope, Protocol, Segment, Syn},
-    host::is_loopback,
+    host::is_same,
     host::SequencedSegment,
     net::SocketPair,
     world::World,
@@ -75,7 +75,7 @@ impl TcpStream {
             let rx = host.tcp.new_stream(pair);
 
             let syn = Protocol::Tcp(Segment::Syn(Syn { ack }));
-            if !is_loopback(local_addr, dst) {
+            if !is_same(local_addr, dst) {
                 world.send_message(local_addr, dst, syn)?;
             } else {
                 send_loopback(local_addr, dst, syn);
@@ -271,7 +271,7 @@ impl WriteHalf {
 
     fn send(&self, world: &mut World, segment: Segment) -> Result<()> {
         let message = Protocol::Tcp(segment);
-        if is_loopback(self.pair.local, self.pair.remote) {
+        if is_same(self.pair.local, self.pair.remote) {
             send_loopback(self.pair.local, self.pair.remote, message);
         } else {
             world.send_message(self.pair.local, self.pair.remote, message)?;

--- a/src/net/tcp/stream.rs
+++ b/src/net/tcp/stream.rs
@@ -74,7 +74,7 @@ impl TcpStream {
             let rx = host.tcp.new_stream(pair);
 
             let syn = Protocol::Tcp(Segment::Syn(Syn { ack }));
-            if !dst.ip().is_loopback() {
+            if !dst.ip().is_loopback() && dst.ip() != local_addr.ip() {
                 world.send_message(local_addr, dst, syn)?;
             } else {
                 send_loopback(local_addr, dst, syn);
@@ -270,7 +270,7 @@ impl WriteHalf {
 
     fn send(&self, world: &mut World, segment: Segment) -> Result<()> {
         let message = Protocol::Tcp(segment);
-        if self.pair.remote.ip().is_loopback() {
+        if self.pair.remote.ip().is_loopback() || self.pair.local.ip() == self.pair.remote.ip() {
             send_loopback(self.pair.local, self.pair.remote, message);
         } else {
             world.send_message(self.pair.local, self.pair.remote, message)?;

--- a/src/net/udp.rs
+++ b/src/net/udp.rs
@@ -6,6 +6,7 @@ use tokio::{
 
 use crate::{
     envelope::{Datagram, Envelope, Protocol},
+    host::is_loopback,
     ToSocketAddrs, World, TRACING_TARGET,
 };
 
@@ -291,7 +292,7 @@ impl UdpSocket {
             src.set_ip(world.current_host_mut().addr);
         }
 
-        if dst.ip().is_loopback() || src.ip() == dst.ip() {
+        if is_loopback(src, dst) {
             send_loopback(src, dst, msg);
         } else {
             world.send_message(src, dst, msg)?;

--- a/src/net/udp.rs
+++ b/src/net/udp.rs
@@ -291,7 +291,7 @@ impl UdpSocket {
             src.set_ip(world.current_host_mut().addr);
         }
 
-        if dst.ip().is_loopback() {
+        if dst.ip().is_loopback() || src.ip() == dst.ip() {
             send_loopback(src, dst, msg);
         } else {
             world.send_message(src, dst, msg)?;

--- a/src/net/udp.rs
+++ b/src/net/udp.rs
@@ -6,7 +6,7 @@ use tokio::{
 
 use crate::{
     envelope::{Datagram, Envelope, Protocol},
-    host::is_loopback,
+    host::is_same,
     ToSocketAddrs, World, TRACING_TARGET,
 };
 
@@ -292,7 +292,7 @@ impl UdpSocket {
             src.set_ip(world.current_host_mut().addr);
         }
 
-        if is_loopback(src, dst) {
+        if is_same(src, dst) {
             send_loopback(src, dst, msg);
         } else {
             world.send_message(src, dst, msg)?;

--- a/tests/tcp.rs
+++ b/tests/tcp.rs
@@ -736,7 +736,9 @@ fn non_zero_bind() -> Result {
     sim.client("client", async move {
         let sock = TcpListener::bind("1.1.1.1:1").await;
 
-        let Err(err) = sock else { panic!("bind should have failed") };
+        let Err(err) = sock else {
+            panic!("bind should have failed")
+        };
         assert_eq!(err.to_string(), "1.1.1.1:1 is not supported");
         Ok(())
     });

--- a/tests/udp.rs
+++ b/tests/udp.rs
@@ -1,6 +1,5 @@
 use std::{
     io::{self, ErrorKind},
-    matches,
     net::{IpAddr, Ipv4Addr, Ipv6Addr, SocketAddr},
     rc::Rc,
     sync::{atomic::AtomicUsize, atomic::Ordering},
@@ -210,7 +209,7 @@ fn hold_and_release() -> Result {
         send_ping(&sock).await?;
 
         let res = timeout(Duration::from_secs(1), recv_pong(&sock)).await;
-        assert!(matches!(res, Err(_)));
+        assert!(res.is_err());
 
         // resume the network. note that the client ping does not have to be
         // resent.
@@ -406,7 +405,9 @@ fn non_zero_bind() -> Result {
     sim.client("client", async move {
         let sock = UdpSocket::bind("1.1.1.1:1").await;
 
-        let Err(err) = sock else { panic!("socket creation should have failed") };
+        let Err(err) = sock else {
+            panic!("socket creation should have failed")
+        };
         assert_eq!(err.to_string(), "1.1.1.1:1 is not supported");
         Ok(())
     });


### PR DESCRIPTION
This should resolve #135.

Current workaround for loopback from #118 does not allow connecting to the same host when using the public ip. This change extends the workaround to allow for that, unblocking additional use cases pending a larger rework to fully support multiple interfaces (see #132)