### PR TITLE
Add reverse DNS resolution capabilities

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -144,6 +144,13 @@ pub fn lookup(addr: impl ToIpAddr) -> IpAddr {
     World::current(|world| world.lookup(addr))
 }
 
+/// Perform a reverse DNS lookup, returning the hostname if the entry exists.
+///
+/// Must be called from within a Turmoil simulation.
+pub fn reverse_lookup(addr: IpAddr) -> Option<String> {
+    World::current(|world| world.reverse_lookup(addr).map(|h| h.to_owned()))
+}
+
 /// Lookup an IP address by host name. Use regex to match a number of hosts.
 ///
 /// Must be called from within a Turmoil simulation.

--- a/src/world.rs
+++ b/src/world.rs
@@ -79,6 +79,10 @@ impl World {
         self.dns.lookup(host)
     }
 
+    pub(crate) fn reverse_lookup(&self, addr: IpAddr) -> Option<&str> {
+        self.dns.reverse(addr)
+    }
+
     pub(crate) fn lookup_many(&mut self, hosts: impl ToIpAddrs) -> Vec<IpAddr> {
         self.dns.lookup_many(hosts)
     }


### PR DESCRIPTION
This provides a path for scanning all hosts in the network via existing functionality, which is useful for building host discovery.