### PR TITLE
Fix unspecified support for same host connections

### DIFF
--- a/src/host.rs
+++ b/src/host.rs
@@ -488,7 +488,7 @@ pub fn matches(bind: SocketAddr, dst: SocketAddr) -> bool {
 /// Returns true if loopback is supported between two addresses, or
 /// if the IPs are the same (in which case turmoil treats it like loopback)
 pub(crate) fn is_same(src: SocketAddr, dst: SocketAddr) -> bool {
-    dst.ip().is_loopback() || src.ip() == dst.ip()
+    dst.ip().is_loopback() || dst.ip().is_unspecified() || src.ip() == dst.ip()
 }
 
 #[cfg(test)]

--- a/src/net/tcp/listener.rs
+++ b/src/net/tcp/listener.rs
@@ -92,11 +92,8 @@ impl TcpListener {
             let host = world.current_host_mut();
 
             let mut my_addr = self.local_addr;
-            if origin.ip().is_loopback() {
+            if origin.ip().is_loopback() || origin.ip().is_unspecified() {
                 my_addr.set_ip(origin.ip());
-            }
-            if my_addr.ip().is_unspecified() {
-                my_addr.set_ip(host.addr);
             }
 
             let pair = SocketPair::new(my_addr, origin);

--- a/src/net/tcp/stream.rs
+++ b/src/net/tcp/stream.rs
@@ -67,7 +67,7 @@ impl TcpStream {
 
             let host = world.current_host_mut();
             let mut local_addr = SocketAddr::new(host.addr, host.assign_ephemeral_port());
-            if dst.ip().is_loopback() {
+            if dst.ip().is_loopback() || dst.ip().is_unspecified() {
                 local_addr.set_ip(dst.ip());
             }
 

--- a/src/net/udp.rs
+++ b/src/net/udp.rs
@@ -336,7 +336,7 @@ impl UdpSocket {
 
     fn send(&self, world: &mut World, dst: SocketAddr, packet: Datagram) -> Result<()> {
         let mut src = self.local_addr;
-        if dst.ip().is_loopback() {
+        if dst.ip().is_loopback() || dst.ip().is_unspecified() {
             src.set_ip(dst.ip());
         }
         if src.ip().is_unspecified() {


### PR DESCRIPTION
This adds a test and fixes behaivor where a client may want to connect to a server listening on an unspecified ip (0.0.0.0). This is probably not the exact correct implementation but this will just route it through the loopback path.

[Playground
example](https://play.rust-lang.org/?version=stable&mode=debug&edition=2024&gist=63aad6ad0374fa62e93d83ec813faca8)