### PR TITLE
Add `turmoil::sim_elapsed` for retrieving total simulation virtual time

### DIFF
--- a/examples/grpc/src/main.rs
+++ b/examples/grpc/src/main.rs
@@ -19,11 +19,7 @@ use proto::{HelloReply, HelloRequest};
 use crate::proto::greeter_client::GreeterClient;
 
 fn main() {
-    if std::env::var("RUST_LOG").is_err() {
-        std::env::set_var("RUST_LOG", "info");
-    }
-
-    tracing_subscriber::fmt::init();
+    configure_tracing();
 
     let addr = (IpAddr::from(Ipv4Addr::UNSPECIFIED), 9999);
 
@@ -60,7 +56,7 @@ fn main() {
             let request = Request::new(HelloRequest { name: "foo".into() });
             let res = greeter_client.say_hello(request).await?;
 
-            tracing::info!("Got response: {:?}", res);
+            tracing::info!(?res, "Got response");
 
             Ok(())
         }
@@ -68,6 +64,32 @@ fn main() {
     );
 
     sim.run().unwrap();
+}
+
+/// An example of how to configure a tracing subscriber that will log logical
+/// elapsed time since the simulation started using `turmoil::sim_elapsed()`.
+fn configure_tracing() {
+    if std::env::var("RUST_LOG").is_err() {
+        std::env::set_var("RUST_LOG", "info");
+    }
+
+    tracing::subscriber::set_global_default(
+        tracing_subscriber::fmt()
+            .with_env_filter(tracing_subscriber::EnvFilter::from_default_env())
+            .with_timer(SimElapsedTime)
+            .finish(),
+    )
+    .expect("Configure tracing");
+}
+
+#[derive(Clone)]
+struct SimElapsedTime;
+impl tracing_subscriber::fmt::time::FormatTime for SimElapsedTime {
+    fn format_time(&self, w: &mut tracing_subscriber::fmt::format::Writer<'_>) -> std::fmt::Result {
+        // The debug implementation of Duration gives reasonably formatted
+        // durations (e.g. `610ms`, `2.62s`).
+        write!(w, "{:?}", turmoil::sim_elapsed().unwrap_or_default())
+    }
 }
 
 #[derive(Default)]
@@ -79,6 +101,7 @@ impl Greeter for MyGreeter {
         &self,
         request: Request<HelloRequest>,
     ) -> Result<Response<HelloReply>, Status> {
+        tracing::info!(?request, "Got request");
         let reply = HelloReply {
             message: format!("Hello {}!", request.into_inner().name),
         };

--- a/examples/grpc/src/main.rs
+++ b/examples/grpc/src/main.rs
@@ -86,9 +86,10 @@ fn configure_tracing() {
 struct SimElapsedTime;
 impl tracing_subscriber::fmt::time::FormatTime for SimElapsedTime {
     fn format_time(&self, w: &mut tracing_subscriber::fmt::format::Writer<'_>) -> std::fmt::Result {
-        // The debug implementation of Duration gives reasonably formatted
-        // durations (e.g. `610ms`, `2.62s`).
-        write!(w, "{:?}", turmoil::sim_elapsed().unwrap_or_default())
+        // Prints real time and sim elapsed time. Example: 2024-01-10T17:06:57.020452Z [76ms]
+        tracing_subscriber::fmt::time()
+            .format_time(w)
+            .and_then(|()| write!(w, " [{:?}]", turmoil::sim_elapsed().unwrap_or_default()))
     }
 }
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -64,6 +64,9 @@
 //! [`tracing-subscriber`](https://docs.rs/tracing-subscriber/latest/tracing_subscriber/).
 //! The log level of turmoil can be configured using `RUST_LOG=turmoil=info`.
 //!
+//! It is possible to configure your tracing subscriber to log elapsed
+//! simulation time instead of real time. See the grpc example.
+//!
 //! Turmoil can provide a full packet level trace of the events happening in a
 //! simulation by passing `RUST_LOG=turmoil=trace`. This is really useful
 //! when you are unable to identify why some unexpected behaviour is happening
@@ -115,7 +118,7 @@ mod readme;
 
 mod builder;
 
-use std::net::IpAddr;
+use std::{net::IpAddr, time::Duration};
 
 pub use builder::Builder;
 
@@ -134,7 +137,6 @@ mod error;
 pub use error::Result;
 
 mod host;
-pub use host::elapsed;
 use host::Host;
 
 mod ip;
@@ -168,6 +170,23 @@ pub(crate) fn for_pairs(a: &Vec<IpAddr>, b: &Vec<IpAddr>, mut f: impl FnMut(IpAd
             }
         }
     }
+}
+
+/// Returns how long the currently executing host has been executing for in
+/// virtual time.
+///
+/// Must be called from within a Turmoil simulation.
+pub fn elapsed() -> Duration {
+    World::current(|world| world.current_host().timer.elapsed())
+}
+
+/// Returns how long the simulation has been executing for in virtual time.
+///
+/// Must be called from within a Turmoil simulation. Will return None if the
+/// duration is not available, typically because there is no currently executing
+/// host.
+pub fn sim_elapsed() -> Option<Duration> {
+    World::try_current(|world| world.current_host().timer.sim_elapsed()).ok()
 }
 
 /// Lookup an IP address by host name.

