### PR TITLE
Fix subtraction overflow bug with latency

### DIFF
--- a/src/top.rs
+++ b/src/top.rs
@@ -149,6 +149,7 @@ struct Link {
     now: Instant,
 }
 
+/// States that a link between two nodes can be in.
 enum State {
     /// The link is healthy.
     Healthy,
@@ -268,6 +269,7 @@ impl Topology {
     }
 }
 
+/// Represents a message sent between two hosts on the network.
 struct Sent {
     src: SocketAddr,
     dst: SocketAddr,


### PR DESCRIPTION
Previously if you specify a `min_message_latency` greater than the default `max_message_latency`, the test would fail with a tokio error: `overflow when subtracting durations`. This change updates the builder to assert that the min/max latencies are valid on build.