### PR TITLE
Update actions/checkout action and replace unmaintained actions-rs actions

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -18,7 +18,7 @@ jobs:
         os: [ubuntu-latest]
     steps:
       - name: Git Checkout
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Rust Toolchain
         uses: actions-rs/toolchain@v1
         with:
@@ -38,7 +38,7 @@ jobs:
       matrix :
         os: [ubuntu-latest]
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: actions-rs/toolchain@v1
         with:
           profile: minimal

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -20,11 +20,7 @@ jobs:
       - name: Git Checkout
         uses: actions/checkout@v4
       - name: Rust Toolchain
-        uses: actions-rs/toolchain@v1
-        with:
-          profile: minimal
-          toolchain: stable
-          override: true
+        uses: dtolnay/rust-toolchain@stable
       - name: Cargo Test
         run: cargo test --verbose --features "${{ matrix.features }}"
 
@@ -36,11 +32,7 @@ jobs:
         os: [ubuntu-latest]
     steps:
       - uses: actions/checkout@v4
-      - uses: actions-rs/toolchain@v1
-        with:
-          profile: minimal
-          toolchain: stable
-          override: true
-          components: clippy
+      - name: Rust Toolchain
+        uses: dtolnay/rust-toolchain@stable
       - name: Run cargo clippy
         run: cargo clippy --all-targets -- --deny warnings

--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -26,10 +26,7 @@ jobs:
           toolchain: stable
           override: true
       - name: Cargo Test
-        uses: actions-rs/cargo@v1
-        with:
-          command: test
-          args: --verbose --features "${{ matrix.features }}"
+        run: cargo test --verbose --features "${{ matrix.features }}"
 
   clippy:
     name: Run Clippy
@@ -46,7 +43,4 @@ jobs:
           override: true
           components: clippy
       - name: Run cargo clippy
-        uses: actions-rs/cargo@v1
-        with:
-          command: clippy
-          args: --all-targets -- --deny warnings
+        run: cargo clippy --all-targets -- --deny warnings


### PR DESCRIPTION
- Update actions/checkout action
- Use cargo directly instead of unmaintained actions-rs/cargo action
- Use [dtolnay/rust-toolchain](https://github.com/dtolnay/rust-toolchain) instead of unmaintained actions-rs/toolchain action

See also https://github.com/tokio-rs/tokio/pull/5316 for the context of unmaintained actions and alternatives.