### PR TITLE
Update to cargo-check-external-types 0.4.0

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -62,10 +62,10 @@ jobs:
       - uses: actions/checkout@v5
       - uses: dtolnay/rust-toolchain@master
         with:
-          toolchain: nightly-2025-08-06
+          toolchain: nightly-2025-10-18
       - name: Install cargo-check-external-types
         uses: taiki-e/cache-cargo-install-action@v2
         with:
-          tool: cargo-check-external-types@0.3.0
+          tool: cargo-check-external-types@0.4.0
       - uses: Swatinem/rust-cache@v2
       - run: cargo check-external-types --all-features


### PR DESCRIPTION
Updates to `cargo-check-external-types` 0.4.0.

https://github.com/awslabs/cargo-check-external-types/releases/tag/v0.4.0