### PR TITLE
Validate `tick_duration` millisecond resolution

### DIFF
--- a/src/builder.rs
+++ b/src/builder.rs
@@ -195,7 +195,11 @@ impl Builder {
 
         if self.config.tick.as_nanos() % Duration::from_millis(1).as_nanos() != 0  {
             // Tick duration is used for tokio::time::sleep, which requires millisecond resolution.
-            panic!("Tick duration resolution is in milliseconds, but value provided would require higher.")
+            panic!("Tick duration resolution is in milliseconds, but value provided would require higher: {:?}.", self.config.tick)
+        }
+
+        if self.config.tick.is_zero() {
+            panic!("Tick duration of zero is not supported.")
         }
 
         let world = World::new(

--- a/src/builder.rs
+++ b/src/builder.rs
@@ -193,6 +193,11 @@ impl Builder {
             panic!("Maximum message latency must be greater than minimum.");
         }
 
+        if self.config.tick.as_nanos() % Duration::from_millis(1).as_nanos() != 0  {
+            // Tick duration is used for tokio::time::sleep, which requires millisecond resolution.
+            panic!("Tick duration resolution is in milliseconds, but value provided would require higher.")
+        }
+
         let world = World::new(
             self.link.clone(),
             rng,
@@ -216,6 +221,14 @@ mod tests {
         let _sim = Builder::new()
             .min_message_latency(Duration::from_millis(100))
             .max_message_latency(Duration::from_millis(50))
+            .build();
+    }
+
+    #[test]
+    #[should_panic]
+    fn invalid_tick_duration() {
+        let _sum = Builder::new()
+            .tick_duration(Duration::from_micros(500))
             .build();
     }
 }


### PR DESCRIPTION
Hi! I noticed some strange behavior while running a simulation where the tick duration was sub-millisecond, and discovered that `tokio::time::sleep` apparently uses [millisecond resolution](https://github.com/tokio-rs/tokio/blob/tokio-1.38.x/tokio/src/time/sleep.rs#L71-L75).

I added some validation to the builder, to panic whenever a duration with higher than ms resolution is supplied, since it looked like some other validation was already happening here. Let me know if this seems useful.

Love the project btw!