### PR TITLE
Bump to 0.7.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,25 @@
+# 0.7.2 (April 24, 2026)
+
+### Added
+
+- Add end-to-end flow control for TCP streams ([#265])
+
+[#265]: https://github.com/tokio-rs/turmoil/pull/265
+
+### Changed
+
+- Send RST when a TcpStream is dropped with unread data ([#269])
+- Enforce O_DIRECT buffer alignment in simulated filesystem ([#266])
+- Drop parking_lot from tokio feature list ([#267])
+- Remove experimental disclaimer from README ([#268])
+- Fix rng warning and flakey example test ([#263])
+
+[#263]: https://github.com/tokio-rs/turmoil/pull/263
+[#266]: https://github.com/tokio-rs/turmoil/pull/266
+[#267]: https://github.com/tokio-rs/turmoil/pull/267
+[#268]: https://github.com/tokio-rs/turmoil/pull/268
+[#269]: https://github.com/tokio-rs/turmoil/pull/269
+
 # 0.7.1 (January 29, 2026)
 
 ### Added

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,7 @@ name = "turmoil"
 #   - README.md
 # - Update CHANGELOG.md
 # - Create git tag
-version = "0.7.1"
+version = "0.7.2"
 edition = "2021"
 license = "MIT"
 authors = ["Tokio Contributors <team@tokio.rs>"]


### PR DESCRIPTION
## Summary
- Version bump to 0.7.2 and `CHANGELOG.md` entry covering commits since 0.7.1.