### PR TITLE
More fixes for loopback networking

### DIFF
--- a/src/builder.rs
+++ b/src/builder.rs
@@ -171,7 +171,13 @@ impl Builder {
             panic!("Maximum message latency must be greater than minimum.");
         }
 
-        let world = World::new(self.link.clone(), rng, self.ip_version.iter());
+        let world = World::new(
+            self.link.clone(),
+            rng,
+            self.ip_version.iter(),
+            self.config.tick,
+        );
+
         Sim::new(self.config.clone(), world)
     }
 }

--- a/src/net/udp.rs
+++ b/src/net/udp.rs
@@ -14,7 +14,6 @@ use std::{
     cmp,
     io::{self, Error, ErrorKind, Result},
     net::SocketAddr,
-    time::Duration,
 };
 
 /// A simulated UDP socket.
@@ -304,7 +303,12 @@ impl UdpSocket {
 
 fn send_loopback(src: SocketAddr, dst: SocketAddr, message: Protocol) {
     tokio::spawn(async move {
-        sleep(Duration::from_micros(1)).await;
+        // FIXME: Forces delivery on the next step which better aligns with the
+        // remote networking behavior.
+        // https://github.com/tokio-rs/turmoil/issues/132
+        let tick_duration = World::current(|world| world.tick_duration);
+        sleep(tick_duration).await;
+
         World::current(|world| {
             world
                 .current_host_mut()

--- a/src/sim.rs
+++ b/src/sim.rs
@@ -29,6 +29,8 @@ pub struct Sim<'a> {
 
     /// Simulation elapsed time
     elapsed: Duration,
+
+    steps: usize,
 }
 
 impl<'a> Sim<'a> {
@@ -44,6 +46,7 @@ impl<'a> Sim<'a> {
             rts: IndexMap::new(),
             since_epoch,
             elapsed: Duration::ZERO,
+            steps: 1, // bumped after each step
         }
     }
 
@@ -325,8 +328,9 @@ impl<'a> Sim<'a> {
     ///
     /// Returns whether or not all clients have completed.
     pub fn step(&mut self) -> Result<bool> {
-        let tick = self.config.tick;
+        tracing::debug!("step {}", self.steps);
 
+        let tick = self.config.tick;
         let mut is_finished = true;
 
         // Tick the networking, processing messages. This is done before
@@ -376,11 +380,12 @@ impl<'a> Sim<'a> {
         }
 
         self.elapsed += tick;
+        self.steps += 1;
 
         if self.elapsed > self.config.duration && !is_finished {
             return Err(format!(
-                "Ran for {:?} without completing",
-                self.config.duration
+                "Ran for duration: {:?} steps: {} without completing",
+                self.config.duration, self.steps,
             ))?;
         }
 

--- a/src/world.rs
+++ b/src/world.rs
@@ -28,6 +28,10 @@ pub(crate) struct World {
     /// Random number generator used for all decisions. To make execution
     /// determinstic, reuse the same seed.
     pub(crate) rng: Box<dyn RngCore>,
+
+    /// Run duration for each host on every step.
+    // TODO: Remove this once we've cleaned up the loopback implementation hacks
+    pub(crate) tick_duration: Duration,
 }
 
 scoped_thread_local!(static CURRENT: RefCell<World>);
@@ -38,6 +42,7 @@ impl World {
         link: config::Link,
         rng: Box<dyn RngCore>,
         addrs: IpVersionAddrIter,
+        tick_duration: Duration,
     ) -> World {
         World {
             hosts: IndexMap::new(),
@@ -45,6 +50,7 @@ impl World {
             dns: Dns::new(addrs),
             current: None,
             rng,
+            tick_duration,
         }
     }
 


### PR DESCRIPTION
- Avoid trying to spawn on teardown when the rt is gone
- Deliver loopback packets in the next step to better align with
how remote networking works.
