### PR TITLE
Make `Config.duration` as `Option<Duration>`

### DIFF
--- a/src/builder.rs
+++ b/src/builder.rs
@@ -25,7 +25,7 @@ use crate::*;
 /// use std::time::{Duration, SystemTime};
 ///
 /// let sim = turmoil::Builder::new()
-///     .simulation_duration(Duration::from_secs(60))
+///     .simulation_duration(Some(Duration::from_secs(60)))
 ///     .epoch(SystemTime::UNIX_EPOCH.checked_add(Duration::from_secs(946684800)).unwrap())
 ///     .fail_rate(0.05) // 5% failure rate
 ///     .build();
@@ -41,7 +41,7 @@ use crate::*;
 /// let mut builder = turmoil::Builder::new();
 ///
 /// // Apply a chain of options to that builder
-/// builder.simulation_duration(Duration::from_secs(45))
+/// builder.simulation_duration(Some(Duration::from_secs(45)))
 ///     .fail_rate(0.05);
 ///
 /// let sim_one = builder.build();
@@ -98,7 +98,7 @@ impl Builder {
     }
 
     /// How long the test should run for in simulated time
-    pub fn simulation_duration(&mut self, value: Duration) -> &mut Self {
+    pub fn simulation_duration(&mut self, value: Option<Duration>) -> &mut Self {
         self.config.duration = value;
         self
     }

--- a/src/config.rs
+++ b/src/config.rs
@@ -21,7 +21,7 @@ use std::{
 #[derive(Clone)]
 pub(crate) struct Config {
     /// How long the test should run for in simulated time.
-    pub(crate) duration: Duration,
+    pub(crate) duration: Option<Duration>,
 
     /// How much simulated time should elapse each tick
     pub(crate) tick: Duration,
@@ -88,7 +88,7 @@ pub(crate) struct MessageLoss {
 impl Default for Config {
     fn default() -> Config {
         Config {
-            duration: Duration::from_secs(10),
+            duration: Some(Duration::from_secs(10)),
             tick: Duration::from_millis(1),
             epoch: SystemTime::now(),
             ephemeral_ports: 49152..=65535,

--- a/tests/tcp.rs
+++ b/tests/tcp.rs
@@ -89,7 +89,7 @@ fn ephemeral_port() -> Result {
 #[test]
 fn ephemeral_port_does_not_leak_on_server_shutdown() -> Result {
     let mut sim = Builder::new()
-        .simulation_duration(Duration::from_secs(60))
+        .simulation_duration(Some(Duration::from_secs(60)))
         .min_message_latency(Duration::from_millis(1))
         .max_message_latency(Duration::from_millis(1))
         .build();
@@ -118,7 +118,7 @@ fn ephemeral_port_does_not_leak_on_server_shutdown() -> Result {
 #[test]
 fn ephemeral_port_does_not_leak_on_client_shutdown() -> Result {
     let mut sim = Builder::new()
-        .simulation_duration(Duration::from_secs(60))
+        .simulation_duration(Some(Duration::from_secs(60)))
         .min_message_latency(Duration::from_millis(1))
         .max_message_latency(Duration::from_millis(1))
         .build();


### PR DESCRIPTION
i think this could be handy for users who'd like to have a custom loop containing `sim.step()` and other fault calls. for such custom loops, i think running for a fixed number of steps would be the only way to go. currently, for such cases, they should also be figuring out and configuring the simulation duration appropriately to go well with their simulation, so they don't face the `"Ran for duration: {:?} steps: {} without completing"` error. this change will enable them to just pass `None` for it.

pls let me know if this kind of change is acceptable.  

