### PR TITLE
Fix builder to use provided rng

### DIFF
--- a/src/builder.rs
+++ b/src/builder.rs
@@ -5,8 +5,6 @@ use std::time::{Duration, SystemTime};
 
 /// Configure the simulation
 pub struct Builder {
-    rng: Option<Box<dyn RngCore>>,
-
     config: Config,
 
     ip_version: IpVersion,
@@ -23,7 +21,6 @@ impl Default for Builder {
 impl Builder {
     pub fn new() -> Self {
         Self {
-            rng: None,
             config: Config::default(),
             ip_version: IpVersion::default(),
             link: config::Link {
@@ -57,12 +54,6 @@ impl Builder {
         self
     }
 
-    /// Set the random number generator used to fuzz
-    pub fn rng(&mut self, rng: impl RngCore + 'static) -> &mut Self {
-        self.rng = Some(Box::new(rng));
-        self
-    }
-
     pub fn min_message_latency(&mut self, value: Duration) -> &mut Self {
         self.link.latency_mut().min_message_latency = value;
         self
@@ -93,11 +84,15 @@ impl Builder {
         self
     }
 
+    /// Build with default rng.
     pub fn build<'a>(&self) -> Sim<'a> {
         self.build_with_rng(Box::new(rand::rngs::SmallRng::from_entropy()))
     }
 
-    pub fn build_with_rng<'a>(&self, rng: Box<dyn RngCore>) -> Sim<'a> {
+    /// Build a sim with a provided `rng`.
+    ///
+    /// This allows setting the random number generator used to fuzz
+    fn build_with_rng<'a>(&self, rng: Box<dyn RngCore>) -> Sim<'a> {
         if self.link.latency().max_message_latency < self.link.latency().min_message_latency {
             panic!("Maximum message latency must be greater than minimum.");
         }

--- a/src/config.rs
+++ b/src/config.rs
@@ -3,7 +3,7 @@ use std::time::{Duration, SystemTime};
 
 #[derive(Clone)]
 pub(crate) struct Config {
-    /// How long the test should run for
+    /// How long the test should run for in simulated time.
     pub(crate) duration: Duration,
 
     /// How much simulated time should elapse each tick


### PR DESCRIPTION
This commit fixes the turmoil sim builder by removing the `rng`
function. Currently the `build` function ignores the `rng` set on the
builder, and due to the boxing of the value there is no easy way to
repeatedly build a sim with the same `rng`. We would need to add the
ability to clone the boxed rng, which requires some complicated trait
bounds and a different breaking of the interface. This is simpler and
fixes the bug where rng was ignored during building.

This is a breaking change:
- `rng` is removed from the builder, as it was not delivering its
  expected behaviour. Users now need to explicitly specify
  `build_with_rng`.