### PR TITLE
Send RST when a TcpStream is dropped with unread data

### DIFF
--- a/src/host.rs
+++ b/src/host.rs
@@ -535,6 +535,26 @@ impl Tcp {
         Ok(())
     }
 
+    /// Returns true if the given stream has any Data segments waiting in the
+    /// out-of-order reorder buffer that have not yet been delivered to the
+    /// receive mpsc channel.
+    pub(crate) fn has_buffered_data(&self, pair: SocketPair) -> bool {
+        self.sockets
+            .get(&pair)
+            .map(|s| {
+                s.buf
+                    .values()
+                    .any(|seg| matches!(seg, SequencedSegment::Data(_)))
+            })
+            .unwrap_or(false)
+    }
+
+    /// Remove the stream socket without decrementing the half-close refcount.
+    /// Used when sending RST: the connection is torn down immediately.
+    pub(crate) fn reset_stream(&mut self, pair: SocketPair) {
+        self.sockets.swap_remove(&pair);
+    }
+
     pub(crate) fn close_stream_half(&mut self, pair: SocketPair) {
         // Receiving a RST removes the socket, so it's possible that has occurred
         // when halves of the stream drop.

--- a/src/net/tcp/stream.rs
+++ b/src/net/tcp/stream.rs
@@ -604,10 +604,7 @@ impl Drop for ReadHalf {
             // drop should stay graceful.
             let has_unread = !self.is_closed
                 && (self.rx.buffer.is_some()
-                    || matches!(
-                        self.rx.recv.try_recv(),
-                        Ok(SequencedSegment::Data(_))
-                    )
+                    || matches!(self.rx.recv.try_recv(), Ok(SequencedSegment::Data(_)))
                     || world.current_host_mut().tcp.has_buffered_data(*self.pair));
 
             if has_unread {

--- a/src/net/tcp/stream.rs
+++ b/src/net/tcp/stream.rs
@@ -592,43 +592,25 @@ impl AsyncWrite for TcpStream {
     }
 }
 
-impl ReadHalf {
-    /// Returns true if there is application-level data that was received but
-    /// never consumed by the user: partial bytes from the last segment, a
-    /// Data segment already queued on the mpsc, or a Data segment still
-    /// waiting in the host's reorder buffer.
-    ///
-    /// A queued FIN is not considered unread data — a graceful close followed
-    /// by a drop should not trigger a RST.
-    fn has_unread_data(&mut self, world: &mut World) -> bool {
-        if self.is_closed {
-            return false;
-        }
-
-        if self.rx.buffer.is_some() {
-            return true;
-        }
-
-        // Inspect the head of the mpsc. Data means unread bytes; a FIN
-        // means EOF has already been delivered (or is about to be) with no
-        // trailing data — not a reset condition. FIN is always the last
-        // segment, so looking past it is unnecessary.
-        match self.rx.recv.try_recv() {
-            Ok(SequencedSegment::Data(_)) => return true,
-            Ok(SequencedSegment::Fin) => self.is_closed = true,
-            Err(_) => {}
-        }
-
-        world.current_host_mut().tcp.has_buffered_data(*self.pair)
-    }
-}
-
 impl Drop for ReadHalf {
     fn drop(&mut self) {
         World::current_if_set(|world| {
-            if self.has_unread_data(world) {
-                // RFC 9293 §3.10.4: closing with unread data MUST send a RST
-                // so the peer learns data was lost.
+            // RFC 9293 §3.10.4: closing with unread data MUST send a RST so
+            // the peer learns data was lost. "Unread data" = application
+            // bytes received but not consumed: partial segment bytes stashed
+            // in the rx buffer, a Data segment still queued on the mpsc, or
+            // a Data segment parked in the host's reorder buffer. A queued
+            // FIN is not a reset condition — a graceful close followed by a
+            // drop should stay graceful.
+            let has_unread = !self.is_closed
+                && (self.rx.buffer.is_some()
+                    || matches!(
+                        self.rx.recv.try_recv(),
+                        Ok(SequencedSegment::Data(_))
+                    )
+                    || world.current_host_mut().tcp.has_buffered_data(*self.pair));
+
+            if has_unread {
                 let pair = *self.pair;
                 let message = Protocol::Tcp(Segment::Rst);
                 if is_same(pair.local, pair.remote) {

--- a/src/net/tcp/stream.rs
+++ b/src/net/tcp/stream.rs
@@ -592,9 +592,61 @@ impl AsyncWrite for TcpStream {
     }
 }
 
+impl ReadHalf {
+    /// Returns true if there is application-level data that was received but
+    /// never consumed by the user: partial bytes from the last segment, a
+    /// Data segment already queued on the mpsc, or a Data segment still
+    /// waiting in the host's reorder buffer.
+    ///
+    /// A queued FIN is not considered unread data — a graceful close followed
+    /// by a drop should not trigger a RST.
+    fn has_unread_data(&mut self, world: &mut World) -> bool {
+        if self.is_closed {
+            return false;
+        }
+
+        if self.rx.buffer.is_some() {
+            return true;
+        }
+
+        // Drain the mpsc looking for Data. Any Data discovered is unread;
+        // a FIN means EOF was already delivered (or about to be) with no
+        // trailing data — not a reset condition.
+        loop {
+            match self.rx.recv.try_recv() {
+                Ok(SequencedSegment::Data(_)) => return true,
+                Ok(SequencedSegment::Fin) => {
+                    self.is_closed = true;
+                    break;
+                }
+                Err(_) => break,
+            }
+        }
+
+        world.current_host_mut().tcp.has_buffered_data(*self.pair)
+    }
+}
+
 impl Drop for ReadHalf {
     fn drop(&mut self) {
         World::current_if_set(|world| {
+            if self.has_unread_data(world) {
+                // RFC 9293 §3.10.4: closing with unread data MUST send a RST
+                // so the peer learns data was lost.
+                let pair = *self.pair;
+                let message = Protocol::Tcp(Segment::Rst);
+                if is_same(pair.local, pair.remote) {
+                    send_loopback(pair.local, pair.remote, message);
+                } else {
+                    let _ = world.send_message(pair.local, pair.remote, message);
+                }
+                // Tear down locally so the sibling WriteHalf drop does not
+                // also send a FIN — seq() will return Err after the socket
+                // is gone.
+                world.current_host_mut().tcp.reset_stream(pair);
+                return;
+            }
+
             world.current_host_mut().tcp.close_stream_half(*self.pair);
         })
     }

--- a/src/net/tcp/stream.rs
+++ b/src/net/tcp/stream.rs
@@ -609,18 +609,14 @@ impl ReadHalf {
             return true;
         }
 
-        // Drain the mpsc looking for Data. Any Data discovered is unread;
-        // a FIN means EOF was already delivered (or about to be) with no
-        // trailing data — not a reset condition.
-        loop {
-            match self.rx.recv.try_recv() {
-                Ok(SequencedSegment::Data(_)) => return true,
-                Ok(SequencedSegment::Fin) => {
-                    self.is_closed = true;
-                    break;
-                }
-                Err(_) => break,
-            }
+        // Inspect the head of the mpsc. Data means unread bytes; a FIN
+        // means EOF has already been delivered (or is about to be) with no
+        // trailing data — not a reset condition. FIN is always the last
+        // segment, so looking past it is unnecessary.
+        match self.rx.recv.try_recv() {
+            Ok(SequencedSegment::Data(_)) => return true,
+            Ok(SequencedSegment::Fin) => self.is_closed = true,
+            Err(_) => {}
         }
 
         world.current_host_mut().tcp.has_buffered_data(*self.pair)

--- a/src/top.rs
+++ b/src/top.rs
@@ -465,18 +465,16 @@ impl Link {
     fn rand_partition_or_repair(&mut self, global_config: &config::Link, rand: &mut dyn RngCore) {
         let do_rand = self.rand_partition(global_config.message_loss(), rand);
         match (self.state_a_b, self.state_b_a) {
-            (State::Healthy, _) | (_, State::Healthy) => {
-                if do_rand {
-                    self.state_a_b = State::RandPartition;
-                    self.state_b_a = State::RandPartition;
+            (State::Healthy, _) | (_, State::Healthy) if do_rand => {
+                self.state_a_b = State::RandPartition;
+                self.state_b_a = State::RandPartition;
 
-                    self.sent.clear();
-                }
+                self.sent.clear();
             }
-            (State::RandPartition, _) | (_, State::RandPartition) => {
-                if self.rand_repair(global_config.message_loss(), rand) {
-                    self.release();
-                }
+            (State::RandPartition, _) | (_, State::RandPartition)
+                if self.rand_repair(global_config.message_loss(), rand) =>
+            {
+                self.release();
             }
             _ => {}
         }

--- a/tests/net/tcp.rs
+++ b/tests/net/tcp.rs
@@ -1750,11 +1750,13 @@ fn close_with_unread_data_sends_rst() -> Result {
     });
 
     sim.client("client", async move {
-        let s = TcpStream::connect(("server", PORT)).await?;
+        let mut s = TcpStream::connect(("server", PORT)).await?;
 
-        // Give the server's data time to arrive in our receive queue before
-        // we drop without reading.
-        tokio::time::sleep(Duration::from_secs(1)).await;
+        // Block until at least one byte has arrived in our receive queue,
+        // then drop without consuming it. Peek stashes the bytes in the rx
+        // buffer so they count as unread at drop time.
+        let mut buf = [0; 1];
+        assert!(s.peek(&mut buf).await? >= 1);
 
         drop(s);
 

--- a/tests/net/tcp.rs
+++ b/tests/net/tcp.rs
@@ -1717,3 +1717,49 @@ fn tcp_backpressure_on_loopback() {
 
     sim.run().unwrap();
 }
+
+// https://github.com/tokio-rs/turmoil/issues/158
+//
+// Per RFC 9293 §3.10.4, if a receiver closes the connection while there is
+// still unread data in the receive queue, the stack MUST send a RST rather
+// than a graceful FIN so the peer learns data was lost.
+#[test]
+fn close_with_unread_data_sends_rst() -> Result {
+    let mut sim = Builder::new().build();
+
+    sim.client("server", async move {
+        let listener = bind().await?;
+        let (mut s, _) = listener.accept().await?;
+
+        // Send some data the client will never read.
+        s.write_all(b"unread").await?;
+
+        // Next I/O on the connection should observe a RST (ConnectionReset),
+        // not a graceful EOF.
+        let mut buf = [0; 8];
+        let err = loop {
+            match s.read(&mut buf).await {
+                Ok(0) => panic!("expected RST, got graceful EOF"),
+                Ok(_) => continue,
+                Err(e) => break e,
+            }
+        };
+        assert_eq!(io::ErrorKind::ConnectionReset, err.kind());
+
+        Ok(())
+    });
+
+    sim.client("client", async move {
+        let s = TcpStream::connect(("server", PORT)).await?;
+
+        // Give the server's data time to arrive in our receive queue before
+        // we drop without reading.
+        tokio::time::sleep(Duration::from_secs(1)).await;
+
+        drop(s);
+
+        Ok(())
+    });
+
+    sim.run()
+}


### PR DESCRIPTION
## Summary
- RFC 9293 §3.10.4: a receiver closing with unread bytes must send RST, not FIN. Previously the ReadHalf drop path fell through to the sibling WriteHalf's FIN, so peers saw a graceful EOF even when data was discarded.
- `ReadHalf::drop` now checks its partial buffer, the mpsc channel, and the host-side reorder buffer for undelivered `Data`. If any is found it emits `Segment::Rst` and tears down the socket locally, which also suppresses the sibling `WriteHalf`'s FIN (via `seq()` returning `Err`).
- Queued FINs are intentionally not treated as a reset condition — a graceful close followed by a drop stays graceful.

Fixes #158.