### PR TITLE
feat(fs): add short_read_probability fault injection

### DIFF
--- a/crates/turmoil/src/fs/mod.rs
+++ b/crates/turmoil/src/fs/mod.rs
@@ -582,9 +582,9 @@ impl FsConfig {
     ///
     /// When set, reads through `File::read`, `File::read_at`, and their async
     /// equivalents may randomly return fewer bytes than requested, even when
-    /// more data is available. This simulates the short-read behavior of plain
-    /// `pread` on real kernels (e.g., interrupted syscalls, partial reads from
-    /// non-`O_DIRECT` file descriptors).
+    /// more data is available. This simulates the short-read behavior of
+    /// `pread` on real kernels (e.g., `EINTR` interrupting a blocking syscall).
+    /// O_DIRECT reads are not exempt — signals can short-circuit them too.
     ///
     /// The tail of the buffer past the returned count is zeroed, so callers
     /// that incorrectly treat the result as a full buffer observe garbage

--- a/crates/turmoil/src/fs/mod.rs
+++ b/crates/turmoil/src/fs/mod.rs
@@ -465,6 +465,7 @@ impl PageCacheConfig {
 /// - `capacity`: None (unlimited)
 /// - `io_error_probability`: 0.0 (no random I/O errors)
 /// - `corruption_probability`: 0.0 (no silent corruption)
+/// - `short_read_probability`: 0.0 (positional reads always return the full count)
 /// - `noatime`: true (access time not updated on reads)
 /// - `direct_io_alignment`: 512 (minimum kernel alignment for O_DIRECT)
 /// - `block_size`: None (writes are atomic, no torn writes)
@@ -480,6 +481,8 @@ pub struct FsConfig {
     pub(crate) io_error_probability: f64,
     /// Probability of silent data corruption on reads (0.0 - 1.0)
     pub(crate) corruption_probability: f64,
+    /// Probability that a positional read returns a short count (0.0 - 1.0)
+    pub(crate) short_read_probability: f64,
     /// Whether to use noatime semantics (atime not updated on reads)
     pub(crate) noatime: bool,
     /// Required alignment in bytes for O_DIRECT I/O (buffer pointer, offset, and length)
@@ -499,6 +502,7 @@ impl Default for FsConfig {
             capacity: None,
             io_error_probability: 0.0,
             corruption_probability: 0.0,
+            short_read_probability: 0.0,
             noatime: true,
             direct_io_alignment: 512,
             block_size: None,
@@ -569,6 +573,29 @@ impl FsConfig {
             "corruption_probability must be between 0.0 and 1.0"
         );
         self.corruption_probability = value;
+        self
+    }
+
+    /// Set the probability that a positional read returns a short count (0.0 - 1.0).
+    ///
+    /// Default: 0.0 (reads always return the full requested count, subject to EOF).
+    ///
+    /// When set, reads through `File::read`, `File::read_at`, and their async
+    /// equivalents may randomly return fewer bytes than requested, even when
+    /// more data is available. This simulates the short-read behavior of plain
+    /// `pread` on real kernels (e.g., interrupted syscalls, partial reads from
+    /// non-`O_DIRECT` file descriptors).
+    ///
+    /// The tail of the buffer past the returned count is zeroed, so callers
+    /// that incorrectly treat the result as a full buffer observe garbage
+    /// instead of silently-correct data. Callers that loop until the requested
+    /// length is reached (or `Ok(0)` / EOF) keep working.
+    pub fn short_read_probability(&mut self, value: f64) -> &mut Self {
+        assert!(
+            (0.0..=1.0).contains(&value),
+            "short_read_probability must be between 0.0 and 1.0"
+        );
+        self.short_read_probability = value;
         self
     }
 
@@ -982,6 +1009,8 @@ pub(crate) struct Fs {
     pub(crate) io_error_probability: f64,
     /// Probability of silent data corruption on reads (0.0 - 1.0)
     pub(crate) corruption_probability: f64,
+    /// Probability that a positional read returns a short count (0.0 - 1.0)
+    pub(crate) short_read_probability: f64,
     /// Required alignment in bytes for O_DIRECT I/O
     pub(crate) direct_io_alignment: u64,
     /// Block size for torn write simulation (None = atomic writes)
@@ -1013,6 +1042,7 @@ impl Fs {
             capacity: config.capacity,
             io_error_probability: config.io_error_probability,
             corruption_probability: config.corruption_probability,
+            short_read_probability: config.short_read_probability,
             direct_io_alignment: config.direct_io_alignment,
             block_size: config.block_size,
             io_latency: config.io_latency,

--- a/crates/turmoil/src/fs/shim/std/fs/mod.rs
+++ b/crates/turmoil/src/fs/shim/std/fs/mod.rs
@@ -758,8 +758,24 @@ impl File {
                 .ok_or_else(|| Error::new(ErrorKind::NotFound, "file handle not found"))?
                 .clone();
             let corruption_prob = ctx.fs.corruption_probability;
+            let short_read_prob = ctx.fs.short_read_probability;
 
-            let n = ctx.fs.read_file(&path, buf, offset);
+            let mut n = ctx.fs.read_file(&path, buf, offset);
+
+            // Inject a short read: trim the reported count to something strictly
+            // smaller than what was actually filled, and zero the tail so callers
+            // that incorrectly assume full-read semantics observe garbage instead
+            // of silently-correct data. We only do this when at least 2 bytes
+            // were read, so the returned count is still > 0 (a return of 0 means
+            // EOF, which is a distinct signal we don't want to fake). O_DIRECT
+            // paths skip this — aligned O_DIRECT pread on a real kernel returns
+            // either the full count or EOF.
+            if !self.direct_io && n > 1 && short_read_prob > 0.0 && ctx.random_bool(short_read_prob)
+            {
+                let short = ctx.random_range(1..n);
+                buf[short..n].fill(0);
+                n = short;
+            }
 
             // Check for random silent corruption
             if n > 0 && corruption_prob > 0.0 && ctx.random_bool(corruption_prob) {

--- a/crates/turmoil/src/fs/shim/std/fs/mod.rs
+++ b/crates/turmoil/src/fs/shim/std/fs/mod.rs
@@ -767,11 +767,10 @@ impl File {
             // that incorrectly assume full-read semantics observe garbage instead
             // of silently-correct data. We only do this when at least 2 bytes
             // were read, so the returned count is still > 0 (a return of 0 means
-            // EOF, which is a distinct signal we don't want to fake). O_DIRECT
-            // paths skip this — aligned O_DIRECT pread on a real kernel returns
-            // either the full count or EOF.
-            if !self.direct_io && n > 1 && short_read_prob > 0.0 && ctx.random_bool(short_read_prob)
-            {
+            // EOF, which is a distinct signal we don't want to fake). This
+            // applies to O_DIRECT too — signals (EINTR) can short-circuit any
+            // blocking syscall, including aligned O_DIRECT pread.
+            if n > 1 && short_read_prob > 0.0 && ctx.random_bool(short_read_prob) {
                 let short = ctx.random_range(1..n);
                 buf[short..n].fill(0);
                 n = short;

--- a/crates/turmoil/tests/fs/durability.rs
+++ b/crates/turmoil/tests/fs/durability.rs
@@ -545,6 +545,106 @@ fn corruption_probability_statistical(prob: f64, expected_rate: f64, tolerance: 
 }
 
 #[test]
+fn short_read_100_percent() -> Result {
+    let mut builder = Builder::new();
+    builder.fs().short_read_probability(1.0);
+    let mut sim = builder.build();
+    sim.client("test", async {
+        create_dir("/data")?;
+        let file = OpenOptions::new()
+            .read(true)
+            .write(true)
+            .create(true)
+            .open("/data/file.txt")?;
+        file.write_all_at(b"0123456789abcdef", 0)?;
+        let mut buf = [0u8; 16];
+        let n = file.read_at(&mut buf, 0)?;
+        assert!((1..16).contains(&n), "short read produced count {n}");
+        assert_eq!(&buf[..n], &b"0123456789abcdef"[..n]);
+        Ok(())
+    });
+    sim.run()
+}
+
+#[test]
+fn short_read_skipped_for_direct_io() -> Result {
+    // O_DIRECT with aligned args must return the full count or EOF on real
+    // kernels, so the short-read injection must not fire for direct_io files.
+    use std::alloc::{alloc_zeroed, dealloc, Layout};
+
+    let mut builder = Builder::new();
+    builder.fs().short_read_probability(1.0);
+    let mut sim = builder.build();
+    sim.client("test", async {
+        create_dir("/data")?;
+        // Seed the file with 512 bytes via a non-direct handle.
+        let writer = OpenOptions::new()
+            .read(true)
+            .write(true)
+            .create(true)
+            .open("/data/file.txt")?;
+        writer.write_all_at(&vec![0xabu8; 512], 0)?;
+        drop(writer);
+
+        let direct = OpenOptions::new()
+            .read(true)
+            .direct_io(true)
+            .open("/data/file.txt")?;
+
+        unsafe {
+            let layout = Layout::from_size_align(512, 512).unwrap();
+            let ptr = alloc_zeroed(layout);
+            assert!(!ptr.is_null());
+            let buf = std::slice::from_raw_parts_mut(ptr, 512);
+            let n = direct.read_at(buf, 0)?;
+            assert_eq!(n, 512, "direct_io read must not be shortened");
+            dealloc(ptr, layout);
+        }
+        Ok(())
+    });
+    sim.run()
+}
+
+#[test_case(0.0, 0.0, 0.05; "no short reads")]
+#[test_case(0.5, 0.5, 0.15; "50 percent short reads")]
+#[test_case(1.0, 1.0, 0.05; "always short reads")]
+fn short_read_probability_statistical(prob: f64, expected_rate: f64, tolerance: f64) -> Result {
+    const ITERATIONS: usize = 100;
+    let mut short_count = 0;
+    for seed in 0..ITERATIONS {
+        let mut builder = Builder::new();
+        builder.rng_seed(seed as u64);
+        builder.fs().short_read_probability(prob);
+        let mut sim = builder.build();
+        let result = std::sync::Arc::new(std::sync::Mutex::new(false));
+        let r = result.clone();
+        sim.client("test", async move {
+            create_dir("/data")?;
+            let file = OpenOptions::new()
+                .read(true)
+                .write(true)
+                .create(true)
+                .open("/data/file.txt")?;
+            file.write_all_at(b"0123456789abcdef", 0)?;
+            let mut buf = [0u8; 16];
+            let n = file.read_at(&mut buf, 0)?;
+            *r.lock().unwrap() = n < 16;
+            Ok(())
+        });
+        sim.run()?;
+        if *result.lock().unwrap() {
+            short_count += 1;
+        }
+    }
+    let actual_rate = short_count as f64 / ITERATIONS as f64;
+    assert!(
+        (actual_rate - expected_rate).abs() <= tolerance,
+        "expected rate {expected_rate} +/- {tolerance}, got {actual_rate}"
+    );
+    Ok(())
+}
+
+#[test]
 fn torn_write_partial_data_survives() -> Result {
     // With block_size configured, writes may be partially applied on crash.
     // Run many iterations to statistically verify torn writes occur.

--- a/crates/turmoil/tests/fs/durability.rs
+++ b/crates/turmoil/tests/fs/durability.rs
@@ -567,9 +567,9 @@ fn short_read_100_percent() -> Result {
 }
 
 #[test]
-fn short_read_skipped_for_direct_io() -> Result {
-    // O_DIRECT with aligned args must return the full count or EOF on real
-    // kernels, so the short-read injection must not fire for direct_io files.
+fn short_read_also_fires_for_direct_io() -> Result {
+    // Signals (EINTR) can interrupt any blocking syscall, including aligned
+    // O_DIRECT pread, so short reads must also be injected on direct_io files.
     use std::alloc::{alloc_zeroed, dealloc, Layout};
 
     let mut builder = Builder::new();
@@ -597,7 +597,10 @@ fn short_read_skipped_for_direct_io() -> Result {
             assert!(!ptr.is_null());
             let buf = std::slice::from_raw_parts_mut(ptr, 512);
             let n = direct.read_at(buf, 0)?;
-            assert_eq!(n, 512, "direct_io read must not be shortened");
+            assert!(
+                (1..512).contains(&n),
+                "direct_io read should also see a short count, got {n}"
+            );
             dealloc(ptr, layout);
         }
         Ok(())


### PR DESCRIPTION
## Summary

Adds a short-read fault-injection knob for the simulated filesystem, per #279.

`FsConfig::short_read_probability` causes positional reads through `File::read`, `File::read_at`, and their async equivalents to randomly return fewer bytes than requested with the configured probability. The tail of the buffer past the returned count is zeroed, so callers that incorrectly treat the result as a full buffer observe garbage instead of silently-correct data. Well-behaved callers that loop until the requested length is reached (or hit `Ok(0)` / EOF) keep working.

Injection fires on O_DIRECT reads too — signals (`EINTR`) can interrupt any blocking syscall, including aligned O_DIRECT `pread`.

```rust
let mut builder = Builder::new();
builder.fs().short_read_probability(0.1);  // 10% chance of a short read
```

Closes #279.

## Test plan

- [x] `cargo fmt --check`
- [x] `cargo clippy -p turmoil -p turmoil-net -p turmoil-fs --all-targets -- --deny warnings`
- [x] `cargo test --workspace`
- [x] `cargo test --workspace --features regex`
- [x] `cargo test --workspace --features unstable-fs` (new tests: `short_read_100_percent`, `short_read_also_fires_for_direct_io`, `short_read_probability_statistical` at 0%/50%/100%)