### PR TITLE
Fix ephemeral port leak upon tcp stream shutdown

### DIFF
--- a/src/net/tcp/stream.rs
+++ b/src/net/tcp/stream.rs
@@ -370,16 +370,14 @@ impl Drop for ReadHalf {
 
 impl Drop for WriteHalf {
     fn drop(&mut self) {
-        // skip if write half is already shutdown
-        if self.is_shutdown {
-            return;
-        }
-
         World::current_if_set(|world| {
             let pair = *self.pair;
 
             if let Some(seq) = world.current_host_mut().tcp.assign_send_seq(pair) {
-                let _ = self.send(world, Segment::Fin(seq));
+                // skip sending Fin if the write half is already shutdown
+                if !self.is_shutdown {
+                    let _ = self.send(world, Segment::Fin(seq));
+                }
                 world.current_host_mut().tcp.close_stream_half(pair);
             }
         })


### PR DESCRIPTION
Do not send a Fin upon the write half drop if the stream is already shutdown but still perform the socket pair clean up.