### PR TITLE
Add ci to check external types

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -55,3 +55,17 @@ jobs:
         uses: obi1kenobi/cargo-semver-checks-action@v2
         with:
           uses: dtolnay/rust-toolchain@stable
+
+  external-types:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+      - uses: dtolnay/rust-toolchain@master
+        with:
+          toolchain: nightly-2025-08-06
+      - name: Install cargo-check-external-types
+        uses: taiki-e/cache-cargo-install-action@v2
+        with:
+          tool: cargo-check-external-types@0.3.0
+      - uses: Swatinem/rust-cache@v2
+      - run: cargo check-external-types --all-features

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,3 +41,9 @@ regex = ["dep:regex"]
 
 [lints.rust]
 unexpected_cfgs = { level = "warn", check-cfg = ['cfg(tokio_unstable)'] }
+
+[package.metadata.cargo_check_external_types]
+allowed_external_types = [
+  "bytes::*",
+  "tokio::*",
+]


### PR DESCRIPTION
Adds a ci to check external types. This allows to detect that unintended dependencies are accidentally exposed as external API.