### PR TITLE
Seed tokio with the world rng

### DIFF
--- a/src/sim.rs
+++ b/src/sim.rs
@@ -1,4 +1,4 @@
-use rand::seq::SliceRandom;
+use rand::{rngs::SmallRng, seq::SliceRandom, Rng, SeedableRng};
 use std::cell::RefCell;
 use std::future::Future;
 use std::net::IpAddr;
@@ -91,8 +91,11 @@ impl<'a> Sim<'a> {
             world.register(addr, &nodename, HostTimer::new(self.elapsed), &self.config);
         }
 
+        let seed = self.world.borrow_mut().rng.gen();
+        let rng = SmallRng::from_seed(seed);
         let config = rt::Config {
             enable_io: self.config.enable_tokio_io,
+            rng: Some(rng),
         };
 
         let rt = World::enter(&self.world, || Rt::client(nodename, client, config));
@@ -128,8 +131,11 @@ impl<'a> Sim<'a> {
             world.register(addr, &nodename, HostTimer::new(self.elapsed), &self.config);
         }
 
+        let seed = self.world.borrow_mut().rng.gen();
+        let rng = SmallRng::from_seed(seed);
         let config = rt::Config {
             enable_io: self.config.enable_tokio_io,
+            rng: Some(rng),
         };
 
         let rt = World::enter(&self.world, || Rt::host(nodename, host, config));


### PR DESCRIPTION
The tokio runtime builder provides [rng_seed](https://docs.rs/tokio/latest/tokio/runtime/struct.Builder.html#method.rng_seed) as a way to make "certain parts" of the runtime deterministic. We can use it to make turmoil simulations more deterministic. Turmoil already allows specifying a custom seeded world rng through `Builder::build_with_rng`. We just have to make sure that rng is used to seed the tokio runtime.

I've taken the approach of introducing a new `rt::Config` struct, to avoid having to juggle two config arguments (`enable_io` and `rng`) in multiple places. Though the juggling wouldn't be too bad either, so happy to drop the `rt::Config` struct if that's preferred.

## Caveats

* `tokio::runtime::Builder::rng_seed` is only available under the `tokio_unstable` config. Nothing we can do about that.
* The implementation skips manually seeding tokio in the `Rt::no_software` constructor. I think for now that's fine since no-software runtimes are only used for timekeeping currently. Once we start using it for more, we'll need to reconsider.