--- a/src/world.rs
+++ b/src/world.rs
@@ -72,7 +72,7 @@ impl World {
     /// down and we don't need to do anything.
     pub(crate) fn current_if_set(f: impl FnOnce(&mut World)) {
         if CURRENT.is_set() {
-            Some(Self::current(f));
+            Self::current(f);
         }
     }
 

--- a/src/world.rs
+++ b/src/world.rs
@@ -1,7 +1,11 @@
 use crate::config::Config;
 use crate::envelope::Protocol;
+use crate::host::HostTimer;
 use crate::ip::IpVersionAddrIter;
-use crate::{config, for_pairs, Dns, Host, ToIpAddr, ToIpAddrs, Topology, TRACING_TARGET};
+use crate::{
+    config, for_pairs, Dns, Host, Result as TurmoilResult, ToIpAddr, ToIpAddrs, Topology,
+    TRACING_TARGET,
+};
 
 use indexmap::IndexMap;
 use rand::RngCore;
@@ -68,7 +72,18 @@ impl World {
     /// down and we don't need to do anything.
     pub(crate) fn current_if_set(f: impl FnOnce(&mut World)) {
         if CURRENT.is_set() {
-            Self::current(f);
+            Some(Self::current(f));
+        }
+    }
+
+    pub(crate) fn try_current<R>(f: impl FnOnce(&World) -> R) -> TurmoilResult<R> {
+        if CURRENT.is_set() {
+            CURRENT.with(|current| match current.try_borrow() {
+                Ok(world) => Ok(f(&world)),
+                Err(_) => Err("World already borrowed".into()),
+            })
+        } else {
+            Err("World not set".into())
         }
     }
 
@@ -79,6 +94,11 @@ impl World {
     pub(crate) fn current_host_mut(&mut self) -> &mut Host {
         let addr = self.current.expect("current host missing");
         self.hosts.get_mut(&addr).expect("host missing")
+    }
+
+    pub(crate) fn current_host(&self) -> &Host {
+        let addr = self.current.expect("current host missing");
+        self.hosts.get(&addr).expect("host missing")
     }
 
     pub(crate) fn lookup(&mut self, host: impl ToIpAddr) -> IpAddr {
@@ -146,7 +166,13 @@ impl World {
     }
 
     /// Register a new host with the simulation.
-    pub(crate) fn register(&mut self, addr: IpAddr, nodename: &str, config: &Config) {
+    pub(crate) fn register(
+        &mut self,
+        addr: IpAddr,
+        nodename: &str,
+        timer: HostTimer,
+        config: &Config,
+    ) {
         assert!(
             !self.hosts.contains_key(&addr),
             "already registered host for the given ip address"
@@ -164,6 +190,7 @@ impl World {
             addr,
             Host::new(
                 addr,
+                timer,
                 config.ephemeral_ports.clone(),
                 config.tcp_capacity,
                 config.udp_capacity,
@@ -188,6 +215,7 @@ impl World {
         self.hosts
             .get_mut(&addr)
             .expect("missing host")
+            .timer
             .tick(duration);
     }
 }


### PR DESCRIPTION
Previously, we only exposed `turmoil::elapsed` which returned the elapsed virtual time for the currently executing host. If you step your simulation for some duration before registering a host then the host's elapsed time will be less than the overall sim elapsed time.

We didn't want to make a breaking API change for this, so opted to add a new function (`turmoil::sim_elapsed`). This function returns an `Option` so that the caller can gracefully handle failure (`turmoil::elapsed` will crash if called outside of an executing host, for example). This makes it easier to use `sim_elapsed` for things like logging elapsed time via the std tracing subscriber (there's an example of how to do this in the `grpc` example).

One sharp edge I ran into is that we sometimes do tracing in this crate itself (e.g. in `Tcp::bind`) which happens while we're holding a mutable borrow of the thread-local `RefCell<World>`. Since the tracing event causes us to call `tracing::sim_elapsed`, we have an attempted double mutable borrow. In these cases I just made `sim_elapsed` return `None`. It's a bit of a wart but I think it's okay. We also return `None` when `sim_elapsed` is called when there's no executing host, so I think the API returning `Option` feels right. We can internally fix the double borrow issue in future without a breaking change.