### PR TITLE
Use compile_fds to compile file descriptor set

### DIFF
--- a/examples/grpc/Cargo.toml
+++ b/examples/grpc/Cargo.toml
@@ -17,6 +17,6 @@ tracing-subscriber = "0.3"
 turmoil = { path = "../.." }
 
 [build-dependencies]
-tonic-build = "0.12"
+tonic-build = "0.12.3"
 protox = "0.7"
 prost = "0.13"

--- a/examples/grpc/build.rs
+++ b/examples/grpc/build.rs
@@ -1,17 +1,4 @@
-use prost::Message;
-use std::path::PathBuf;
-
 fn main() -> std::io::Result<()> {
-    let file_descriptors = protox::compile(["helloworld.proto"], ["."]).unwrap();
-    let file_descriptor_path = PathBuf::from(std::env::var_os("OUT_DIR").expect("OUT_DIR not set"))
-        .join("file_descriptor_set.bin");
-    std::fs::write(&file_descriptor_path, file_descriptors.encode_to_vec()).unwrap();
-
-    tonic_build::configure()
-        .file_descriptor_set_path(&file_descriptor_path)
-        .skip_protoc_run()
-        .compile_protos(&["helloworld.proto"], &["."])
-        .unwrap();
-
-    Ok(())
+    let fds = protox::compile(["helloworld.proto"], ["."]).unwrap();
+    tonic_build::compile_fds(fds)
 }


### PR DESCRIPTION
`compile_fds` can be used to compile the file descriptor set.