### PR TITLE
Fix subtraction overflow bug with min latency

### DIFF
--- a/src/builder.rs
+++ b/src/builder.rs
@@ -69,14 +69,34 @@ impl Builder {
             .as_mut()
             .expect("`Latency` missing")
             .min_message_latency = value;
+        // If the min latency is greater than the max latency, update 
+        // the max latency.
+        if self.link
+            .latency
+            .as_mut()
+            .expect("`Latency` missing")
+            .max_message_latency < value {
+                self.link
+                    .latency
+                    .as_mut()
+                    .expect("`Latency` missing")
+                    .max_message_latency = value.clone()
+            }
         self
     }
 
     pub fn max_message_latency(&mut self, value: Duration) -> &mut Self {
+        if self.link
+            .latency
+            .as_mut()
+            .expect("`Latency` missing")
+            .min_message_latency > value {
+                panic!("Max message latency must be greater than minimum.")
+            };
         self.link
             .latency
             .as_mut()
-            .expect("`MessageLoss` missing")
+            .expect("`Latency` missing")
             .max_message_latency = value;
         self
     }

--- a/src/builder.rs
+++ b/src/builder.rs
@@ -69,30 +69,36 @@ impl Builder {
             .as_mut()
             .expect("`Latency` missing")
             .min_message_latency = value;
-        // If the min latency is greater than the max latency, update 
+        // If the min latency is greater than the max latency, update
         // the max latency.
-        if self.link
+        if self
+            .link
             .latency
             .as_mut()
             .expect("`Latency` missing")
-            .max_message_latency < value {
-                self.link
-                    .latency
-                    .as_mut()
-                    .expect("`Latency` missing")
-                    .max_message_latency = value.clone()
-            }
+            .max_message_latency
+            < value
+        {
+            self.link
+                .latency
+                .as_mut()
+                .expect("`Latency` missing")
+                .max_message_latency = value
+        }
         self
     }
 
     pub fn max_message_latency(&mut self, value: Duration) -> &mut Self {
-        if self.link
+        if self
+            .link
             .latency
             .as_mut()
             .expect("`Latency` missing")
-            .min_message_latency > value {
-                panic!("Max message latency must be greater than minimum.")
-            };
+            .min_message_latency
+            > value
+        {
+            panic!("Max message latency must be greater than minimum.")
+        };
         self.link
             .latency
             .as_mut()

--- a/src/top.rs
+++ b/src/top.rs
@@ -268,6 +268,7 @@ impl Topology {
     }
 }
 
+/// Represents a message sent between two hosts on the network.
 struct Sent {
     src: SocketAddr,
     dst: SocketAddr,


### PR DESCRIPTION
Previously if you specify a `min_message_latency` greater than the default `max_message_latency`, the test would fail with a tokio error: `overflow when subtracting durations`. This updates the `min_message_latency` setter to update the `max_message_latency` if it is less than the new minimum value.

I also updated the max message latency setter to panic if provided with a value less than the minimum message latency. Given this is much more obviously incorrect to a user of the crate (given the default min latency of 0), I felt a panic was appropriate, and would provide an easier error to debug than the tokio message.