### PR TITLE
Scaffold empty turmoil-fs crate

### DIFF
--- a/.github/workflows/rust.yml
+++ b/.github/workflows/rust.yml
@@ -44,7 +44,7 @@ jobs:
       - name: Rust Toolchain
         uses: dtolnay/rust-toolchain@stable
       - name: Run cargo clippy
-        run: cargo clippy -p turmoil -p turmoil-net --all-targets -- --deny warnings
+        run: cargo clippy -p turmoil -p turmoil-net -p turmoil-fs --all-targets -- --deny warnings
 
   semver:
     name: semver

--- a/crates/turmoil-fs/Cargo.toml
+++ b/crates/turmoil-fs/Cargo.toml
@@ -1,0 +1,18 @@
+[package]
+name = "turmoil-fs"
+version = "0.0.0"
+edition = "2021"
+license = "MIT"
+authors = ["Tokio Contributors <team@tokio.rs>"]
+description = "Simulated filesystem for turmoil"
+homepage = "https://github.com/tokio-rs/turmoil"
+repository = "https://github.com/tokio-rs/turmoil"
+publish = false
+
+[dependencies]
+bytes = "1.4"
+tokio = { version = "1.25.0", features = ["fs", "io-util", "sync", "time"] }
+tracing = "0.1"
+
+[lints.rust]
+unexpected_cfgs = { level = "warn", check-cfg = ['cfg(tokio_unstable)'] }

--- a/crates/turmoil-fs/src/kernel/mod.rs
+++ b/crates/turmoil-fs/src/kernel/mod.rs
@@ -1,0 +1,5 @@
+//! Authoritative filesystem implementation.
+//!
+//! TODO: lift the per-host namespace, inode/file table, pending/synced
+//! durability state, crash recovery, and O_DIRECT alignment rules out of
+//! `turmoil::fs` into this module.

--- a/crates/turmoil-fs/src/lib.rs
+++ b/crates/turmoil-fs/src/lib.rs
@@ -1,0 +1,11 @@
+//! Simulated filesystem for turmoil.
+//!
+//! This crate will house the filesystem layer currently living in
+//! `turmoil::fs`, factored out along the same kernel/shim split used by
+//! `turmoil-net`. The [`kernel`] module will hold the authoritative
+//! implementation (per-host namespace, durability model, pending/synced
+//! state), and [`shim`] will provide drop-in replacements for `std::fs`,
+//! `std::os::unix::fs`, and `tokio::fs`.
+
+pub mod kernel;
+pub mod shim;

--- a/crates/turmoil-fs/src/shim/mod.rs
+++ b/crates/turmoil-fs/src/shim/mod.rs
@@ -1,0 +1,4 @@
+//! Drop-in shims over the [`kernel`](crate::kernel) filesystem layer.
+
+pub mod std;
+pub mod tokio;

--- a/crates/turmoil-fs/src/shim/std/fs/mod.rs
+++ b/crates/turmoil-fs/src/shim/std/fs/mod.rs
@@ -1,0 +1,5 @@
+//! `std::fs` shim.
+//!
+//! TODO: `File`, `OpenOptions`, `Metadata`, and free functions
+//! (`create_dir`, `rename`, `remove_file`, `canonicalize`, ...). Implement
+//! `std::io::{Read, Write, Seek}` on the shimmed `File`.

--- a/crates/turmoil-fs/src/shim/std/mod.rs
+++ b/crates/turmoil-fs/src/shim/std/mod.rs
@@ -1,0 +1,4 @@
+//! Drop-in replacements for `std::fs` and `std::os::unix::fs` types.
+
+pub mod fs;
+pub mod os;

--- a/crates/turmoil-fs/src/shim/std/os/mod.rs
+++ b/crates/turmoil-fs/src/shim/std/os/mod.rs
@@ -1,0 +1,1 @@
+pub mod unix;

--- a/crates/turmoil-fs/src/shim/std/os/unix/fs/mod.rs
+++ b/crates/turmoil-fs/src/shim/std/os/unix/fs/mod.rs
@@ -1,0 +1,4 @@
+//! `std::os::unix::fs` shim.
+//!
+//! TODO: implement `std::os::unix::fs::FileExt` / `OpenOptionsExt` on the
+//! shimmed types so real std traits keep working.

--- a/crates/turmoil-fs/src/shim/std/os/unix/mod.rs
+++ b/crates/turmoil-fs/src/shim/std/os/unix/mod.rs
@@ -1,0 +1,1 @@
+pub mod fs;

--- a/crates/turmoil-fs/src/shim/tokio/fs/mod.rs
+++ b/crates/turmoil-fs/src/shim/tokio/fs/mod.rs
@@ -1,0 +1,4 @@
+//! `tokio::fs` shim.
+//!
+//! TODO: async `File`, `OpenOptions`, and free functions. `File` implements
+//! `AsyncRead`/`AsyncWrite`/`AsyncSeek`.

--- a/crates/turmoil-fs/src/shim/tokio/mod.rs
+++ b/crates/turmoil-fs/src/shim/tokio/mod.rs
@@ -1,0 +1,3 @@
+//! Tokio-shaped shim over the kernel filesystem layer.
+
+pub mod fs;


### PR DESCRIPTION
## Summary

- Mirror the `turmoil-net` structure for a future filesystem extraction: `kernel/` + `shim/{std,tokio}` with an `FsRuntime` trait sketch in `lib.rs`.
- No implementation — just the module skeleton so the eventual lift-out of `turmoil::fs` has a home.
- Extends the clippy CI scope to include `-p turmoil-fs`.