### PR TITLE
Add unexpected_cfgs lint exception, fixes #182

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,3 +42,6 @@ tracing-subscriber = "0.3"
 [features]
 default = []
 regex = ["dep:regex"]
+
+[lints.rust]
+unexpected_cfgs = { level = "warn", check-cfg = ['cfg(tokio_unstable)'] }


### PR DESCRIPTION
> Some crates might use custom cfgs, like loom, fuzzing or tokio_unstable that they expected from the environment (RUSTFLAGS or other means) and which are always statically known at compile time. For those cases, Cargo provides via the [lints] table a way to statically declare those cfgs as expected.

Reference: https://blog.rust-lang.org/2024/05/06/check-cfg.html

Fixes https://github.com/tokio-rs/turmoil/issues/182