### PR TITLE
Fix duplicate FIN in the drop glue

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,6 +37,7 @@ tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 [dev-dependencies]
 doc-comment = "0.3.3"
 regex = "1"
+tracing-subscriber = "0.3"
 
 [features]
 default = []

--- a/src/net/tcp/stream.rs
+++ b/src/net/tcp/stream.rs
@@ -370,6 +370,11 @@ impl Drop for ReadHalf {
 
 impl Drop for WriteHalf {
     fn drop(&mut self) {
+        // skip if write half is already shutdown
+        if self.is_shutdown {
+            return;
+        }
+
         World::current_if_set(|world| {
             let pair = *self.pair;
 


### PR DESCRIPTION
If the stream is shutdown manually it sends a FIN on the write half,
however we don't check the state in the drop implementation, which led
to a duplicate FIN being sent.

To fix, `is_shutdown` is checked before sending the FIN.
