### PR TITLE
Use EnvFilter config to set default tracing level

### DIFF
--- a/examples/axum/src/main.rs
+++ b/examples/axum/src/main.rs
@@ -6,11 +6,13 @@ use tracing::{info_span, Instrument};
 use turmoil::{net, Builder};
 
 fn main() {
-    if std::env::var("RUST_LOG").is_err() {
-        std::env::set_var("RUST_LOG", "info");
-    }
-
-    tracing_subscriber::fmt::init();
+    tracing_subscriber::fmt()
+        .with_env_filter(
+            tracing_subscriber::EnvFilter::builder()
+                .with_default_directive(tracing::level_filters::LevelFilter::INFO.into())
+                .from_env_lossy(),
+        )
+        .init();
 
     let addr = (IpAddr::from(Ipv4Addr::UNSPECIFIED), 9999);
 

--- a/examples/grpc/src/main.rs
+++ b/examples/grpc/src/main.rs
@@ -66,13 +66,13 @@ fn main() {
 /// An example of how to configure a tracing subscriber that will log logical
 /// elapsed time since the simulation started using `turmoil::sim_elapsed()`.
 fn configure_tracing() {
-    if std::env::var("RUST_LOG").is_err() {
-        std::env::set_var("RUST_LOG", "info");
-    }
-
     tracing::subscriber::set_global_default(
         tracing_subscriber::fmt()
-            .with_env_filter(tracing_subscriber::EnvFilter::from_default_env())
+            .with_env_filter(
+                tracing_subscriber::EnvFilter::builder()
+                    .with_default_directive(tracing::level_filters::LevelFilter::INFO.into())
+                    .from_env_lossy(),
+            )
             .with_timer(SimElapsedTime)
             .finish(),
     )


### PR DESCRIPTION
`EnvFilter`'s config can be used to set the default tracing level instead of editing the environment variable.