### PR TITLE
Add ability to run hosts in random order

### DIFF
--- a/src/builder.rs
+++ b/src/builder.rs
@@ -170,6 +170,14 @@ impl Builder {
         self
     }
 
+    /// Enables running of nodes in random order. This allows exploration
+    /// of extra state space in multi-node simulations where rance conditions may arise
+    /// based on message send/receive order
+    pub fn enable_random_order(&mut self) -> &mut Self {
+        self.config.random_node_order = true;
+        self
+    }
+
     /// Build a simulation with the settings from the builder.
     ///
     /// This will use default rng with entropy from the device running.

--- a/src/builder.rs
+++ b/src/builder.rs
@@ -171,8 +171,8 @@ impl Builder {
     }
 
     /// Enables running of nodes in random order. This allows exploration
-    /// of extra state space in multi-node simulations where rance conditions may arise
-    /// based on message send/receive order
+    /// of extra state space in multi-node simulations where race conditions
+    /// may arise based on message send/receive order.
     pub fn enable_random_order(&mut self) -> &mut Self {
         self.config.random_node_order = true;
         self

--- a/src/config.rs
+++ b/src/config.rs
@@ -39,6 +39,10 @@ pub(crate) struct Config {
 
     /// Enables tokio IO driver
     pub(crate) enable_tokio_io: bool,
+
+    /// Enables running of host/client code in random order at each
+    /// simulation step
+    pub(crate) random_node_order: bool,
 }
 
 /// Configures link behavior.
@@ -91,6 +95,7 @@ impl Default for Config {
             tcp_capacity: 64,
             udp_capacity: 64,
             enable_tokio_io: false,
+            random_node_order: false,
         }
     }
 }


### PR DESCRIPTION
This was quite useful in our tests, where the outcome of a multi-node simulation is sensitive to processing order.

Plumbed through as a boolean option through Config/Builder, w/ the default being `false` (current behavior)