### PR TITLE
ci: automate releases with release-plz

### DIFF
--- a/.github/workflows/release-plz.yml
+++ b/.github/workflows/release-plz.yml
@@ -1,0 +1,55 @@
+name: Release-plz
+
+on:
+  push:
+    branches:
+      - main
+
+jobs:
+  release-plz-release:
+    name: Release-plz release
+    if: ${{ github.repository_owner == 'tokio-rs' }}
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+      - name: Run release-plz
+        uses: release-plz/action@v0.5
+        with:
+          command: release
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}
+
+  release-plz-pr:
+    name: Release-plz PR
+    if: ${{ github.repository_owner == 'tokio-rs' }}
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+      pull-requests: write
+    concurrency:
+      group: release-plz-${{ github.ref }}
+      cancel-in-progress: false
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+      - name: Install Rust toolchain
+        uses: dtolnay/rust-toolchain@stable
+      - name: Run release-plz
+        uses: release-plz/action@v0.5
+        with:
+          command: release-pr
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          CARGO_REGISTRY_TOKEN: ${{ secrets.CARGO_REGISTRY_TOKEN }}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,62 @@
+# turmoil — Claude notes
+
+Deterministic simulation-testing framework for distributed systems. See
+`README.md` for user-facing docs and `CONTRIBUTING.md` for the full contributor
+workflow.
+
+## Workspace
+
+- `crates/turmoil` — published core crate (`0.7.x`).
+- `crates/turmoil-net` — scaffold; simulated socket layer. Not yet published.
+- `crates/turmoil-fs` — scaffold; simulated filesystem. Not yet published.
+- `examples/*` — non-published example crates that depend on `turmoil` via path.
+
+## Commands
+
+```sh
+cargo test --workspace
+cargo test --workspace --features regex
+cargo fmt --check
+cargo clippy -p turmoil -p turmoil-net -p turmoil-fs --all-targets -- --deny warnings
+```
+
+Public-API drift on `turmoil` is gated by `cargo-check-external-types` (nightly
+toolchain pinned in `.github/workflows/rust.yml`). Allowed external types are
+listed in `crates/turmoil/Cargo.toml` under
+`[package.metadata.cargo_check_external_types]`.
+
+## Commit style
+
+Conventional Commits. `release-plz` parses these to pick version bumps and
+generate the changelog, so this is load-bearing — not cosmetic.
+
+- `feat:` → minor bump, `fix:`/`perf:` → patch bump.
+- `docs:`, `refactor:`, `test:`, `chore:`, `build:` → no bump.
+- Breaking: `feat!:` or `BREAKING CHANGE:` footer.
+- Scope when localized: `feat(net):`, `fix(fs):`, `fix(turmoil):`.
+
+See `CONTRIBUTING.md` for the full table and examples.
+
+## Releases
+
+Automated by release-plz (`.github/workflows/release-plz.yml`,
+`release-plz.toml`):
+
+- Every push to `main` opens/updates a "release PR" with version bumps +
+  `CHANGELOG.md`.
+- Merging that PR publishes to crates.io, tags, and cuts a GitHub Release.
+- `turmoil-net` and `turmoil-fs` are excluded (`release = false`) until their
+  first manual publish to crates.io — release-plz can't create new crates.
+
+To group changes into one release: leave the release PR open; it rolls in new
+commits automatically on each push.
+
+## Gotchas
+
+- `examples/*` crates have `publish = false` — never add them to the release
+  flow.
+- The `unstable-fs` and `unstable-barriers` features in `turmoil` are not
+  covered by semver; changes there don't need a major bump.
+- README doctests run as part of `cargo test --workspace` via `doc-comment`;
+  if you move `README.md`, fix the include path in
+  `crates/turmoil/src/readme.rs`.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,93 @@
+# Contributing to turmoil
+
+Thanks for your interest in contributing. This document covers the workflow for
+landing changes in this repo.
+
+## Workspace layout
+
+```
+crates/
+  turmoil/       # published core crate
+  turmoil-net/   # scaffold, not yet published
+  turmoil-fs/    # scaffold, not yet published
+examples/        # non-published example crates
+```
+
+## Local checks
+
+Before opening a PR, run:
+
+```sh
+cargo fmt --check
+cargo clippy -p turmoil -p turmoil-net -p turmoil-fs --all-targets -- --deny warnings
+cargo test --workspace
+cargo test --workspace --features regex
+```
+
+Public-API drift on `turmoil` is gated by `cargo-check-external-types` in CI.
+
+## Commit style
+
+This repo uses [Conventional Commits](https://www.conventionalcommits.org/).
+`release-plz` parses commit messages to decide version bumps and to generate
+the changelog, so following the convention matters.
+
+Format:
+
+```
+<type>(<optional scope>): <short summary>
+
+<optional body>
+
+<optional footers>
+```
+
+Common types:
+
+| Type       | Use for                                        | Bump  |
+|------------|------------------------------------------------|-------|
+| `feat`     | new user-visible functionality                 | minor |
+| `fix`      | bug fix                                        | patch |
+| `perf`     | performance improvement                        | patch |
+| `docs`     | documentation only                             | none  |
+| `refactor` | internal change, no behavior change            | none  |
+| `test`     | tests only                                     | none  |
+| `chore`    | tooling, CI, deps, etc.                        | none  |
+| `build`    | build system / packaging                       | none  |
+
+Breaking changes: append `!` after the type (e.g. `feat!: ...`) or add a
+`BREAKING CHANGE:` footer. These produce a major bump (or a minor bump while
+`0.x`).
+
+Scopes are optional but useful when a change is localized to one crate:
+`feat(net): ...`, `fix(fs): ...`, `fix(turmoil): ...`.
+
+Examples:
+
+```
+feat(net): add UdpSocket::peek
+fix: avoid panic when host crashes during send
+refactor(turmoil): extract rng helpers
+feat!: replace Builder::fs_sync with fs_sync_probability
+```
+
+## Releases
+
+Releases are automated via [release-plz](https://release-plz.dev/).
+
+1. Merge conventional-commit PRs into `main`.
+2. release-plz opens (or updates) a **release PR** with version bumps and a
+   generated `CHANGELOG.md`. Review it as you would any PR.
+3. Merging the release PR publishes to crates.io, creates the git tag, and
+   cuts a GitHub Release.
+
+To group multiple changes into one release, just leave the release PR open;
+it updates on each push to `main` and rolls in new commits automatically.
+
+`turmoil-net` and `turmoil-fs` are not yet published — they are excluded from
+the release flow in `release-plz.toml` until their first manual publish.
+
+## License
+
+By contributing, you agree that your contributions will be licensed under the
+MIT license, as stated in the README.

--- a/crates/turmoil/Cargo.toml
+++ b/crates/turmoil/Cargo.toml
@@ -1,10 +1,5 @@
 [package]
 name = "turmoil"
-# When releasing to crates.io:
-# - Update version number
-#   - README.md
-# - Update CHANGELOG.md
-# - Create git tag
 version = "0.7.2"
 edition = "2021"
 license = "MIT"

--- a/release-plz.toml
+++ b/release-plz.toml
@@ -1,0 +1,14 @@
+[workspace]
+changelog_update = true
+git_release_enable = true
+git_tag_enable = true
+semver_check = true
+publish = true
+
+[[package]]
+name = "turmoil-net"
+release = false
+
+[[package]]
+name = "turmoil-fs"
+release = false


### PR DESCRIPTION
## Summary
- Adds `.github/workflows/release-plz.yml` with `release-pr` + `release` jobs, gated on `github.repository_owner == 'tokio-rs'`.
- Adds `release-plz.toml` enabling semver checks, changelog, tags, and GitHub releases. `turmoil-net` and `turmoil-fs` set to `release = false` until their first manual publish.
- Adds `CONTRIBUTING.md` covering workspace layout, local checks, Conventional Commits (which release-plz depends on), and the release flow.
- Adds `CLAUDE.md` as a terser repo guide for Claude Code sessions.
- Drops the stale "When releasing to crates.io" comment from `crates/turmoil/Cargo.toml` — release-plz owns that now.

## Manual steps before merging
- Repo settings → Actions → General → Workflow permissions: allow Actions to create and approve pull requests.
- Add `CARGO_REGISTRY_TOKEN` repo secret (crates.io token scoped to `publish-update` for `turmoil`), or switch to trusted publishing and add `id-token: write` to the `release` job.

## Follow-ups (not in this PR)
- When `turmoil-net` / `turmoil-fs` are ready to ship: flip `publish = false` → `true`, do a one-time manual `cargo publish`, then remove their overrides from `release-plz.toml`.
- Optional: PR-title lint action to enforce Conventional Commits if we squash-merge.