### PR TITLE
Add try_write to TcpStream

### DIFF
--- a/src/net/tcp/stream.rs
+++ b/src/net/tcp/stream.rs
@@ -106,41 +106,6 @@ impl TcpStream {
     /// If data is successfully written, `Ok(n)` is returned, where `n` is the
     /// number of bytes written. If the stream is not ready to write data,
     /// `Err(io::ErrorKind::WouldBlock)` is returned.
-    ///
-    /// # Examples
-    ///
-    /// ```no_run
-    /// use turmoil::net::TcpStream;
-    /// use std::error::Error;
-    /// use std::io;
-    ///
-    /// #[tokio::main]
-    /// async fn main() -> Result<(), Box<dyn Error>> {
-    ///     // Connect to a peer
-    ///     let stream = TcpStream::connect("127.0.0.1:8080").await?;
-    ///
-    ///     loop {
-    ///         // Wait for the socket to be writable
-    ///         stream.writable().await?;
-    ///
-    ///         // Try to write data, this may still fail with `WouldBlock`
-    ///         // if the readiness event is a false positive.
-    ///         match stream.try_write(b"hello world") {
-    ///             Ok(n) => {
-    ///                 break;
-    ///             }
-    ///             Err(ref e) if e.kind() == io::ErrorKind::WouldBlock => {
-    ///                 continue;
-    ///             }
-    ///             Err(e) => {
-    ///                 return Err(e.into());
-    ///             }
-    ///         }
-    ///     }
-    ///
-    ///     Ok(())
-    /// }
-    /// ```
     pub fn try_write(&self, buf: &[u8]) -> Result<usize> {
         self.write_half.try_write(buf)
     }
@@ -173,41 +138,6 @@ impl TcpStream {
     /// will continue to return immediately until the readiness event is
     /// consumed by an attempt to write that fails with `WouldBlock` or
     /// `Poll::Pending`.
-    ///
-    /// # Examples
-    ///
-    /// ```no_run
-    /// use tokio::net::TcpStream;
-    /// use std::error::Error;
-    /// use std::io;
-    ///
-    /// #[tokio::main]
-    /// async fn main() -> Result<(), Box<dyn Error>> {
-    ///     // Connect to a peer
-    ///     let stream = TcpStream::connect("127.0.0.1:8080").await?;
-    ///
-    ///     loop {
-    ///         // Wait for the socket to be writable
-    ///         stream.writable().await?;
-    ///
-    ///         // Try to write data, this may still fail with `WouldBlock`
-    ///         // if the readiness event is a false positive.
-    ///         match stream.try_write(b"hello world") {
-    ///             Ok(n) => {
-    ///                 break;
-    ///             }
-    ///             Err(ref e) if e.kind() == io::ErrorKind::WouldBlock => {
-    ///                 continue;
-    ///             }
-    ///             Err(e) => {
-    ///                 return Err(e.into());
-    ///             }
-    ///         }
-    ///     }
-    ///
-    ///     Ok(())
-    /// }
-    /// ```
     pub async fn writable(&self) -> Result<()> {
         Ok(())
     }

--- a/tests/async_send_sync.rs
+++ b/tests/async_send_sync.rs
@@ -1,31 +1,25 @@
 //! Copied over from:
 //! https://github.com/tokio-rs/tokio/blob/master/tokio/tests/async_send_sync.rs
+#![allow(dead_code)]
 
-#[allow(dead_code)]
 fn require_send<T: Send>(_t: &T) {}
-#[allow(dead_code)]
 fn require_sync<T: Sync>(_t: &T) {}
-#[allow(dead_code)]
 fn require_unpin<T: Unpin>(_t: &T) {}
 
-#[allow(dead_code)]
 struct Invalid;
 
-#[allow(dead_code)]
 trait AmbiguousIfSend<A> {
     fn some_item(&self) {}
 }
 impl<T: ?Sized> AmbiguousIfSend<()> for T {}
 impl<T: ?Sized + Send> AmbiguousIfSend<Invalid> for T {}
 
-#[allow(dead_code)]
 trait AmbiguousIfSync<A> {
     fn some_item(&self) {}
 }
 impl<T: ?Sized> AmbiguousIfSync<()> for T {}
 impl<T: ?Sized + Sync> AmbiguousIfSync<Invalid> for T {}
 
-#[allow(dead_code)]
 trait AmbiguousIfUnpin<A> {
     fn some_item(&self) {}
 }

--- a/tests/async_send_sync.rs
+++ b/tests/async_send_sync.rs
@@ -11,18 +11,21 @@ fn require_unpin<T: Unpin>(_t: &T) {}
 #[allow(dead_code)]
 struct Invalid;
 
+#[allow(dead_code)]
 trait AmbiguousIfSend<A> {
     fn some_item(&self) {}
 }
 impl<T: ?Sized> AmbiguousIfSend<()> for T {}
 impl<T: ?Sized + Send> AmbiguousIfSend<Invalid> for T {}
 
+#[allow(dead_code)]
 trait AmbiguousIfSync<A> {
     fn some_item(&self) {}
 }
 impl<T: ?Sized> AmbiguousIfSync<()> for T {}
 impl<T: ?Sized + Sync> AmbiguousIfSync<Invalid> for T {}
 
+#[allow(dead_code)]
 trait AmbiguousIfUnpin<A> {
     fn some_item(&self) {}
 }


### PR DESCRIPTION
Add `TcpStream::try_write()` and `WriteHalf::try_write()`. 

These allow for a result-based synchronous write attempt. 