### PR TITLE
Remove futures crate from dependency

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -21,7 +21,6 @@ members = ["examples/*"]
 
 [dependencies]
 bytes = "1.4"
-futures = "0.3"
 indexmap = "1.9"
 rand = { version = "0.8.5", features = ["small_rng"] }
 rand_distr = "0.4.3"

--- a/src/rt.rs
+++ b/src/rt.rs
@@ -1,8 +1,8 @@
+use std::future::Future;
 use std::mem;
 use std::pin::Pin;
 use std::sync::Arc;
 
-use futures::Future;
 use tokio::runtime::Runtime;
 use tokio::task::JoinHandle;
 use tokio::task::LocalSet;

--- a/src/sim.rs
+++ b/src/sim.rs
@@ -1052,9 +1052,7 @@ mod test {
 
         let how_many = 3;
         for i in 0..how_many {
-            sim.host(format!("host-{i}"), || async {
-                futures::future::pending().await
-            })
+            sim.host(format!("host-{i}"), || async { future::pending().await })
         }
 
         let mut ips = sim.lookup_many(regex::Regex::new(".*")?);


### PR DESCRIPTION
The APIs from standard library can be used instead of futures crate's ones.