### PR TITLE
Update release type in Rust workflow

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -55,4 +55,3 @@ jobs:
         uses: obi1kenobi/cargo-semver-checks-action@v2
         with:
           uses: dtolnay/rust-toolchain@stable
-          release-type: minor


### PR DESCRIPTION
Change release type from 'minor' to default.