### PR TITLE
Bump tokio to version "1"

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,7 +27,7 @@ rand = { version = "0.8.5", features = ["small_rng"] }
 rand_distr = "0.4.3"
 regex = { version = "1", optional = true }
 scoped-tls = "1.0.1"
-tokio = { version = "1.25.0", features = ["full"] }
+tokio = { version = "1", features = ["full"] }
 tokio-stream = "0.1"
 tokio-test = "0.4.2"
 tokio-util = "0.7.4"


### PR DESCRIPTION
Opting to only specify major version to limit dependency maintenance.
