### PR TITLE
Remove prost from build-dependencies

### DIFF
--- a/examples/grpc/Cargo.toml
+++ b/examples/grpc/Cargo.toml
@@ -19,4 +19,3 @@ turmoil = { path = "../.." }
 [build-dependencies]
 tonic-build = "0.12.3"
 protox = "0.8"
-prost = "0.13"


### PR DESCRIPTION
It is already defined at the dependencies section.