### PR TITLE
refactor(turmoil-net): let callers own the egress buffer

### DIFF
--- a/crates/turmoil-net/src/fabric.rs
+++ b/crates/turmoil-net/src/fabric.rs
@@ -105,9 +105,7 @@ impl Fabric {
     /// source host's `deliver` inline (inside `Kernel::egress`) and
     /// never appear in `out`.
     pub fn egress_all(&mut self, out: &mut Vec<Packet>) {
-        let ids: Vec<_> = self.hosts.keys().copied().collect();
-        for id in ids {
-            let host = self.hosts.get_mut(&id).expect("id from iteration");
+        for host in self.hosts.values_mut() {
             host.kernel.egress(out);
         }
     }

--- a/crates/turmoil-net/src/fabric.rs
+++ b/crates/turmoil-net/src/fabric.rs
@@ -98,19 +98,18 @@ impl Fabric {
         self.ip_to_host.get(&ip).copied()
     }
 
-    /// Drain outbound packets from every host, in host-insertion order.
-    /// The caller decides what happens to each packet — deliver, drop,
-    /// schedule for later. Loopback packets fold back through the
+    /// Drain outbound packets from every host, in host-insertion order,
+    /// appending to `out`. The caller decides what happens to each
+    /// packet — deliver, drop, schedule for later — and reuses the
+    /// buffer across ticks. Loopback packets fold back through the
     /// source host's `deliver` inline (inside `Kernel::egress`) and
-    /// never appear here.
-    pub fn egress_all(&mut self) -> Vec<Packet> {
-        let mut out = Vec::new();
+    /// never appear in `out`.
+    pub fn egress_all(&mut self, out: &mut Vec<Packet>) {
         let ids: Vec<_> = self.hosts.keys().copied().collect();
         for id in ids {
             let host = self.hosts.get_mut(&id).expect("id from iteration");
-            out.extend(host.kernel.egress());
+            host.kernel.egress(out);
         }
-        out
     }
 
     /// Route a packet to the host bound to its destination IP. Drops

--- a/crates/turmoil-net/src/fixture/scheduler.rs
+++ b/crates/turmoil-net/src/fixture/scheduler.rs
@@ -32,11 +32,17 @@ pub(crate) struct Scheduler {
     /// contiguous drain.
     pending: Vec<Scheduled>,
     next_seq: u64,
+    /// Reused egress buffer, refilled each `tick` and drained by end
+    /// of `tick`. Preallocated to skip the first few grows on startup.
+    egress: Vec<Packet>,
 }
 
 impl Scheduler {
     pub fn new() -> Self {
-        Self::default()
+        Self {
+            egress: Vec::with_capacity(64),
+            ..Self::default()
+        }
     }
 
     /// One fabric tick:
@@ -57,7 +63,12 @@ impl Scheduler {
             guard.deliver(s.pkt);
         }
 
-        for pkt in guard.egress_all() {
+        // Move the buffer out to a local: `schedule` (below) needs
+        // `&mut self`, which collides with a borrow of `self.egress`.
+        // Swapping it back at the end preserves the allocation.
+        let mut egress = std::mem::take(&mut self.egress);
+        guard.egress_all(&mut egress);
+        for pkt in egress.drain(..) {
             match guard.evaluate(&pkt) {
                 Verdict::Drop => {}
                 Verdict::Deliver(d) if d.is_zero() => guard.deliver(pkt),
@@ -65,6 +76,7 @@ impl Scheduler {
                 Verdict::Pass => guard.deliver(pkt),
             }
         }
+        self.egress = egress;
     }
 
     fn schedule(&mut self, pkt: Packet, delay: Duration) {

--- a/crates/turmoil-net/src/kernel/mod.rs
+++ b/crates/turmoil-net/src/kernel/mod.rs
@@ -591,19 +591,19 @@ impl Kernel {
         }
     }
 
-    /// Take all packets the stack has produced since the last call.
+    /// Drain packets the stack has produced since the last call,
+    /// appending those leaving this host to `out`. Passing the buffer
+    /// in lets callers amortize the allocation across ticks.
     ///
     /// Runs TCP segmentation first (draining each established socket's
     /// `send_buf` into MSS-sized segments on `outbound`), then drains
     /// `outbound`. Loopback packets fold back through
-    /// [`deliver`](Self::deliver) inline; the returned vec holds only
-    /// packets that need to leave this host.
+    /// [`deliver`](Self::deliver) inline and never reach `out`.
     ///
     /// Loops until a full pass produces no new outbound packets, so
     /// that an ACK folded through `deliver` can open a window and let
     /// the next segmentation pass pick up queued bytes.
-    pub fn egress(&mut self) -> Vec<Packet> {
-        let mut leaving = Vec::new();
+    pub fn egress(&mut self, out: &mut Vec<Packet>) {
         // Count-based retx check runs once per egress, before
         // segmentation — if it rewinds snd_nxt for a socket, this
         // call's segment_all pass picks up the re-emission.
@@ -618,13 +618,12 @@ impl Kernel {
                 if self.is_local(pkt.dst) {
                     self.deliver(pkt);
                 } else {
-                    leaving.push(pkt);
+                    out.push(pkt);
                 }
             }
         }
         // Reap any `fd_closed` sockets that have finished closing.
         tcp::reap_closed(self);
-        leaving
     }
 }
 

--- a/crates/turmoil-net/src/lib.rs
+++ b/crates/turmoil-net/src/lib.rs
@@ -168,19 +168,20 @@ pub struct EnterGuard {
 }
 
 impl EnterGuard {
-    /// Drain every host's outbound queue. The caller decides what
-    /// happens next — typically: consult rules via
+    /// Drain every host's outbound queue into `out`. The caller decides
+    /// what happens next — typically: consult rules via
     /// [`EnterGuard::evaluate`] for each packet and then
-    /// [`EnterGuard::deliver`] (or schedule for later). See
-    /// [`fixture`] for the default tokio-driven loop.
-    pub fn egress_all(&self) -> Vec<Packet> {
+    /// [`EnterGuard::deliver`] (or schedule for later). The buffer is
+    /// passed in so the caller can reuse its allocation across ticks.
+    /// See [`fixture`] for the default tokio-driven loop.
+    pub fn egress_all(&self, out: &mut Vec<Packet>) {
         CURRENT.with(|c| {
             c.borrow_mut()
                 .as_mut()
                 .expect("guard is live")
                 .fabric
-                .egress_all()
-        })
+                .egress_all(out)
+        });
     }
 
     /// Route a packet to the host owning its destination IP. Drops


### PR DESCRIPTION
`Kernel::egress`, `Fabric::egress_all`, and `EnterGuard::egress_all`
now append into a caller-supplied `&mut Vec<Packet>` instead of
returning a fresh `Vec` each call. The fixture `Scheduler` holds a
preallocated buffer and reuses it across ticks.
