### PR TITLE
Let TCP peek methods take `&self`

### DIFF
--- a/src/net/tcp/split_owned.rs
+++ b/src/net/tcp/split_owned.rs
@@ -40,12 +40,8 @@ impl OwnedReadHalf {
     /// Attempts to receive data on the socket, without removing that data from
     /// the queue, registering the current task for wakeup if data is not yet
     /// available.
-    pub fn poll_peek(
-        mut self: Pin<&mut Self>,
-        cx: &mut Context<'_>,
-        buf: &mut ReadBuf,
-    ) -> Poll<io::Result<usize>> {
-        Pin::new(&mut self.inner).poll_peek(cx, buf)
+    pub fn poll_peek(&self, cx: &mut Context<'_>, buf: &mut ReadBuf) -> Poll<io::Result<usize>> {
+        self.inner.poll_peek(cx, buf)
     }
 
     /// Receives data on the socket from the remote address to which it is
@@ -53,7 +49,7 @@ impl OwnedReadHalf {
     /// returns the number of bytes peeked.
     ///
     /// Successive calls return the same data.
-    pub async fn peek(&mut self, buf: &mut [u8]) -> io::Result<usize> {
+    pub async fn peek(&self, buf: &mut [u8]) -> io::Result<usize> {
         self.inner.peek(buf).await
     }
 }

--- a/tests/tcp.rs
+++ b/tests/tcp.rs
@@ -821,7 +821,7 @@ fn peek_empty_buffer() -> Result {
     });
 
     sim.client("client", async move {
-        let mut s = TcpStream::connect(("server", PORT)).await?;
+        let s = TcpStream::connect(("server", PORT)).await?;
 
         // no-op peek with empty buffer
         let mut buf = [0; 0];


### PR DESCRIPTION
This changes the `TcpStream::peek` and the various other peek methods to take `&self` instead of `&mut self`, ensuring tokio API compatibility and making them usable in more contexts.

To achieve this, we wrap the `ReadHalf` internals in `Mutex` and `AtomicBool`, respectively. Note that we can't use `RefCell`/`Cell` here because we also require `ReadHalf` to be `Sync`.