### PR TITLE
feat(turmoil): add simulated io_uring behind unstable-io_uring

### DIFF
--- a/crates/turmoil/Cargo.toml
+++ b/crates/turmoil/Cargo.toml
@@ -31,14 +31,27 @@ test-case = "3"
 tokio-test = "0.4.2"
 tracing-subscriber = { version = "0.3", features = ["env-filter"] }
 
+[target.'cfg(target_os = "linux")'.dev-dependencies]
+io-uring = "0.7"
+tempfile = "3"
+
 [features]
 default = []
 regex = ["dep:regex"]
 unstable-fs = []
+unstable-io_uring = ["unstable-fs"]
 unstable-barriers = ["dep:uuid"]
+# Dev-only: opts into running the io_uring conformance suite against
+# the real Linux kernel ring (in addition to the sim arm). Enables the
+# `io-uring` dev-dependency so the conformance tests can submit SQEs
+# to a real `IoUring`. Requires `target_os = "linux"`.
+real-uring-conformance = []
 
 [lints.rust]
-unexpected_cfgs = { level = "warn", check-cfg = ['cfg(tokio_unstable)'] }
+unexpected_cfgs = { level = "warn", check-cfg = [
+    'cfg(tokio_unstable)',
+    'cfg(parity_io_uring)',
+] }
 
 [package.metadata.cargo_check_external_types]
 allowed_external_types = [

--- a/crates/turmoil/src/fs/mod.rs
+++ b/crates/turmoil/src/fs/mod.rs
@@ -33,9 +33,18 @@ use rand::{Rng, RngCore};
 use rand_distr::{Distribution, Exp};
 use std::cell::RefCell;
 use std::ops::Range;
+use std::os::fd::RawFd;
 use std::path::{Path, PathBuf};
 use std::sync::{Arc, Mutex};
 use std::time::Duration;
+
+/// Base value for sim-allocated file descriptors.
+///
+/// Far enough above any plausible real fd (typical kernel max is ~1M) that
+/// even if a sim fd accidentally leaked into a real syscall it would
+/// reliably error with `EBADF` rather than silently address a real fd.
+/// Stays inside `i32` to fit `RawFd`.
+pub(crate) const SIM_FD_BASE: RawFd = 1 << 30;
 
 // Thread-local storage for worker thread filesystem context.
 // When a worker thread calls `FsHandle::enter()`, this stores the context
@@ -173,7 +182,7 @@ pub(crate) struct FsContext<'a> {
     /// The filesystem state
     pub fs: &'a mut Fs,
     /// Random number generator for probabilistic behaviors
-    rng: &'a mut dyn RngCore,
+    pub(crate) rng: &'a mut dyn RngCore,
     /// Current simulated time
     pub now: Duration,
 }
@@ -997,10 +1006,30 @@ pub(crate) struct Fs {
     synced_entries: IndexSet<PathBuf>,
     /// Queue of pending operations (lost on crash unless synced)
     pub(crate) pending: Vec<PendingOp>,
-    /// Open file handles: fd -> path
-    pub(crate) open_handles: IndexMap<u64, PathBuf>,
-    /// Next file descriptor to assign
-    next_fd: u64,
+    /// Open file handles: fd -> path.
+    ///
+    /// Allocated `RawFd`s start at [`SIM_FD_BASE`] so they can never collide
+    /// with a real-OS fd if one accidentally leaks across the simulation
+    /// boundary.
+    pub(crate) open_handles: IndexMap<RawFd, PathBuf>,
+    /// Subset of [`Self::open_handles`] opened with O_DIRECT semantics.
+    ///
+    /// Tracked separately so the io_uring shim — which only sees a
+    /// bare `RawFd` on the SQE — can enforce alignment requirements
+    /// and bypass the page cache without plumbing the per-`File`
+    /// `direct_io` flag through the kernel-shaped API.
+    #[cfg(feature = "unstable-io_uring")]
+    pub(crate) direct_io_fds: indexmap::IndexSet<RawFd>,
+    /// Active io_uring rings on this host: ring fd -> ring state.
+    ///
+    /// Keyed by the same sim-allocated `RawFd` space as `open_handles`,
+    /// so a single counter (`next_fd`) covers both. The ring is dropped
+    /// (and its in-flight ops abandoned) when the owning [`crate::io_uring::IoUring`]
+    /// is dropped or the host crashes.
+    #[cfg(feature = "unstable-io_uring")]
+    pub(crate) io_uring_rings: IndexMap<RawFd, crate::io_uring::sim::RingState>,
+    /// Next file descriptor to assign.
+    next_fd: RawFd,
     /// Probability that writes are randomly synced to durable storage (0.0 - 1.0)
     pub(crate) sync_probability: f64,
     /// Disk capacity in bytes (None = unlimited)
@@ -1037,7 +1066,11 @@ impl Fs {
             synced_entries,
             pending: Vec::new(),
             open_handles: IndexMap::new(),
-            next_fd: 0,
+            #[cfg(feature = "unstable-io_uring")]
+            direct_io_fds: indexmap::IndexSet::new(),
+            #[cfg(feature = "unstable-io_uring")]
+            io_uring_rings: IndexMap::new(),
+            next_fd: SIM_FD_BASE,
             sync_probability: config.sync_probability,
             capacity: config.capacity,
             io_error_probability: config.io_error_probability,
@@ -1128,10 +1161,16 @@ impl Fs {
         Ok(())
     }
 
-    /// Allocate a new file descriptor.
-    pub(crate) fn alloc_fd(&mut self) -> u64 {
+    /// Allocate a new sim-side file descriptor.
+    ///
+    /// Returns a `RawFd` from a high range (see [`SIM_FD_BASE`]) so that
+    /// these integers cannot collide with real OS fds.
+    pub(crate) fn alloc_fd(&mut self) -> RawFd {
         let fd = self.next_fd;
-        self.next_fd += 1;
+        self.next_fd = self
+            .next_fd
+            .checked_add(1)
+            .expect("simulated fd counter overflowed RawFd range");
         fd
     }
 
@@ -1166,6 +1205,22 @@ impl Fs {
             .retain(|path, _| self.synced_entries.contains(path));
         self.persisted_symlinks
             .retain(|path, _| self.synced_entries.contains(path));
+
+        // Drop every io_uring ring on the host: in-flight ops vanish
+        // (no CQE will ever be delivered), pending side effects of
+        // not-yet-completed writes were never staged, and after
+        // bounce the consumer must construct a new IoUring.
+        //
+        // Wake AsyncFd waiters first so they observe the empty
+        // registry on their next snapshot instead of sleeping until
+        // their cached deadline.
+        #[cfg(feature = "unstable-io_uring")]
+        {
+            for ring in self.io_uring_rings.values() {
+                ring.cq_notify.notify_waiters();
+            }
+            self.io_uring_rings.clear();
+        }
     }
 
     /// Apply torn writes for pending Write operations.
@@ -1387,18 +1442,20 @@ impl Fs {
                 PendingOp::CreateDir { path: p, .. } if p == path => exists = true,
                 PendingOp::RemoveDir { path: p } if p == path => exists = false,
                 // For renames, we need to check if the source was a directory
-                PendingOp::Rename { from, to: _ } if from == path => {
+                PendingOp::Rename { from, to: _ }
+                    if from == path
                     // Source directory is being renamed away
-                    if self.persisted_dirs.contains_key(from) {
-                        exists = false;
-                    }
+                    && self.persisted_dirs.contains_key(from) =>
+                {
+                    exists = false;
                 }
-                PendingOp::Rename { from, to } if to == path => {
+                PendingOp::Rename { from, to }
+                    if to == path
                     // Something is being renamed to this path - only mark as directory
                     // if the source was a directory
-                    if self.persisted_dirs.contains_key(from) {
-                        exists = true;
-                    }
+                    && self.persisted_dirs.contains_key(from) =>
+                {
+                    exists = true;
                 }
                 _ => {}
             }
@@ -1414,21 +1471,22 @@ impl Fs {
                 PendingOp::CreateSymlink { path: p, .. } if p == path => exists = true,
                 PendingOp::RemoveFile { path: p } if p == path => exists = false,
                 // For renames, we need to check if the source was a symlink
-                PendingOp::Rename { from, to: _ } if from == path => {
+                PendingOp::Rename { from, to: _ }
+                    if from == path
                     // Source symlink is being renamed away - it no longer exists at 'from'
                     // Check both persisted and if 'exists' was set by a prior pending create
-                    if self.persisted_symlinks.contains_key(from) || exists {
-                        exists = false;
-                    }
+                    && (self.persisted_symlinks.contains_key(from) || exists) =>
+                {
+                    exists = false;
                 }
-                PendingOp::Rename { from, to } if to == path => {
+                PendingOp::Rename { from, to }
+                    if to == path
                     // Something is being renamed to this path - only mark as symlink
                     // if the source was a symlink (persisted or pending)
-                    if self.persisted_symlinks.contains_key(from)
-                        || self.was_symlink_created_at(from)
-                    {
-                        exists = true;
-                    }
+                    && (self.persisted_symlinks.contains_key(from)
+                        || self.was_symlink_created_at(from)) =>
+                {
+                    exists = true;
                 }
                 _ => {}
             }
@@ -1465,24 +1523,22 @@ impl Fs {
                     offset,
                     data,
                     ..
-                } => {
+                }
                     // Check if this write applies to the content path
-                    if p == &content_path || self.path_renamed_to(p, &content_path) {
+                    if (p == &content_path || self.path_renamed_to(p, &content_path)) => {
                         let end = offset + data.len() as u64;
                         if end > len {
                             len = end;
                         }
                     }
-                }
                 PendingOp::SetLen {
                     path: p,
                     len: new_len,
                     ..
-                } => {
-                    if p == &content_path || self.path_renamed_to(p, &content_path) {
+                }
+                    if (p == &content_path || self.path_renamed_to(p, &content_path)) => {
                         len = *new_len;
                     }
-                }
                 _ => {}
             }
         }
@@ -1561,20 +1617,20 @@ impl Fs {
         // Check pending creates (using exists checks to account for later removals)
         for op in &self.pending {
             match op {
-                PendingOp::CreateFile { path: p, .. } if p.parent() == Some(path) => {
-                    if self.file_exists(p) {
-                        return true;
-                    }
+                PendingOp::CreateFile { path: p, .. }
+                    if p.parent() == Some(path) && self.file_exists(p) =>
+                {
+                    return true;
                 }
-                PendingOp::CreateDir { path: p, .. } if p.parent() == Some(path) => {
-                    if self.dir_exists(p) {
-                        return true;
-                    }
+                PendingOp::CreateDir { path: p, .. }
+                    if p.parent() == Some(path) && self.dir_exists(p) =>
+                {
+                    return true;
                 }
-                PendingOp::CreateSymlink { path: p, .. } if p.parent() == Some(path) => {
-                    if self.symlink_exists(p) {
-                        return true;
-                    }
+                PendingOp::CreateSymlink { path: p, .. }
+                    if p.parent() == Some(path) && self.symlink_exists(p) =>
+                {
+                    return true;
                 }
                 _ => {}
             }
@@ -2158,13 +2214,12 @@ impl Fs {
                     timestamps = Some((*time, *time, *time));
                 }
                 PendingOp::Write { path: p, time, .. }
-                | PendingOp::SetLen { path: p, time, .. } => {
+                | PendingOp::SetLen { path: p, time, .. }
                     // Writes and truncates update mtime/ctime
-                    if (p == path || self.path_renamed_to(p, path)) && timestamps.is_some() {
+                    if (p == path || self.path_renamed_to(p, path)) && timestamps.is_some() => {
                         let (crtime, _, _) = timestamps.unwrap();
                         timestamps = Some((crtime, *time, *time));
                     }
-                }
                 _ => {}
             }
         }
@@ -2220,14 +2275,13 @@ impl Fs {
                         timestamps = Some((crtime, mtime, mtime));
                     }
                 }
-                PendingOp::Rename { from, to } => {
+                PendingOp::Rename { from, to }
                     // Rename affects both source and destination parent directories
-                    if from.parent() == Some(path) || to.parent() == Some(path) {
+                    if (from.parent() == Some(path) || to.parent() == Some(path)) => {
                         if let Some((crtime, mtime, _)) = timestamps {
                             timestamps = Some((crtime, mtime, mtime));
                         }
                     }
-                }
                 _ => {}
             }
         }
@@ -2287,26 +2341,27 @@ impl Fs {
         // Add pending creations
         for op in &self.pending {
             match op {
-                PendingOp::CreateFile { path: p, .. } if p.parent() == Some(path) => {
-                    if self.file_exists(p) {
-                        entries.insert(p.clone());
-                    }
+                PendingOp::CreateFile { path: p, .. }
+                    if p.parent() == Some(path) && self.file_exists(p) =>
+                {
+                    entries.insert(p.clone());
                 }
-                PendingOp::CreateDir { path: p, .. } if p.parent() == Some(path) => {
-                    if self.dir_exists(p) {
-                        entries.insert(p.clone());
-                    }
+                PendingOp::CreateDir { path: p, .. }
+                    if p.parent() == Some(path) && self.dir_exists(p) =>
+                {
+                    entries.insert(p.clone());
                 }
-                PendingOp::CreateSymlink { path: p, .. } if p.parent() == Some(path) => {
-                    if self.symlink_exists(p) {
-                        entries.insert(p.clone());
-                    }
+                PendingOp::CreateSymlink { path: p, .. }
+                    if p.parent() == Some(path) && self.symlink_exists(p) =>
+                {
+                    entries.insert(p.clone());
                 }
-                PendingOp::Rename { to, .. } if to.parent() == Some(path) => {
+                PendingOp::Rename { to, .. }
+                    if to.parent() == Some(path)
                     // Check if it still exists (wasn't removed later)
-                    if self.file_exists(to) || self.dir_exists(to) || self.symlink_exists(to) {
-                        entries.insert(to.clone());
-                    }
+                    && (self.file_exists(to) || self.dir_exists(to) || self.symlink_exists(to)) =>
+                {
+                    entries.insert(to.clone());
                 }
                 _ => {}
             }

--- a/crates/turmoil/src/fs/shim/std/fs/mod.rs
+++ b/crates/turmoil/src/fs/shim/std/fs/mod.rs
@@ -109,6 +109,7 @@
 
 use crate::fs::FsContext;
 use std::io::{Error, ErrorKind, Result};
+use std::os::fd::RawFd;
 use std::path::{Path, PathBuf};
 use std::time::{Duration, SystemTime, UNIX_EPOCH};
 
@@ -513,8 +514,13 @@ impl FileType {
 /// per-host simulated filesystem.
 #[derive(Debug)]
 pub struct File {
-    /// File descriptor used to identify this file in the host's Fs
-    fd: u64,
+    /// File descriptor used to identify this file in the host's Fs.
+    ///
+    /// Allocated from a high range (see [`crate::fs::SIM_FD_BASE`]) so it
+    /// is safe to expose via [`AsRawFd`](std::os::fd::AsRawFd) — the
+    /// io_uring shim resolves these back to paths through the host's
+    /// open-file table.
+    fd: RawFd,
     /// Whether the file is readable
     readable: bool,
     /// Whether the file is writable
@@ -694,6 +700,10 @@ impl File {
             // Allocate new fd and register it
             let new_fd = ctx.fs.alloc_fd();
             ctx.fs.open_handles.insert(new_fd, path);
+            #[cfg(feature = "unstable-io_uring")]
+            if self.direct_io {
+                ctx.fs.direct_io_fds.insert(new_fd);
+            }
 
             Ok(File {
                 fd: new_fd,
@@ -860,7 +870,7 @@ impl File {
 
     /// Create a File from internal state (used by OpenOptions).
     pub(crate) fn from_parts(
-        fd: u64,
+        fd: RawFd,
         readable: bool,
         writable: bool,
         append_mode: bool,
@@ -942,7 +952,24 @@ impl Drop for File {
     fn drop(&mut self) {
         FsContext::current_if_set(|ctx| {
             ctx.fs.open_handles.swap_remove(&self.fd);
+            #[cfg(feature = "unstable-io_uring")]
+            ctx.fs.direct_io_fds.swap_remove(&self.fd);
         });
+    }
+}
+
+/// Exposes the simulated file descriptor.
+///
+/// The returned [`RawFd`] is allocated from a high range
+/// ([`crate::fs::SIM_FD_BASE`]) so it cannot collide with any real OS
+/// fd. It is meaningful only inside the turmoil simulation that minted
+/// it; passing it to a real syscall will reliably fail with `EBADF`.
+///
+/// This impl exists so consumers can hand the fd to the
+/// [`crate::io_uring`] shim.
+impl std::os::fd::AsRawFd for File {
+    fn as_raw_fd(&self) -> RawFd {
+        self.fd
     }
 }
 
@@ -1286,6 +1313,10 @@ impl OpenOptions {
             // Check for direct I/O (bypasses page cache)
             // Can be set via direct_io() method or custom_flags(O_DIRECT)
             let direct_io = self.direct_io || (self.custom_flags & O_DIRECT) != 0;
+            #[cfg(feature = "unstable-io_uring")]
+            if direct_io {
+                ctx.fs.direct_io_fds.insert(fd);
+            }
 
             Ok(File::from_parts(
                 fd,

--- a/crates/turmoil/src/fs/shim/tokio/fs/mod.rs
+++ b/crates/turmoil/src/fs/shim/tokio/fs/mod.rs
@@ -347,6 +347,16 @@ impl File {
     }
 }
 
+/// Exposes the simulated file descriptor.
+///
+/// See [`sync_fs::File`]'s `AsRawFd` impl for details. The fd is the
+/// hand-off point for the [`crate::io_uring`] shim.
+impl std::os::fd::AsRawFd for File {
+    fn as_raw_fd(&self) -> std::os::fd::RawFd {
+        self.inner.as_raw_fd()
+    }
+}
+
 impl tokio::io::AsyncRead for File {
     fn poll_read(
         mut self: std::pin::Pin<&mut Self>,

--- a/crates/turmoil/src/io_uring/async_fd.rs
+++ b/crates/turmoil/src/io_uring/async_fd.rs
@@ -1,0 +1,155 @@
+//! `AsyncFd` mirror for the simulated ring fd.
+//!
+//! Drives readiness off the per-ring `Notify` plus a
+//! `tokio::time::sleep_until(next_deadline)` race. Both fire under
+//! turmoil's simulated time, so consumers get correct wake
+//! semantics without touching real epoll/kqueue/eventfd.
+
+use crate::fs::FsContext;
+use std::io;
+use std::os::fd::{AsRawFd, RawFd};
+use std::sync::Arc;
+use std::time::Duration;
+use tokio::io::Interest;
+use tokio::sync::Notify;
+use tokio::time::Instant;
+
+/// Mirrors [`tokio::io::unix::AsyncFd`].
+///
+/// Construction snapshots the ring's `Notify` so subsequent
+/// [`AsyncFd::readable`] calls don't need a per-call ring lookup just
+/// to resubscribe. If the ring is gone (e.g. host crashed and the
+/// underlying state was cleared), [`AsyncFd::readable`] returns an
+/// [`io::Error`].
+pub struct AsyncFd<T: AsRawFd> {
+    inner: T,
+    notify: Arc<Notify>,
+}
+
+impl<T: AsRawFd> AsyncFd<T> {
+    /// New AsyncFd registered for read interest.
+    pub fn new(inner: T) -> io::Result<Self> {
+        Self::with_interest(inner, Interest::READABLE)
+    }
+
+    /// New AsyncFd with a specific interest. The simulation only
+    /// models READABLE; other interests are accepted but unused.
+    pub fn with_interest(inner: T, _interest: Interest) -> io::Result<Self> {
+        let fd = inner.as_raw_fd();
+        let notify = FsContext::current(|ctx| {
+            ctx.fs
+                .io_uring_rings
+                .get(&fd)
+                .map(|r| r.cq_notify.clone())
+                .ok_or_else(|| {
+                    io::Error::new(
+                        io::ErrorKind::NotFound,
+                        format!("AsyncFd: fd {fd} is not a registered turmoil ring"),
+                    )
+                })
+        })?;
+        Ok(Self { inner, notify })
+    }
+
+    /// Reference to the wrapped value.
+    pub fn get_ref(&self) -> &T {
+        &self.inner
+    }
+
+    /// Mutable reference to the wrapped value.
+    pub fn get_mut(&mut self) -> &mut T {
+        &mut self.inner
+    }
+
+    /// Take ownership of the wrapped value.
+    pub fn into_inner(self) -> T {
+        self.inner
+    }
+
+    /// Resolve when the ring has at least one ready CQE, mirroring
+    /// [`tokio::io::unix::AsyncFd::readable`].
+    pub async fn readable(&self) -> io::Result<AsyncFdReadyGuard<'_, T>> {
+        let fd = self.inner.as_raw_fd();
+        loop {
+            // Subscribe BEFORE we sample state, so a `notify_waiters()`
+            // call that races between the snapshot and the await is
+            // observed. `notify_waiters()` only wakes registered
+            // waiters, so a `Notified` future that hasn't been polled
+            // yet won't see it. `Notified::enable()` registers without
+            // requiring an `.await`, closing that race.
+            let notified = self.notify.notified();
+            tokio::pin!(notified);
+            notified.as_mut().enable();
+
+            // Snapshot under the fs lock: are we ready right now? If
+            // not, what's the next deadline?
+            let snapshot = FsContext::current(|ctx| -> io::Result<Snapshot> {
+                let ring = ctx.fs.io_uring_rings.get(&fd).ok_or_else(|| {
+                    io::Error::new(
+                        io::ErrorKind::NotFound,
+                        "AsyncFd: ring is no longer registered",
+                    )
+                })?;
+                let now = ctx.now;
+                let ready = ring.ready_cq_count(now) > 0;
+                let deadline = ring.next_deadline();
+                Ok(Snapshot {
+                    ready,
+                    deadline,
+                    now,
+                })
+            })?;
+
+            if snapshot.ready {
+                return Ok(AsyncFdReadyGuard { _async_fd: self });
+            }
+
+            match snapshot.deadline {
+                Some(d) if d > snapshot.now => {
+                    // sleep_until uses simulated time.
+                    let until = Instant::now() + (d - snapshot.now);
+                    tokio::select! {
+                        _ = &mut notified => {}
+                        _ = tokio::time::sleep_until(until) => {}
+                    }
+                }
+                Some(_) => {
+                    // Already due — loop and recheck. A bare yield
+                    // hands control to the runtime so any pending
+                    // submit() that would advance time can run.
+                    tokio::task::yield_now().await;
+                }
+                None => {
+                    // Nothing in flight. Wait indefinitely for the
+                    // next submit() to push something.
+                    notified.await;
+                }
+            }
+        }
+    }
+}
+
+struct Snapshot {
+    ready: bool,
+    deadline: Option<Duration>,
+    now: Duration,
+}
+
+impl<T: AsRawFd> AsRawFd for AsyncFd<T> {
+    fn as_raw_fd(&self) -> RawFd {
+        self.inner.as_raw_fd()
+    }
+}
+
+/// Mirrors [`tokio::io::unix::AsyncFdReadyGuard`].
+pub struct AsyncFdReadyGuard<'a, T: AsRawFd> {
+    _async_fd: &'a AsyncFd<T>,
+}
+
+impl<'a, T: AsRawFd> AsyncFdReadyGuard<'a, T> {
+    /// No-op in the simulation. The real type re-arms the IO driver's
+    /// readiness flag when the consumer drained the fd; in our model
+    /// readiness is recomputed on every `readable()` call from ring
+    /// state, so there is no flag to clear.
+    pub fn clear_ready(&mut self) {}
+}

--- a/crates/turmoil/src/io_uring/cqueue.rs
+++ b/crates/turmoil/src/io_uring/cqueue.rs
@@ -1,0 +1,149 @@
+//! Completion queue types mirroring [`io_uring::cqueue`](https://docs.rs/io-uring/0.7/io_uring/cqueue).
+
+use crate::fs::FsContext;
+use std::os::fd::RawFd;
+
+/// Sealed trait selecting between [`Entry`] (default) and the larger
+/// `Entry32` shape exposed by the real crate. Only `Entry` is
+/// implemented in the simulation.
+pub trait EntryMarker: private::Sealed + Sized {}
+
+/// One completion queue entry. Yielded by iterating a
+/// [`CompletionQueue`].
+#[derive(Clone, Debug)]
+pub struct Entry {
+    pub(crate) user_data: u64,
+    pub(crate) result: i32,
+    pub(crate) flags: u32,
+}
+
+impl Entry {
+    /// User-data tag set on the originating SQE.
+    pub fn user_data(&self) -> u64 {
+        self.user_data
+    }
+
+    /// Op result: non-negative on success (e.g. bytes read), negative
+    /// `errno` on failure.
+    pub fn result(&self) -> i32 {
+        self.result
+    }
+
+    /// Per-CQE flags. The simulation always reports zero.
+    pub fn flags(&self) -> u32 {
+        self.flags
+    }
+}
+
+impl EntryMarker for Entry {}
+
+/// Completion queue handle. Iterating it yields any CQEs whose
+/// scheduled completion time has elapsed in simulated time, in
+/// RNG-shuffled order.
+///
+/// # Real-Linux fidelity: `sync()` is required before iterating
+///
+/// On real Linux, [`Self::sync`] copies the kernel's CQ head pointer
+/// into userspace; without it, `next()` returns `None` even when the
+/// kernel has posted CQEs. The simulation enforces the same contract:
+/// a freshly-constructed `CompletionQueue` has `visible == 0`, and
+/// `next()` returns `None` until `sync()` exposes the matured CQEs.
+/// This catches at sim time the bug where a consumer forgets to
+/// `sync()` and silently misses CQEs on real Linux.
+///
+/// # Divergence from real Linux: side effects run at `next()` time
+///
+/// `next()` is where the read/write/fsync side effect actually runs
+/// against the simulated `Fs`. On real Linux, the kernel has already
+/// completed the op by the time the CQE is in the ring. This means
+/// in the simulation, dropping the `CompletionQueue` mid-iteration
+/// leaves any not-yet-yielded matured ops un-executed (their effects
+/// are queued but not staged into `Fs`). Drain to completion or hold
+/// the iterator across the full set of expected CQEs.
+pub struct CompletionQueue<'a> {
+    ring_fd: RawFd,
+    /// Number of CQEs the most recent `sync()` exposed for this
+    /// handle. `next()` decrements this on each yield; when it hits
+    /// zero, further `next()` calls return `None` until `sync()` is
+    /// called again. `None` means "not yet synced," which behaves
+    /// like zero.
+    visible: Option<usize>,
+    _lifetime: std::marker::PhantomData<&'a ()>,
+}
+
+impl<'a> CompletionQueue<'a> {
+    pub(crate) fn new(ring_fd: RawFd) -> Self {
+        Self {
+            ring_fd,
+            visible: None,
+            _lifetime: std::marker::PhantomData,
+        }
+    }
+
+    /// Snapshot the ring: subsequent `next()` calls may yield up to
+    /// the number of CQEs currently matured. Mirrors the real crate's
+    /// `sync()` which copies the kernel CQ head into userspace.
+    pub fn sync(&mut self) {
+        self.visible = Some(FsContext::current(|ctx| {
+            ctx.fs
+                .io_uring_rings
+                .get(&self.ring_fd)
+                .map(|r| r.ready_cq_count(ctx.now))
+                .unwrap_or(0)
+        }));
+    }
+
+    /// Number of CQEs the last `sync()` exposed and not yet drained.
+    /// Returns `0` for a freshly-constructed handle (matches real
+    /// Linux: nothing visible until you sync).
+    pub fn len(&self) -> usize {
+        self.visible.unwrap_or(0)
+    }
+
+    /// Whether [`Self::len`] is zero.
+    pub fn is_empty(&self) -> bool {
+        self.len() == 0
+    }
+}
+
+impl<'a> Iterator for CompletionQueue<'a> {
+    type Item = Entry;
+
+    fn next(&mut self) -> Option<Entry> {
+        // Real Linux only yields CQEs the most recent `sync()`
+        // exposed. We enforce the same: a consumer that forgets to
+        // call `sync()` before iterating sees an empty CQ even if
+        // ops have matured.
+        let remaining = self.visible.as_mut()?;
+        if *remaining == 0 {
+            return None;
+        }
+        let entry = FsContext::current(|ctx| {
+            let now = ctx.now;
+            let ring_fd = self.ring_fd;
+            // Borrow the ring mutably and pop one ready scheduled op.
+            let scheduled = ctx
+                .fs
+                .io_uring_rings
+                .get_mut(&ring_fd)?
+                .pop_ready(now, ctx.rng)?;
+            // Execute the op against the fs (this is where reads,
+            // writes, and fsync touch persisted/pending state). We
+            // re-borrow `ctx` because `apply` needs `&mut Fs` and the
+            // `RingState` is no longer in scope.
+            let result = scheduled.apply.execute(ctx.fs, ctx.rng, now);
+            Some(Entry {
+                user_data: scheduled.user_data,
+                result,
+                flags: 0,
+            })
+        })?;
+        *remaining -= 1;
+        Some(entry)
+    }
+}
+
+mod private {
+    pub trait Sealed {}
+    impl Sealed for super::Entry {}
+}

--- a/crates/turmoil/src/io_uring/mod.rs
+++ b/crates/turmoil/src/io_uring/mod.rs
@@ -1,0 +1,267 @@
+//! Simulated [`io_uring`](https://kernel.dk/io_uring.pdf) for turmoil.
+//!
+//! This module mirrors the [`io-uring` 0.7](https://docs.rs/io-uring/0.7)
+//! crate's Rust API closely enough that consumers can flip a feature
+//! flag and swap their `use io_uring::*` imports for
+//! `use turmoil::io_uring::*`, then run the same code on macOS or
+//! Windows under a turmoil simulation.
+//!
+//! It is **not** a real `io_uring` — there is no kernel ring, no SQ/CQ
+//! mmap, no `io_uring_enter` syscall. Instead, SQEs are queued in
+//! per-host Rust state, and CQEs become observable as simulated time
+//! advances past per-op completion timestamps drawn from the existing
+//! [`crate::fs::FsConfig`] latency distribution. Out-of-order completion
+//! falls out naturally because every op samples its own timestamp.
+//!
+//! All filesystem effects (read returning data, write becoming visible,
+//! fsync flushing pending ops, fault injection, page cache, torn writes
+//! on crash) flow through the same code paths as
+//! [`crate::fs::shim::std::fs`] and [`crate::fs::shim::tokio::fs`] —
+//! there is one source of truth for fs behavior under simulation.
+//!
+//! # What is supported
+//!
+//! - [`IoUring::new`], [`IoUring::builder`], submission/completion
+//!   queues (shared and exclusive variants).
+//! - Opcodes: [`opcode::Read`], [`opcode::Write`], [`opcode::Fsync`],
+//!   [`opcode::AsyncCancel`].
+//! - [`Submitter::submit`], [`Submitter::submit_and_wait`],
+//!   [`Submitter::submit_with_args`].
+//! - [`AsyncFd`] mirroring [`tokio::io::unix::AsyncFd`] for the ring's
+//!   readiness fd, driven by simulated time.
+//!
+//! # What is rejected
+//!
+//! - `IORING_SETUP_SQPOLL`, `IORING_SETUP_IOPOLL`.
+//! - Linked SQEs (`IOSQE_IO_LINK`, `IOSQE_IO_HARDLINK`).
+//! - Fixed files / registered buffers / BufRing.
+//! - Multi-shot ops.
+//! - Any opcode other than the four listed above.
+//!
+//! Submitting any of these surfaces as `EINVAL` — either at submit time
+//! or as a CQE result — exactly as the real kernel would.
+//!
+//! # Stability
+//!
+//! Gated behind the `unstable-io_uring` feature (which depends on
+//! `unstable-fs`); the API may change between patch releases. See
+//! the design doc at `docs/dev/io-uring-sim-plan.md` for the full
+//! rationale.
+
+pub mod cqueue;
+pub mod opcode;
+pub mod squeue;
+pub mod types;
+
+mod async_fd;
+pub(crate) mod sim;
+mod submit;
+
+pub use async_fd::{AsyncFd, AsyncFdReadyGuard};
+pub use submit::Submitter;
+pub use tokio::io::Interest;
+
+use crate::fs::FsContext;
+use std::io;
+use std::os::fd::{AsRawFd, RawFd};
+
+/// Simulated `io_uring` instance.
+///
+/// Mirrors [`io_uring::IoUring`](https://docs.rs/io-uring/0.7/io_uring/struct.IoUring.html).
+/// The two type parameters exist for source-level compatibility with the
+/// real crate's `IoUring<S, C>`; only the default
+/// `(squeue::Entry, cqueue::Entry)` shape is implemented in the
+/// simulation.
+pub struct IoUring<S = squeue::Entry, C = cqueue::Entry>
+where
+    S: squeue::EntryMarker,
+    C: cqueue::EntryMarker,
+{
+    /// Sim-allocated id used to look up [`sim::RingState`] on the host's
+    /// `Fs` and to back [`AsRawFd`].
+    ring_fd: RawFd,
+    params: Parameters,
+    _markers: std::marker::PhantomData<(S, C)>,
+}
+
+/// Setup parameters reported by [`IoUring::params`].
+///
+/// Mirrors a small subset of [`io_uring::Parameters`](https://docs.rs/io-uring/0.7/io_uring/struct.Parameters.html).
+#[derive(Clone, Debug, Default)]
+pub struct Parameters {
+    sq_entries: u32,
+    cq_entries: u32,
+}
+
+impl Parameters {
+    /// Number of submission queue entries.
+    pub fn sq_entries(&self) -> u32 {
+        self.sq_entries
+    }
+
+    /// Number of completion queue entries.
+    pub fn cq_entries(&self) -> u32 {
+        self.cq_entries
+    }
+}
+
+/// Builder for [`IoUring`], mirroring
+/// [`io_uring::Builder`](https://docs.rs/io-uring/0.7/io_uring/struct.Builder.html).
+///
+/// Note: real crate's `Builder` doesn't impl `Debug`, so we don't
+/// either. The parity test pins this contract.
+#[derive(Clone, Default)]
+pub struct Builder {
+    setup_sqpoll: Option<u32>,
+    setup_iopoll: bool,
+}
+
+impl Builder {
+    /// Reject SQPOLL — the simulation has no kernel thread to model.
+    /// Recorded here so [`Builder::build`] can fail with `EINVAL`.
+    pub fn setup_sqpoll(&mut self, idle_ms: u32) -> &mut Self {
+        self.setup_sqpoll = Some(idle_ms);
+        self
+    }
+
+    /// Reject IOPOLL.
+    pub fn setup_iopoll(&mut self) -> &mut Self {
+        self.setup_iopoll = true;
+        self
+    }
+
+    /// Build the simulated ring with `entries` SQ/CQ slots.
+    pub fn build(&self, entries: u32) -> io::Result<IoUring> {
+        if self.setup_sqpoll.is_some() {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidInput,
+                "turmoil io_uring shim does not support IORING_SETUP_SQPOLL",
+            ));
+        }
+        if self.setup_iopoll {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidInput,
+                "turmoil io_uring shim does not support IORING_SETUP_IOPOLL",
+            ));
+        }
+        IoUring::new_inner(entries)
+    }
+}
+
+impl IoUring {
+    /// Allocate a fresh ring on the current host with the given depth.
+    pub fn new(entries: u32) -> io::Result<Self> {
+        Self::new_inner(entries)
+    }
+
+    /// Construct a [`Builder`] for advanced setup options.
+    pub fn builder() -> Builder {
+        Builder::default()
+    }
+
+    fn new_inner(entries: u32) -> io::Result<Self> {
+        if entries == 0 {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidInput,
+                "io_uring entries must be > 0",
+            ));
+        }
+        let depth = entries.next_power_of_two().max(1);
+        let ring_fd = FsContext::current(|ctx| ctx.fs.alloc_fd());
+        FsContext::current(|ctx| {
+            ctx.fs
+                .io_uring_rings
+                .insert(ring_fd, sim::RingState::new(depth));
+        });
+        Ok(IoUring {
+            ring_fd,
+            params: Parameters {
+                sq_entries: depth,
+                cq_entries: depth * 2,
+            },
+            _markers: std::marker::PhantomData,
+        })
+    }
+
+    /// Setup parameters for this ring (depth, etc.).
+    pub fn params(&self) -> &Parameters {
+        &self.params
+    }
+
+    /// Submission-side handle requiring exclusive access to the ring.
+    pub fn submission(&mut self) -> squeue::SubmissionQueue<'_> {
+        squeue::SubmissionQueue::new(self.ring_fd)
+    }
+
+    /// Submission-side handle that allows shared access. Caller asserts
+    /// they are the sole writer of the SQ.
+    ///
+    /// # Safety
+    ///
+    /// Mirrors the real crate's contract: the SQ has a single writer
+    /// at any time. The simulation does not currently enforce this;
+    /// it trusts the caller, same as the real `io-uring` crate.
+    pub unsafe fn submission_shared(&self) -> squeue::SubmissionQueue<'_> {
+        squeue::SubmissionQueue::new(self.ring_fd)
+    }
+
+    /// Completion-side handle requiring exclusive access to the ring.
+    pub fn completion(&mut self) -> cqueue::CompletionQueue<'_> {
+        cqueue::CompletionQueue::new(self.ring_fd)
+    }
+
+    /// Completion-side handle that allows shared access. Caller asserts
+    /// they are the sole consumer of the CQ.
+    ///
+    /// # Safety
+    ///
+    /// Same single-consumer contract as the real crate.
+    pub unsafe fn completion_shared(&self) -> cqueue::CompletionQueue<'_> {
+        cqueue::CompletionQueue::new(self.ring_fd)
+    }
+
+    /// [`Submitter`] handle for this ring.
+    pub fn submitter(&self) -> Submitter<'_> {
+        Submitter::new(self.ring_fd)
+    }
+
+    /// Convenience: equivalent to `self.submitter().submit()`.
+    pub fn submit(&self) -> io::Result<usize> {
+        self.submitter().submit()
+    }
+
+    /// Convenience: equivalent to `self.submitter().submit_and_wait(want)`.
+    pub fn submit_and_wait(&self, want: usize) -> io::Result<usize> {
+        self.submitter().submit_and_wait(want)
+    }
+}
+
+impl<S, C> Drop for IoUring<S, C>
+where
+    S: squeue::EntryMarker,
+    C: cqueue::EntryMarker,
+{
+    fn drop(&mut self) {
+        FsContext::current_if_set(|ctx| {
+            // Wake any AsyncFd::readable() callers before removing
+            // the ring so they observe NotFound on the next snapshot
+            // instead of sleeping until their cached deadline.
+            if let Some(ring) = ctx.fs.io_uring_rings.get(&self.ring_fd) {
+                ring.cq_notify.notify_waiters();
+            }
+            ctx.fs.io_uring_rings.swap_remove(&self.ring_fd);
+        });
+    }
+}
+
+/// Exposes the simulated ring fd so consumers can hand it to
+/// [`AsyncFd`].
+impl<S, C> AsRawFd for IoUring<S, C>
+where
+    S: squeue::EntryMarker,
+    C: cqueue::EntryMarker,
+{
+    fn as_raw_fd(&self) -> RawFd {
+        self.ring_fd
+    }
+}

--- a/crates/turmoil/src/io_uring/opcode.rs
+++ b/crates/turmoil/src/io_uring/opcode.rs
@@ -1,0 +1,143 @@
+//! Opcode builders mirroring a small subset of
+//! [`io_uring::opcode`](https://docs.rs/io-uring/0.7/io_uring/opcode).
+//!
+//! Only four ops are exposed: [`Read`], [`Write`], [`Fsync`],
+//! [`AsyncCancel`] — the minimum set a typical io_uring consumer
+//! actually submits. Other opcodes have no builder here; consumers
+//! that need them must either teach this module or stop using the
+//! simulation.
+
+use super::squeue::{Entry, Flags, OpKind};
+use super::types::Fd;
+
+/// Read at offset, mirroring [`io_uring::opcode::Read`].
+pub struct Read {
+    fd: Fd,
+    ptr: *mut u8,
+    len: u32,
+    offset: u64,
+}
+
+impl Read {
+    /// New read SQE for `fd`, target buffer at `ptr` of length `len`.
+    pub fn new(fd: Fd, ptr: *mut u8, len: u32) -> Self {
+        Self {
+            fd,
+            ptr,
+            len,
+            offset: 0,
+        }
+    }
+
+    /// Set the file offset.
+    pub fn offset(mut self, off: u64) -> Self {
+        self.offset = off;
+        self
+    }
+
+    /// Finalize into an [`Entry`] ready to push onto the SQ.
+    pub fn build(self) -> Entry {
+        Entry {
+            op: OpKind::Read {
+                fd: self.fd.0,
+                ptr: self.ptr,
+                len: self.len,
+                offset: self.offset,
+            },
+            user_data: 0,
+            flags: Flags::default(),
+        }
+    }
+}
+
+/// Write at offset, mirroring [`io_uring::opcode::Write`].
+pub struct Write {
+    fd: Fd,
+    ptr: *const u8,
+    len: u32,
+    offset: u64,
+}
+
+impl Write {
+    /// New write SQE for `fd`, source buffer at `ptr` of length `len`.
+    pub fn new(fd: Fd, ptr: *const u8, len: u32) -> Self {
+        Self {
+            fd,
+            ptr,
+            len,
+            offset: 0,
+        }
+    }
+
+    /// Set the file offset.
+    pub fn offset(mut self, off: u64) -> Self {
+        self.offset = off;
+        self
+    }
+
+    /// Finalize into an [`Entry`] ready to push onto the SQ.
+    pub fn build(self) -> Entry {
+        Entry {
+            op: OpKind::Write {
+                fd: self.fd.0,
+                ptr: self.ptr,
+                len: self.len,
+                offset: self.offset,
+            },
+            user_data: 0,
+            flags: Flags::default(),
+        }
+    }
+}
+
+/// `fsync(2)` SQE, mirroring [`io_uring::opcode::Fsync`].
+pub struct Fsync {
+    fd: Fd,
+}
+
+impl Fsync {
+    /// New fsync SQE for `fd`.
+    ///
+    /// `IORING_FSYNC_DATASYNC` (fdatasync semantics) is not modeled —
+    /// the simulation always performs a full sync. Add a `.flags()`
+    /// method that threads through to `exec_fsync` when a consumer
+    /// needs the distinction.
+    pub fn new(fd: Fd) -> Self {
+        Self { fd }
+    }
+
+    /// Finalize into an [`Entry`] ready to push onto the SQ.
+    pub fn build(self) -> Entry {
+        Entry {
+            op: OpKind::Fsync { fd: self.fd.0 },
+            user_data: 0,
+            flags: Flags::default(),
+        }
+    }
+}
+
+/// `IORING_OP_ASYNC_CANCEL`, mirroring [`io_uring::opcode::AsyncCancel`].
+///
+/// The simulation matches by the `user_data` of an in-flight op.
+/// Targeting a fd or any other kernel match-mode is not modeled.
+pub struct AsyncCancel {
+    target: u64,
+}
+
+impl AsyncCancel {
+    /// Build a cancel for the SQE whose CQE will carry `user_data`.
+    pub fn new(user_data: u64) -> Self {
+        Self { target: user_data }
+    }
+
+    /// Finalize into an [`Entry`] ready to push onto the SQ.
+    pub fn build(self) -> Entry {
+        Entry {
+            op: OpKind::AsyncCancel {
+                target_user_data: self.target,
+            },
+            user_data: 0,
+            flags: Flags::default(),
+        }
+    }
+}

--- a/crates/turmoil/src/io_uring/sim.rs
+++ b/crates/turmoil/src/io_uring/sim.rs
@@ -1,0 +1,392 @@
+//! Per-host ring state and scheduling heap.
+
+use super::squeue::Entry as SqEntry;
+use crate::fs::Fs;
+use rand::seq::SliceRandom;
+use rand::RngCore;
+use std::collections::VecDeque;
+use std::os::fd::RawFd;
+use std::sync::Arc;
+use std::time::Duration;
+use tokio::sync::Notify;
+
+/// State for one [`crate::io_uring::IoUring`] instance, hung off
+/// [`crate::fs::Fs::io_uring_rings`].
+pub(crate) struct RingState {
+    pub(crate) depth: u32,
+    /// Entries pushed via `SubmissionQueue::push` but not yet handed
+    /// off via `submit()`.
+    pub(crate) sq: VecDeque<SqEntry>,
+    /// Ops accepted by `submit()` but whose scheduled completion time
+    /// is still in the future.
+    inflight: Vec<ScheduledCqe>,
+    /// CQEs whose scheduled time has elapsed but which the consumer
+    /// has not yet drained via `CompletionQueue::next()`. Held in
+    /// RNG-shuffled order to model out-of-order kernel completion.
+    ready: VecDeque<ScheduledCqe>,
+    /// Woken whenever the readiness state of the ring changes:
+    /// a new CQE matures, a CQE is posted immediately, or the ring
+    /// is being torn down. The [`crate::io_uring::AsyncFd`] shim
+    /// awaits this to avoid spinning.
+    pub(crate) cq_notify: Arc<Notify>,
+}
+
+impl RingState {
+    pub(crate) fn new(depth: u32) -> Self {
+        Self {
+            depth,
+            sq: VecDeque::with_capacity(depth as usize),
+            inflight: Vec::new(),
+            ready: VecDeque::new(),
+            cq_notify: Arc::new(Notify::new()),
+        }
+    }
+
+    /// Schedule an op to complete at `when`.
+    pub(crate) fn schedule(&mut self, user_data: u64, when: Duration, apply: PendingApply) {
+        self.inflight.push(ScheduledCqe {
+            when,
+            user_data,
+            apply,
+        });
+        self.cq_notify.notify_waiters();
+    }
+
+    /// Post an immediate error CQE (no fs effect).
+    pub(crate) fn post_immediate_error(&mut self, user_data: u64, errno: i32, now: Duration) {
+        self.inflight.push(ScheduledCqe {
+            when: now,
+            user_data,
+            apply: PendingApply::ImmediateError(errno),
+        });
+        self.cq_notify.notify_waiters();
+    }
+
+    /// Cancel an op by `user_data`. Posts two CQEs: one `-ECANCELED`
+    /// for the target, one `0` for the cancel itself (or `-ENOENT` if
+    /// no match anywhere).
+    ///
+    /// We scan both `inflight` (deadline still in the future) and
+    /// `ready` (matured but not yet drained). The latter is critical:
+    /// each `ScheduledCqe` carries raw buffer pointers, and we drop
+    /// the op rather than execute it — leaving a matured op in
+    /// `ready` after cancel would let `pop_ready` later dereference
+    /// pointers the consumer may have already freed.
+    ///
+    /// # Divergence from real Linux
+    ///
+    /// - Real `io_uring_register(IORING_OP_ASYNC_CANCEL)` is
+    ///   best-effort: an op already submitted to the storage stack
+    ///   may still complete normally and a write's effects may
+    ///   persist. The simulation cancels deterministically and drops
+    ///   any pending side effects. A consumer that treats cancel
+    ///   outcomes as "may or may not have applied" is unaffected.
+    /// - Real cancel of a CQE that has already completed (sat in the
+    ///   kernel CQ unread) returns `-EALREADY`. The simulation
+    ///   returns `-ENOENT` for "no such user_data anywhere" — close
+    ///   enough for consumers that don't distinguish the two.
+    pub(crate) fn cancel(&mut self, cancel_ud: u64, target_ud: u64, now: Duration) {
+        // Drop the matching op (in either pool) without executing its
+        // apply. The raw pointers in PendingApply::Read/Write die
+        // here, so the consumer can free the buffer the moment the
+        // cancel CQE is observed.
+        let mut found = false;
+        if let Some(idx) = self.inflight.iter().position(|s| s.user_data == target_ud) {
+            self.inflight.swap_remove(idx);
+            found = true;
+        } else if let Some(idx) = self.ready.iter().position(|s| s.user_data == target_ud) {
+            self.ready.remove(idx);
+            found = true;
+        }
+
+        let cancel_result = if found {
+            self.inflight.push(ScheduledCqe {
+                when: now,
+                user_data: target_ud,
+                apply: PendingApply::ImmediateError(-ECANCELED),
+            });
+            0
+        } else {
+            -ENOENT
+        };
+        self.inflight.push(ScheduledCqe {
+            when: now,
+            user_data: cancel_ud,
+            apply: PendingApply::ImmediateError(cancel_result),
+        });
+        self.cq_notify.notify_waiters();
+    }
+
+    /// Earliest scheduled completion time. `None` when nothing is in
+    /// flight. The [`crate::io_uring::AsyncFd`] shim sleeps until this
+    /// deadline to avoid spinning on the world clock.
+    pub(crate) fn next_deadline(&self) -> Option<Duration> {
+        if !self.ready.is_empty() {
+            return Some(Duration::ZERO);
+        }
+        self.inflight.iter().map(|s| s.when).min()
+    }
+
+    /// Number of CQEs whose scheduled time is `<= now`.
+    pub(crate) fn ready_cq_count(&self, now: Duration) -> usize {
+        self.ready.len() + self.inflight.iter().filter(|s| s.when <= now).count()
+    }
+
+    /// Drain matured ops from `inflight` into `ready`, shuffling them
+    /// to model out-of-order kernel completion.
+    fn promote_ready(&mut self, now: Duration, rng: &mut dyn RngCore) {
+        let mut matured: Vec<ScheduledCqe> = Vec::new();
+        let mut i = 0;
+        while i < self.inflight.len() {
+            if self.inflight[i].when <= now {
+                matured.push(self.inflight.swap_remove(i));
+            } else {
+                i += 1;
+            }
+        }
+        if !matured.is_empty() {
+            matured.shuffle(rng);
+            self.ready.extend(matured);
+        }
+    }
+
+    /// Pop one ready scheduled CQE, promoting from `inflight` first.
+    pub(crate) fn pop_ready(
+        &mut self,
+        now: Duration,
+        rng: &mut dyn RngCore,
+    ) -> Option<ScheduledCqe> {
+        self.promote_ready(now, rng);
+        self.ready.pop_front()
+    }
+}
+
+pub(crate) struct ScheduledCqe {
+    pub(crate) when: Duration,
+    pub(crate) user_data: u64,
+    pub(crate) apply: PendingApply,
+}
+
+/// What runs against [`Fs`] at completion time.
+///
+/// Held until the [`super::cqueue::CompletionQueue`] iterator yields
+/// the corresponding CQE; only then does the read/write/fsync take
+/// effect on persisted state. This lets reads observe writes that
+/// completed in the meantime, and writes apply in completion order
+/// rather than submission order.
+pub(crate) enum PendingApply {
+    Read {
+        fd: RawFd,
+        ptr: *mut u8,
+        len: u32,
+        offset: u64,
+    },
+    Write {
+        fd: RawFd,
+        ptr: *const u8,
+        len: u32,
+        offset: u64,
+    },
+    Fsync {
+        fd: RawFd,
+    },
+    /// Posted by `cancel()` and unsupported-op paths.
+    ImmediateError(i32),
+}
+
+// Same Send/Sync rationale as `super::squeue::OpKind`: the buffer
+// lifetime is the caller's responsibility (real-io_uring contract),
+// and the per-host `Mutex` serializes drainer access.
+unsafe impl Send for PendingApply {}
+unsafe impl Sync for PendingApply {}
+
+impl PendingApply {
+    /// Execute the op against `fs`, returning the CQE result.
+    pub(crate) fn execute(self, fs: &mut Fs, rng: &mut dyn RngCore, now: Duration) -> i32 {
+        match self {
+            PendingApply::ImmediateError(err) => err,
+            PendingApply::Read {
+                fd,
+                ptr,
+                len,
+                offset,
+            } => exec_read(fs, rng, fd, ptr, len, offset),
+            PendingApply::Write {
+                fd,
+                ptr,
+                len,
+                offset,
+            } => exec_write(fs, rng, fd, ptr, len, offset, now),
+            PendingApply::Fsync { fd } => exec_fsync(fs, rng, fd),
+        }
+    }
+}
+
+// --- fs effect execution ---------------------------------------------
+//
+// These touch the existing `Fs` API surface (open_handles, read_file,
+// write_file, sync_file) and apply the same probabilistic fault knobs
+// the [`crate::fs::shim`] surface does. There is one source of truth
+// for fs behavior: ops submitted via io_uring observe the same
+// io_error_probability / short_read_probability / corruption_probability
+// / sync_probability the sync and tokio shims observe.
+//
+// # Divergence from real Linux: fd lifetime
+//
+// On real Linux, a file submitted via SQE has its open-file struct
+// reference-counted by the kernel; closing the fd does NOT cancel an
+// in-flight op. The simulation resolves the fd at completion time by
+// looking it up in `Fs::open_handles`, so closing the file (dropping
+// the `shim::std::fs::File`) between submit and completion turns the
+// CQE into `-EBADF` instead of completing normally. Consumers must
+// keep the file alive until they've drained the corresponding CQE.
+
+fn exec_read(
+    fs: &mut Fs,
+    rng: &mut dyn RngCore,
+    fd: RawFd,
+    ptr: *mut u8,
+    len: u32,
+    offset: u64,
+) -> i32 {
+    let Some(path) = fs.open_handles.get(&fd).cloned() else {
+        return -EBADF;
+    };
+
+    // O_DIRECT: enforce ptr/offset/len alignment, mirroring
+    // shim::std::fs::File::read_at_internal. Real io_uring on a
+    // misaligned O_DIRECT op returns -EINVAL.
+    if fs.direct_io_fds.contains(&fd) && !direct_io_aligned(fs, ptr as usize, offset, len) {
+        return -EINVAL;
+    }
+
+    // io_error_probability: surfaces as -EIO before touching the buf.
+    if sample_prob(rng, fs.io_error_probability) {
+        return -EIO;
+    }
+
+    // SAFETY: caller invariant — buffer remains valid for the in-flight
+    // lifetime of the op.
+    let buf = unsafe { std::slice::from_raw_parts_mut(ptr, len as usize) };
+    let mut n = fs.read_file(&path, buf, offset);
+
+    // short_read_probability: trim the reported count and zero the
+    // tail, mirroring shim::std::fs::File::read_at_internal.
+    if n > 1 && sample_prob(rng, fs.short_read_probability) {
+        let short = sample_range(rng, 1..n);
+        buf[short..n].fill(0);
+        n = short;
+    }
+
+    // corruption_probability: silent bit-flip on a random byte.
+    //
+    // TODO: when `unstable-barriers` is enabled, fire
+    // `crate::barriers::trigger_noop(crate::fs::FsCorruption { ... })`
+    // here — same as `shim::std::fs::File::read_at_internal` does —
+    // so tests observing FsCorruption events see ring-driven reads
+    // alongside shim reads.
+    if n > 0 && sample_prob(rng, fs.corruption_probability) {
+        let corrupt_offset = sample_range(rng, 0..n);
+        let corrupt_byte = (rng.next_u32() & 0xff) as u8;
+        // Ensure at least one bit flip.
+        buf[corrupt_offset] ^= corrupt_byte.max(1);
+    }
+
+    n as i32
+}
+
+fn exec_write(
+    fs: &mut Fs,
+    rng: &mut dyn RngCore,
+    fd: RawFd,
+    ptr: *const u8,
+    len: u32,
+    offset: u64,
+    now: Duration,
+) -> i32 {
+    let Some(path) = fs.open_handles.get(&fd).cloned() else {
+        return -EBADF;
+    };
+
+    // O_DIRECT alignment, see exec_read for the rationale.
+    if fs.direct_io_fds.contains(&fd) && !direct_io_aligned(fs, ptr as usize, offset, len) {
+        return -EINVAL;
+    }
+
+    // io_error_probability: surface -EIO before mutating state.
+    if sample_prob(rng, fs.io_error_probability) {
+        return -EIO;
+    }
+
+    // Capacity check, mirroring shim::std::fs::File::write_at_internal.
+    let current_len = fs.file_len(&path);
+    let write_end = offset + len as u64;
+    let additional = write_end.saturating_sub(current_len);
+    if additional > 0 && fs.check_space(additional).is_err() {
+        return -ENOSPC;
+    }
+
+    // SAFETY: same as above.
+    let buf = unsafe { std::slice::from_raw_parts(ptr, len as usize) };
+    fs.write_file(&path, offset, buf, now);
+
+    // sync_probability: spontaneous flush, again mirroring the shim.
+    if sample_prob(rng, fs.sync_probability) {
+        let _ = fs.sync_file(&path);
+    }
+
+    len as i32
+}
+
+fn exec_fsync(fs: &mut Fs, rng: &mut dyn RngCore, fd: RawFd) -> i32 {
+    let Some(path) = fs.open_handles.get(&fd).cloned() else {
+        return -EBADF;
+    };
+    if sample_prob(rng, fs.io_error_probability) {
+        return -EIO;
+    }
+    match fs.sync_file(&path) {
+        Ok(()) => 0,
+        Err(_) => -EIO,
+    }
+}
+
+fn sample_prob(rng: &mut dyn RngCore, p: f64) -> bool {
+    if p <= 0.0 {
+        return false;
+    }
+    if p >= 1.0 {
+        return true;
+    }
+    // 53-bit float in [0, 1). Same shape as rand's `gen_bool` path
+    // without forcing an extra trait import.
+    let bits = (rng.next_u64() >> 11) as f64 * (1.0 / (1u64 << 53) as f64);
+    bits < p
+}
+
+fn sample_range(rng: &mut dyn RngCore, range: std::ops::Range<usize>) -> usize {
+    let span = range.end - range.start;
+    debug_assert!(span > 0, "empty range");
+    range.start + (rng.next_u64() as usize) % span
+}
+
+/// O_DIRECT alignment check: pointer, offset, and length must each be
+/// multiples of `Fs::direct_io_alignment`. Mirrors the same check in
+/// the sync and tokio shims; real Linux returns `EINVAL` for these.
+fn direct_io_aligned(fs: &Fs, ptr: usize, offset: u64, len: u32) -> bool {
+    let alignment = fs.direct_io_alignment;
+    if alignment == 0 {
+        return true;
+    }
+    let align = alignment as usize;
+    ptr.is_multiple_of(align)
+        && offset.is_multiple_of(alignment)
+        && (len as u64).is_multiple_of(alignment)
+}
+
+const EBADF: i32 = 9;
+const EIO: i32 = 5;
+const ECANCELED: i32 = 125;
+const ENOENT: i32 = 2;
+const ENOSPC: i32 = 28;
+const EINVAL: i32 = 22;

--- a/crates/turmoil/src/io_uring/squeue.rs
+++ b/crates/turmoil/src/io_uring/squeue.rs
@@ -1,0 +1,224 @@
+//! Submission queue types mirroring [`io_uring::squeue`](https://docs.rs/io-uring/0.7/io_uring/squeue).
+
+use crate::fs::FsContext;
+use std::os::fd::RawFd;
+
+/// Sealed trait selecting between [`Entry`] (default) and the larger
+/// `Entry128` shape exposed by the real crate. Only `Entry` is
+/// implemented in the simulation.
+pub trait EntryMarker: private::Sealed + Sized {}
+
+/// One submission queue entry. Built by [`crate::io_uring::opcode`]
+/// builders and pushed onto a [`SubmissionQueue`].
+///
+/// The simulation does not preserve the kernel's wire layout — the
+/// fields are whatever the simulation needs to execute the op at
+/// completion time. Source-level compatibility is preserved: every
+/// method the real crate's `Entry` exposes (currently `user_data`,
+/// `flags`) returns `Entry` and is chainable.
+#[derive(Clone, Debug)]
+pub struct Entry {
+    pub(crate) op: OpKind,
+    pub(crate) user_data: u64,
+    pub(crate) flags: Flags,
+}
+
+impl Entry {
+    /// Replace the `user_data` tag posted in the resulting CQE.
+    pub fn user_data(mut self, ud: u64) -> Self {
+        self.user_data = ud;
+        self
+    }
+
+    /// Replace the per-op flags. Most flags are rejected at submit time
+    /// (see module docs); `ASYNC` is accepted as a no-op.
+    pub fn flags(mut self, f: Flags) -> Self {
+        self.flags = f;
+        self
+    }
+}
+
+impl EntryMarker for Entry {}
+
+/// Per-SQE flags. Mirrors `IOSQE_*`.
+#[derive(Copy, Clone, Default, Debug, Eq, PartialEq)]
+pub struct Flags(pub(crate) u8);
+
+impl Flags {
+    pub const FIXED_FILE: Self = Self(1 << 0);
+    pub const IO_DRAIN: Self = Self(1 << 1);
+    pub const IO_LINK: Self = Self(1 << 2);
+    pub const IO_HARDLINK: Self = Self(1 << 3);
+    pub const ASYNC: Self = Self(1 << 4);
+    pub const BUFFER_SELECT: Self = Self(1 << 5);
+
+    /// No flags. Mirrors `bitflags`'s `empty()` method on the real
+    /// crate's `Flags` type.
+    pub const fn empty() -> Self {
+        Self(0)
+    }
+
+    /// Whether any flag the simulation rejects is set.
+    pub(crate) fn has_unsupported(self) -> bool {
+        const REJECTED: u8 = Flags::FIXED_FILE.0
+            | Flags::IO_DRAIN.0
+            | Flags::IO_LINK.0
+            | Flags::IO_HARDLINK.0
+            | Flags::BUFFER_SELECT.0;
+        self.0 & REJECTED != 0
+    }
+}
+
+impl std::ops::BitOr for Flags {
+    type Output = Self;
+    fn bitor(self, rhs: Self) -> Self {
+        Self(self.0 | rhs.0)
+    }
+}
+
+impl std::ops::BitOrAssign for Flags {
+    fn bitor_assign(&mut self, rhs: Self) {
+        self.0 |= rhs.0;
+    }
+}
+
+/// What the SQE asks the simulation to do at completion time.
+///
+/// Stored on [`Entry`] in lieu of the kernel's opcode/field union.
+/// The buffer pointers are unsafe by construction — same caller
+/// invariants as the real crate (buffer must remain valid until the
+/// CQE is reaped, no aliasing).
+#[derive(Clone, Debug)]
+pub(crate) enum OpKind {
+    Read {
+        fd: RawFd,
+        ptr: *mut u8,
+        len: u32,
+        offset: u64,
+    },
+    Write {
+        fd: RawFd,
+        ptr: *const u8,
+        len: u32,
+        offset: u64,
+    },
+    Fsync {
+        fd: RawFd,
+    },
+    AsyncCancel {
+        target_user_data: u64,
+    },
+}
+
+// Raw pointers are not auto-Send/Sync. Sound here because:
+//
+// - The buffer's lifetime contract matches the real `io-uring` crate:
+//   the caller must keep it valid until the CQE is reaped, with no
+//   concurrent aliasing. We rely on that, same as Linux does.
+// - SQEs CAN cross threads via the `WORKER_FS_CONTEXT` thread-local
+//   path: a worker thread that called `FsHandle::enter()` may push
+//   an Entry into `RingState::sq` (held inside `Arc<Mutex<Fs>>`),
+//   and another thread later drains it in `schedule_pending`. The
+//   `Mutex` ensures the Entry is exclusively owned by one thread at
+//   a time, so `Send` is sound. Aliasing of the underlying buffer
+//   between submitter and drainer is the caller's responsibility.
+unsafe impl Send for OpKind {}
+unsafe impl Sync for OpKind {}
+
+/// Submission queue handle. Borrows the ring for the duration of its
+/// existence (or, for `submission_shared`, asserts unique writer
+/// access — see [`crate::io_uring::IoUring::submission_shared`]).
+pub struct SubmissionQueue<'a> {
+    ring_fd: RawFd,
+    _lifetime: std::marker::PhantomData<&'a ()>,
+}
+
+/// Returned by [`SubmissionQueue::push`] when the SQ is full.
+#[derive(Debug)]
+pub struct PushError;
+
+impl std::fmt::Display for PushError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str("submission queue is full")
+    }
+}
+
+impl std::error::Error for PushError {}
+
+impl<'a> SubmissionQueue<'a> {
+    pub(crate) fn new(ring_fd: RawFd) -> Self {
+        Self {
+            ring_fd,
+            _lifetime: std::marker::PhantomData,
+        }
+    }
+
+    /// Push one SQE into the ring's submission queue.
+    ///
+    /// # Safety
+    ///
+    /// Mirrors the real crate's contract: the caller must be the sole
+    /// writer of the SQ. The simulation does not currently enforce
+    /// this invariant.
+    pub unsafe fn push(&mut self, entry: &Entry) -> Result<(), PushError> {
+        FsContext::current(|ctx| {
+            let ring = ctx
+                .fs
+                .io_uring_rings
+                .get_mut(&self.ring_fd)
+                .ok_or(PushError)?;
+            if ring.sq.len() >= ring.depth as usize {
+                return Err(PushError);
+            }
+            ring.sq.push_back(entry.clone());
+            Ok(())
+        })
+    }
+
+    /// Number of entries currently queued (not yet submitted).
+    pub fn len(&self) -> usize {
+        FsContext::current(|ctx| {
+            ctx.fs
+                .io_uring_rings
+                .get(&self.ring_fd)
+                .map(|r| r.sq.len())
+                .unwrap_or(0)
+        })
+    }
+
+    /// Whether the SQ has no queued entries.
+    pub fn is_empty(&self) -> bool {
+        self.len() == 0
+    }
+
+    /// Whether the SQ is at its configured depth.
+    pub fn is_full(&self) -> bool {
+        FsContext::current(|ctx| {
+            ctx.fs
+                .io_uring_rings
+                .get(&self.ring_fd)
+                .map(|r| r.sq.len() >= r.depth as usize)
+                .unwrap_or(true)
+        })
+    }
+
+    /// Maximum SQ depth.
+    pub fn capacity(&self) -> usize {
+        FsContext::current(|ctx| {
+            ctx.fs
+                .io_uring_rings
+                .get(&self.ring_fd)
+                .map(|r| r.depth as usize)
+                .unwrap_or(0)
+        })
+    }
+
+    /// No-op in the simulation; mirrors the real crate's interface
+    /// where it synchronizes the userspace tail with the kernel head.
+    pub fn sync(&mut self) {}
+}
+
+mod private {
+    pub trait Sealed {}
+    impl Sealed for super::Entry {}
+}

--- a/crates/turmoil/src/io_uring/submit.rs
+++ b/crates/turmoil/src/io_uring/submit.rs
@@ -1,0 +1,206 @@
+//! Submitter handle mirroring [`io_uring::Submitter`](https://docs.rs/io-uring/0.7/io_uring/struct.Submitter.html).
+
+use super::sim::PendingApply;
+use super::squeue::{Entry, OpKind};
+use super::types::SubmitArgs;
+use crate::fs::FsContext;
+use std::io;
+use std::os::fd::RawFd;
+use std::time::Duration;
+
+/// Handle for the submit side of the ring.
+///
+/// In the simulation, `submit()` walks the SQ, schedules a per-op
+/// completion timestamp drawn from the configured I/O latency
+/// distribution, and returns. CQEs become observable via the
+/// [`crate::io_uring::cqueue::CompletionQueue`] iterator as simulated
+/// time advances past each timestamp.
+pub struct Submitter<'a> {
+    ring_fd: RawFd,
+    _lifetime: std::marker::PhantomData<&'a ()>,
+}
+
+impl<'a> Submitter<'a> {
+    pub(crate) fn new(ring_fd: RawFd) -> Self {
+        Self {
+            ring_fd,
+            _lifetime: std::marker::PhantomData,
+        }
+    }
+
+    /// Push every queued SQE into the in-flight set.
+    ///
+    /// Returns the number of SQEs accepted (matching the real kernel,
+    /// which may submit fewer than queued). The simulation always
+    /// accepts the entire SQ.
+    pub fn submit(&self) -> io::Result<usize> {
+        FsContext::current(|ctx| schedule_pending(ctx.fs, ctx.rng, ctx.now, self.ring_fd))
+    }
+
+    /// `submit()`, then in the real kernel block the calling thread
+    /// until at least `want` CQEs are ready.
+    ///
+    /// In the simulation the call is sync and returns as soon as the
+    /// SQ has been scheduled — there is no thread to block, and the
+    /// turmoil runtime advances simulated time only on `await`
+    /// points. Callers awaiting CQEs should use
+    /// [`crate::io_uring::AsyncFd::readable`] (which honors simulated
+    /// time) instead. The `want` argument is accepted for API
+    /// compatibility but has no in-sim effect.
+    pub fn submit_and_wait(&self, want: usize) -> io::Result<usize> {
+        self.submit_with_args(want, &SubmitArgs::default())
+    }
+
+    /// Submit + bounded wait, mirroring the real
+    /// `Submitter::submit_with_args`. `args.timeout` is recorded but
+    /// not honored: the simulation cannot block sync code on
+    /// simulated time. If a test needs a timeout, await
+    /// [`crate::io_uring::AsyncFd::readable`] inside a
+    /// `tokio::time::timeout` — both fire under simulated time and
+    /// give the same observable behavior as the real kernel call.
+    pub fn submit_with_args(&self, _want: usize, args: &SubmitArgs<'_>) -> io::Result<usize> {
+        // Validate the timespec shape: tv_nsec must be < 1_000_000_000
+        // per real-kernel rules. Surfaces an EINVAL on the call
+        // itself, before any SQE is scheduled.
+        if let Some(ts) = args.timeout {
+            if ts.nsec >= 1_000_000_000 {
+                return Err(io::Error::new(
+                    io::ErrorKind::InvalidInput,
+                    "SubmitArgs::timespec: nsec must be < 1_000_000_000",
+                ));
+            }
+        }
+        FsContext::current(|ctx| schedule_pending(ctx.fs, ctx.rng, ctx.now, self.ring_fd))
+    }
+}
+
+/// Walk the ring's SQ; for each entry, sample latency and either
+/// schedule a future CQE or post an immediate `EINVAL` CQE for
+/// unsupported ops.
+fn schedule_pending(
+    fs: &mut crate::fs::Fs,
+    rng: &mut dyn rand::RngCore,
+    now: Duration,
+    ring_fd: RawFd,
+) -> io::Result<usize> {
+    // Drain SQ first (single mutable borrow), then process each entry
+    // by re-borrowing the ring on demand. Latency sampling needs
+    // `&Fs`, so we cannot keep `&mut RingState` live across it.
+    let entries: Vec<Entry> = match fs.io_uring_rings.get_mut(&ring_fd) {
+        Some(ring) => ring.sq.drain(..).collect(),
+        None => {
+            return Err(io::Error::new(
+                io::ErrorKind::NotFound,
+                "io_uring ring is no longer registered",
+            ));
+        }
+    };
+
+    let mut accepted = 0usize;
+    for entry in entries {
+        accepted += 1;
+        if entry.flags.has_unsupported() {
+            let ring = fs.io_uring_rings.get_mut(&ring_fd).expect("ring vanished");
+            ring.post_immediate_error(entry.user_data, libc_einval(), now);
+            continue;
+        }
+        match entry.op {
+            OpKind::Read {
+                fd,
+                ptr,
+                len,
+                offset,
+            } => {
+                // Mirror shim::tokio::fs::apply_read_latency: O_DIRECT
+                // bypasses the cache; otherwise probe `access()` and
+                // bump the LRU via `insert()`. We sample latency with
+                // the resulting cache_hit so reads of recently-touched
+                // offsets are near-instant.
+                //
+                // Divergence: on real Linux, two reads at the same
+                // offset submitted in one batch both miss the cache
+                // until the first completes. Here, the second sees a
+                // hit because we insert at submit time. This matches
+                // how the existing tokio shim models the cache —
+                // the simulation is internally consistent with
+                // itself even where it differs from the kernel.
+                let direct_io = fs.direct_io_fds.contains(&fd);
+                let cache_hit = if direct_io {
+                    false
+                } else if let Some(path) = fs.open_handles.get(&fd).cloned() {
+                    if let Some(cache) = &mut fs.page_cache {
+                        let hit = cache.access(&path, offset, rng);
+                        cache.insert(&path, offset);
+                        hit
+                    } else {
+                        false
+                    }
+                } else {
+                    // Bad fd; let exec_read surface -EBADF later. No
+                    // sensible cache state to consult.
+                    false
+                };
+                let latency = fs.calculate_latency(rng, cache_hit);
+                let ring = fs.io_uring_rings.get_mut(&ring_fd).expect("ring vanished");
+                ring.schedule(
+                    entry.user_data,
+                    now + latency,
+                    PendingApply::Read {
+                        fd,
+                        ptr,
+                        len,
+                        offset,
+                    },
+                );
+            }
+            OpKind::Write {
+                fd,
+                ptr,
+                len,
+                offset,
+            } => {
+                // Mirror shim::tokio::fs::apply_write_latency: writes
+                // populate the cache (write-through) unless O_DIRECT.
+                // Latency itself never sees a cache hit on writes —
+                // they always wait for disk.
+                let direct_io = fs.direct_io_fds.contains(&fd);
+                if !direct_io {
+                    if let Some(path) = fs.open_handles.get(&fd).cloned() {
+                        if let Some(cache) = &mut fs.page_cache {
+                            cache.insert(&path, offset);
+                        }
+                    }
+                }
+                let latency = fs.calculate_latency(rng, false);
+                let ring = fs.io_uring_rings.get_mut(&ring_fd).expect("ring vanished");
+                ring.schedule(
+                    entry.user_data,
+                    now + latency,
+                    PendingApply::Write {
+                        fd,
+                        ptr,
+                        len,
+                        offset,
+                    },
+                );
+            }
+            OpKind::Fsync { fd } => {
+                let latency = fs.calculate_latency(rng, false);
+                let ring = fs.io_uring_rings.get_mut(&ring_fd).expect("ring vanished");
+                ring.schedule(entry.user_data, now + latency, PendingApply::Fsync { fd });
+            }
+            OpKind::AsyncCancel { target_user_data } => {
+                let ring = fs.io_uring_rings.get_mut(&ring_fd).expect("ring vanished");
+                ring.cancel(entry.user_data, target_user_data, now);
+            }
+        }
+    }
+    Ok(accepted)
+}
+
+/// `EINVAL` as a negative `errno`, the form CQE results take for
+/// errors. Linux's value; we use the constant directly to avoid
+/// pulling in libc on non-Linux targets.
+fn libc_einval() -> i32 {
+    -22
+}

--- a/crates/turmoil/src/io_uring/types.rs
+++ b/crates/turmoil/src/io_uring/types.rs
@@ -1,0 +1,77 @@
+//! Type fragments mirroring [`io_uring::types`](https://docs.rs/io-uring/0.7/io_uring/types).
+
+use std::os::fd::RawFd;
+use std::time::Duration;
+
+/// File-descriptor wrapper consumed by opcode builders.
+///
+/// Holds the same kind of integer the real crate accepts. In the
+/// simulation the integer is one allocated by
+/// [`crate::fs::Fs::alloc_fd`] (i.e. from the high `SIM_FD_BASE` range)
+/// and is resolved back to a path by the ring at completion time.
+#[derive(Copy, Clone, Eq, PartialEq, Debug)]
+pub struct Fd(pub RawFd);
+
+/// Mirrors [`io_uring::types::Timespec`].
+#[derive(Copy, Clone, Default, Debug, PartialEq, Eq)]
+pub struct Timespec {
+    pub(crate) sec: u64,
+    pub(crate) nsec: u32,
+}
+
+impl Timespec {
+    /// Construct a zero-duration `Timespec`. Use [`Timespec::sec`]
+    /// and [`Timespec::nsec`] to set the components.
+    pub const fn new() -> Self {
+        Self { sec: 0, nsec: 0 }
+    }
+
+    /// Replace the second component.
+    pub const fn sec(mut self, sec: u64) -> Self {
+        self.sec = sec;
+        self
+    }
+
+    /// Replace the nanosecond component.
+    pub const fn nsec(mut self, nsec: u32) -> Self {
+        self.nsec = nsec;
+        self
+    }
+}
+
+impl From<Duration> for Timespec {
+    fn from(d: Duration) -> Self {
+        Self {
+            sec: d.as_secs(),
+            nsec: d.subsec_nanos(),
+        }
+    }
+}
+
+/// Arguments for [`crate::io_uring::Submitter::submit_with_args`].
+///
+/// The timespec timeout is validated for shape (nsec must be a valid
+/// nanosecond) but is not used to bound a wait — `submit_with_args`
+/// is sync and the simulation cannot block sync code on simulated
+/// time. Tests needing a real wall-time bound should await on
+/// [`crate::io_uring::AsyncFd::readable`] inside a
+/// `tokio::time::timeout`. The sigmask field exists for source
+/// compatibility but is ignored.
+#[derive(Default)]
+pub struct SubmitArgs<'a> {
+    pub(crate) timeout: Option<Timespec>,
+    _lifetime: std::marker::PhantomData<&'a ()>,
+}
+
+impl<'a> SubmitArgs<'a> {
+    /// Construct empty args.
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// Set a timeout for [`crate::io_uring::Submitter::submit_with_args`].
+    pub fn timespec(mut self, ts: &'a Timespec) -> Self {
+        self.timeout = Some(*ts);
+        self
+    }
+}

--- a/crates/turmoil/src/lib.rs
+++ b/crates/turmoil/src/lib.rs
@@ -204,6 +204,9 @@ pub mod fs;
 #[cfg(feature = "unstable-fs")]
 pub use fs::FsConfig;
 
+#[cfg(feature = "unstable-io_uring")]
+pub mod io_uring;
+
 #[cfg(feature = "unstable-barriers")]
 pub mod barriers;
 

--- a/crates/turmoil/tests/fs/basic.rs
+++ b/crates/turmoil/tests/fs/basic.rs
@@ -336,3 +336,88 @@ fn per_host_isolation() -> Result {
     });
     sim.run()
 }
+
+#[test]
+fn as_raw_fd_yields_distinct_high_range_values() -> Result {
+    use std::os::fd::AsRawFd;
+    let mut sim = Builder::new().build();
+    sim.client("test", async {
+        create_dir_all("/test")?;
+        let f1 = OpenOptions::new()
+            .read(true)
+            .write(true)
+            .create(true)
+            .open("/test/a")?;
+        let f2 = OpenOptions::new()
+            .read(true)
+            .write(true)
+            .create(true)
+            .open("/test/b")?;
+        // Distinct fds.
+        assert_ne!(f1.as_raw_fd(), f2.as_raw_fd());
+        // Both above SIM_FD_BASE, so they cannot collide with real OS fds.
+        assert!(
+            f1.as_raw_fd() >= 1 << 30,
+            "fd {} below SIM_FD_BASE",
+            f1.as_raw_fd()
+        );
+        assert!(
+            f2.as_raw_fd() >= 1 << 30,
+            "fd {} below SIM_FD_BASE",
+            f2.as_raw_fd()
+        );
+        Ok(())
+    });
+    sim.run()
+}
+
+#[test]
+fn as_raw_fd_isolated_per_host() -> Result {
+    use std::os::fd::AsRawFd;
+    use std::sync::Arc;
+    use tokio::sync::Notify;
+    let mut sim = Builder::new().build();
+    // Each host opens one file; both expect the same fd integer because
+    // the fd table is per-host (two independent counters starting at
+    // SIM_FD_BASE).
+    let n1 = Arc::new(Notify::new());
+    let n2 = Arc::new(Notify::new());
+    let n1h = n1.clone();
+    sim.host("host1", move || {
+        let n = n1h.clone();
+        async move {
+            create_dir_all("/h")?;
+            let f = OpenOptions::new()
+                .read(true)
+                .write(true)
+                .create(true)
+                .open("/h/f")?;
+            assert_eq!(f.as_raw_fd(), 1 << 30);
+            n.notify_one();
+            std::future::pending::<()>().await;
+            Ok(())
+        }
+    });
+    let n2h = n2.clone();
+    sim.host("host2", move || {
+        let n = n2h.clone();
+        async move {
+            create_dir_all("/h")?;
+            let f = OpenOptions::new()
+                .read(true)
+                .write(true)
+                .create(true)
+                .open("/h/f")?;
+            assert_eq!(f.as_raw_fd(), 1 << 30);
+            n.notify_one();
+            std::future::pending::<()>().await;
+            Ok(())
+        }
+    });
+    sim.client("test", async move {
+        n1.notified().await;
+        n2.notified().await;
+        Ok(())
+    });
+    sim.run()
+}

--- a/crates/turmoil/tests/fs/io_uring.rs
+++ b/crates/turmoil/tests/fs/io_uring.rs
@@ -1,0 +1,1300 @@
+//! Smoke tests for [`turmoil::io_uring`].
+//!
+//! Exercises the core ring data flow: push SQE, submit, drain CQE,
+//! observe the side effects landing in the simulated fs. Out-of-order
+//! completion, fault wiring, and crash semantics are covered in their
+//! own task-specific modules.
+
+use std::os::fd::AsRawFd;
+use std::os::unix::fs::{FileExt, OpenOptionsExt};
+use turmoil::fs::shim::std::fs::{create_dir_all, OpenOptions};
+use turmoil::io_uring::{cqueue, opcode, squeue, types, AsyncFd, IoUring};
+use turmoil::{Builder, Result};
+
+const TEST_DIR: &str = "/uring";
+
+fn open_rw(path: &str) -> std::io::Result<turmoil::fs::shim::std::fs::File> {
+    OpenOptions::new()
+        .read(true)
+        .write(true)
+        .create(true)
+        .open(path)
+}
+
+#[test]
+fn write_then_read_via_ring() -> Result {
+    let mut sim = Builder::new().build();
+    sim.client("c", async {
+        create_dir_all(TEST_DIR)?;
+        let file = open_rw(&format!("{TEST_DIR}/data"))?;
+        let fd = types::Fd(file.as_raw_fd());
+
+        let mut ring = IoUring::new(8).expect("new ring");
+
+        // Submit a Write.
+        let payload = b"hello uring".to_vec();
+        let write = opcode::Write::new(fd, payload.as_ptr(), payload.len() as u32)
+            .offset(0)
+            .build()
+            .user_data(1);
+        unsafe {
+            ring.submission().push(&write).expect("push write");
+        }
+        ring.submit().expect("submit write");
+
+        // Drain its CQE.
+        let cqe = drain_one(&mut ring).await;
+        assert_eq!(cqe.user_data(), 1);
+        assert_eq!(cqe.result(), payload.len() as i32);
+
+        // Submit a Read into a fresh buffer.
+        let mut buf = vec![0u8; payload.len()];
+        let read = opcode::Read::new(fd, buf.as_mut_ptr(), buf.len() as u32)
+            .offset(0)
+            .build()
+            .user_data(2);
+        unsafe {
+            ring.submission().push(&read).expect("push read");
+        }
+        ring.submit().expect("submit read");
+
+        let cqe = drain_one(&mut ring).await;
+        assert_eq!(cqe.user_data(), 2);
+        assert_eq!(cqe.result(), payload.len() as i32);
+        assert_eq!(buf, payload);
+
+        // Hold the file alive across the ops to keep its fd live.
+        drop(file);
+        Ok(())
+    });
+    sim.run()
+}
+
+#[test]
+fn fsync_returns_zero() -> Result {
+    let mut sim = Builder::new().build();
+    sim.client("c", async {
+        create_dir_all(TEST_DIR)?;
+        let file = open_rw(&format!("{TEST_DIR}/sync"))?;
+        let fd = types::Fd(file.as_raw_fd());
+        let mut ring = IoUring::new(4).expect("new ring");
+
+        let entry = opcode::Fsync::new(fd).build().user_data(7);
+        unsafe {
+            ring.submission().push(&entry).expect("push fsync");
+        }
+        ring.submit().expect("submit fsync");
+
+        let cqe = drain_one(&mut ring).await;
+        assert_eq!(cqe.user_data(), 7);
+        assert_eq!(cqe.result(), 0);
+        drop(file);
+        Ok(())
+    });
+    sim.run()
+}
+
+#[test]
+fn ring_fsync_makes_ring_writes_durable() -> Result {
+    // Pure-ring durability: write via ring, fsync via ring (no shim
+    // sync), crash + bounce, expect data to survive. The mix_*
+    // tests cover ring+shim cross-flush; this test pins the
+    // ring-only path so a regression in exec_fsync's wiring (e.g.
+    // calling sync_data instead of sync_file, or skipping the
+    // sync_dir step) shows up.
+    use std::sync::atomic::{AtomicBool, Ordering};
+    use std::sync::Arc;
+    use tokio::sync::Notify;
+
+    let mut sim = Builder::new().build();
+    let phase = Arc::new(AtomicBool::new(false));
+    let notify = Arc::new(Notify::new());
+    let phase_host = phase.clone();
+    let notify_host = notify.clone();
+
+    sim.host("server", move || {
+        let phase = phase_host.clone();
+        let notify = notify_host.clone();
+        async move {
+            if !phase.load(Ordering::SeqCst) {
+                create_dir_all(TEST_DIR)?;
+                turmoil::fs::shim::std::fs::sync_dir("/")?;
+                let file = open_rw(&format!("{TEST_DIR}/ring-durable"))?;
+                let fd = types::Fd(file.as_raw_fd());
+                let mut ring = IoUring::new(4).expect("ring");
+
+                let payload = b"ring-durable".to_vec();
+                let w = opcode::Write::new(fd, payload.as_ptr(), payload.len() as u32)
+                    .build()
+                    .user_data(1);
+                unsafe {
+                    ring.submission().push(&w).expect("push w");
+                }
+                ring.submit().expect("submit w");
+                let _ = drain_one(&mut ring).await;
+
+                let f = opcode::Fsync::new(fd).build().user_data(2);
+                unsafe {
+                    ring.submission().push(&f).expect("push f");
+                }
+                ring.submit().expect("submit f");
+                let cqe = drain_one(&mut ring).await;
+                assert_eq!(cqe.result(), 0);
+                turmoil::fs::shim::std::fs::sync_dir(TEST_DIR)?;
+                std::mem::forget(file);
+            } else {
+                let file = OpenOptions::new()
+                    .read(true)
+                    .open(format!("{TEST_DIR}/ring-durable"))?;
+                let mut buf = [0u8; 12];
+                file.read_at(&mut buf, 0)?;
+                assert_eq!(&buf, b"ring-durable");
+            }
+            notify.notify_one();
+            std::future::pending::<()>().await;
+            Ok(())
+        }
+    });
+    let n = notify.clone();
+    sim.client("phase0", async move {
+        n.notified().await;
+        Ok(())
+    });
+    sim.run()?;
+    sim.crash("server");
+    phase.store(true, Ordering::SeqCst);
+    sim.bounce("server");
+    let n = notify.clone();
+    sim.client("phase1", async move {
+        n.notified().await;
+        Ok(())
+    });
+    sim.run()
+}
+
+#[test]
+fn many_concurrent_reads_complete_in_shuffled_order() -> Result {
+    // Submits N reads; verifies all N CQEs come back with correct
+    // user_data and result, regardless of order. The order itself is
+    // RNG-shuffled inside the simulation, so we only check coverage.
+    let mut sim = Builder::new().build();
+    sim.client("c", async {
+        create_dir_all(TEST_DIR)?;
+        let path = format!("{TEST_DIR}/many");
+        let file = open_rw(&path)?;
+        let fd = types::Fd(file.as_raw_fd());
+
+        // Seed the file with content via a single ring write.
+        let payload: Vec<u8> = (0..(64 * 8)).map(|i| (i & 0xff) as u8).collect();
+        let mut ring = IoUring::new(64).expect("new ring");
+        let write = opcode::Write::new(fd, payload.as_ptr(), payload.len() as u32)
+            .build()
+            .user_data(0);
+        unsafe {
+            ring.submission().push(&write).expect("push seed");
+        }
+        ring.submit().expect("submit seed");
+        let _ = drain_one(&mut ring).await;
+
+        // Submit 64 reads at distinct offsets, distinct user_data tags.
+        let mut bufs: Vec<Vec<u8>> = (0..64).map(|_| vec![0u8; 8]).collect();
+        for (i, buf) in bufs.iter_mut().enumerate() {
+            let entry = opcode::Read::new(fd, buf.as_mut_ptr(), buf.len() as u32)
+                .offset((i * 8) as u64)
+                .build()
+                .user_data(100 + i as u64);
+            unsafe {
+                ring.submission().push(&entry).expect("push read");
+            }
+        }
+        ring.submit().expect("submit reads");
+
+        // Drain all 64; record the arrival order.
+        let mut seen: Vec<u64> = Vec::new();
+        for _ in 0..64 {
+            let cqe = drain_one(&mut ring).await;
+            seen.push(cqe.user_data());
+        }
+
+        // (a) Coverage: every submitted user_data shows up exactly once.
+        let mut sorted = seen.clone();
+        sorted.sort_unstable();
+        let expected: Vec<u64> = (100..164).collect();
+        assert_eq!(sorted, expected);
+
+        // (b) Out-of-order: the simulation shuffles matured CQEs with
+        // the seed RNG, so arrival order MUST differ from submission
+        // order at least somewhere. A FIFO regression would fail
+        // here. (Probability of all 64 landing in submission order
+        // by accident is 1/64! — vanishingly small.)
+        assert_ne!(
+            seen, expected,
+            "CQEs delivered in submission order; sim should shuffle"
+        );
+
+        // Spot-check buffer content of two reads to confirm payloads
+        // weren't garbled by the reorder.
+        assert_eq!(bufs[0][0], 0);
+        assert_eq!(bufs[10][0], (10 * 8) as u8);
+        drop(file);
+        Ok(())
+    });
+    sim.run()
+}
+
+#[test]
+fn read_with_invalid_fd_returns_ebadf() -> Result {
+    let mut sim = Builder::new().build();
+    sim.client("c", async {
+        let mut ring = IoUring::new(4).expect("new ring");
+        let mut buf = [0u8; 4];
+        let bogus = types::Fd(999_999_999); // outside SIM_FD_BASE range
+        let entry = opcode::Read::new(bogus, buf.as_mut_ptr(), buf.len() as u32)
+            .build()
+            .user_data(11);
+        unsafe {
+            ring.submission().push(&entry).expect("push read");
+        }
+        ring.submit().expect("submit read");
+        let cqe = drain_one(&mut ring).await;
+        assert_eq!(cqe.user_data(), 11);
+        assert_eq!(cqe.result(), -9, "expected -EBADF");
+        Ok(())
+    });
+    sim.run()
+}
+
+#[test]
+fn o_direct_misaligned_read_yields_einval() -> Result {
+    // O_DIRECT requires ptr/offset/len to be multiples of
+    // direct_io_alignment. Real Linux returns -EINVAL for misaligned
+    // ops; the simulation surfaces the same.
+    let mut sim = Builder::new().build();
+    sim.client("c", async {
+        create_dir_all(TEST_DIR)?;
+        // direct_io_alignment defaults to 512; ask for direct I/O.
+        let file = OpenOptions::new()
+            .read(true)
+            .write(true)
+            .create(true)
+            .custom_flags(0x4000) // O_DIRECT (turmoil's documented value)
+            .open(format!("{TEST_DIR}/odirect"))?;
+        let fd = types::Fd(file.as_raw_fd());
+        let mut ring = IoUring::new(4).expect("new ring");
+
+        // 7-byte buffer at non-page-aligned offset: violates all three
+        // alignment requirements.
+        let mut buf = [0u8; 7];
+        let entry = opcode::Read::new(fd, buf.as_mut_ptr(), buf.len() as u32)
+            .offset(1)
+            .build()
+            .user_data(1);
+        unsafe {
+            ring.submission().push(&entry).expect("push");
+        }
+        ring.submit().expect("submit");
+        let cqe = drain_one(&mut ring).await;
+        assert_eq!(
+            cqe.result(),
+            -22,
+            "expected -EINVAL for misaligned O_DIRECT"
+        );
+        drop(file);
+        Ok(())
+    });
+    sim.run()
+}
+
+#[test]
+fn submit_with_args_rejects_bad_timespec() -> Result {
+    // tv_nsec must be < 1_000_000_000. Real-kernel io_uring_enter
+    // returns EINVAL on a bad timespec; the simulation should match.
+    let mut sim = Builder::new().build();
+    sim.client("c", async {
+        let ring = IoUring::new(2).expect("new ring");
+        let bogus = types::Timespec::new().sec(1).nsec(1_500_000_000);
+        let args = types::SubmitArgs::new().timespec(&bogus);
+        let res = ring.submitter().submit_with_args(0, &args);
+        match res {
+            Err(e) if e.kind() == std::io::ErrorKind::InvalidInput => {}
+            other => panic!("expected InvalidInput, got {other:?}"),
+        }
+        Ok(())
+    });
+    sim.run()
+}
+
+#[test]
+fn io_link_flag_yields_einval() -> Result {
+    // IOSQE_IO_LINK is one of the SQE flags the simulation rejects.
+    // Submitting an SQE with the flag set must surface as -EINVAL on
+    // its CQE (same as the real kernel's behavior for an unsupported
+    // op flag).
+    let mut sim = Builder::new().build();
+    sim.client("c", async {
+        create_dir_all(TEST_DIR)?;
+        let file = open_rw(&format!("{TEST_DIR}/link"))?;
+        let fd = types::Fd(file.as_raw_fd());
+        let mut ring = IoUring::new(4).expect("new ring");
+        let mut buf = [0u8; 4];
+        let entry = opcode::Read::new(fd, buf.as_mut_ptr(), buf.len() as u32)
+            .build()
+            .user_data(1)
+            .flags(squeue::Flags::IO_LINK);
+        unsafe {
+            ring.submission().push(&entry).expect("push");
+        }
+        ring.submit().expect("submit");
+        let cqe = drain_one(&mut ring).await;
+        assert_eq!(cqe.user_data(), 1);
+        assert_eq!(cqe.result(), -22, "expected -EINVAL for IO_LINK");
+        drop(file);
+        Ok(())
+    });
+    sim.run()
+}
+
+#[test]
+fn async_cancel_targets_inflight_op() -> Result {
+    let mut builder = Builder::new();
+    builder
+        .fs()
+        .io_latency()
+        .min_latency(std::time::Duration::from_millis(10))
+        .max_latency(std::time::Duration::from_millis(10));
+    let mut sim = builder.build();
+    sim.client("c", async {
+        create_dir_all(TEST_DIR)?;
+        let file = open_rw(&format!("{TEST_DIR}/cancel"))?;
+        let fd = types::Fd(file.as_raw_fd());
+        let mut ring = IoUring::new(4).expect("new ring");
+
+        // Stage a slow read (10ms).
+        let mut buf = vec![0u8; 8];
+        let read = opcode::Read::new(fd, buf.as_mut_ptr(), buf.len() as u32)
+            .build()
+            .user_data(20);
+        unsafe {
+            ring.submission().push(&read).expect("push read");
+        }
+        ring.submit().expect("submit read");
+
+        // Cancel by user_data before time advances enough for the read
+        // to mature.
+        let cancel = opcode::AsyncCancel::new(20).build().user_data(21);
+        unsafe {
+            ring.submission().push(&cancel).expect("push cancel");
+        }
+        ring.submit().expect("submit cancel");
+
+        // Drain both CQEs. Order is shuffled.
+        let mut by_ud = std::collections::HashMap::new();
+        for _ in 0..2 {
+            let cqe = drain_one(&mut ring).await;
+            by_ud.insert(cqe.user_data(), cqe.result());
+        }
+        assert_eq!(by_ud.get(&20), Some(&-125), "read should be -ECANCELED");
+        assert_eq!(by_ud.get(&21), Some(&0), "cancel itself succeeds");
+        drop(file);
+        Ok(())
+    });
+    sim.run()
+}
+
+#[test]
+fn io_error_probability_surfaces_eio() -> Result {
+    let mut builder = Builder::new();
+    builder.fs().io_error_probability(1.0);
+    let mut sim = builder.build();
+    sim.client("c", async {
+        create_dir_all(TEST_DIR)?;
+        let file = open_rw(&format!("{TEST_DIR}/eio"))?;
+        let fd = types::Fd(file.as_raw_fd());
+        let mut ring = IoUring::new(4).expect("new ring");
+
+        // Read should error. Use a tiny buffer so the slice is valid
+        // regardless of file content.
+        let mut buf = [0u8; 4];
+        let read = opcode::Read::new(fd, buf.as_mut_ptr(), buf.len() as u32)
+            .build()
+            .user_data(1);
+        unsafe {
+            ring.submission().push(&read).expect("push read");
+        }
+        ring.submit().expect("submit");
+        let cqe = drain_one(&mut ring).await;
+        assert_eq!(cqe.result(), -5, "expected -EIO on forced io_error");
+        drop(file);
+        Ok(())
+    });
+    sim.run()
+}
+
+#[test]
+fn corruption_probability_flips_a_byte() -> Result {
+    let mut builder = Builder::new();
+    builder.fs().corruption_probability(1.0);
+    let mut sim = builder.build();
+    sim.client("c", async {
+        create_dir_all(TEST_DIR)?;
+        let file = open_rw(&format!("{TEST_DIR}/corrupt"))?;
+        let fd = types::Fd(file.as_raw_fd());
+        let mut ring = IoUring::new(4).expect("new ring");
+
+        // Seed via ring write so the test exercises the same path.
+        let payload = b"the quick brown fox".to_vec();
+        let w = opcode::Write::new(fd, payload.as_ptr(), payload.len() as u32)
+            .build()
+            .user_data(1);
+        unsafe {
+            ring.submission().push(&w).expect("push w");
+        }
+        ring.submit().expect("submit w");
+        let _ = drain_one(&mut ring).await;
+
+        // Read it back; at least one byte should differ.
+        let mut buf = vec![0u8; payload.len()];
+        let r = opcode::Read::new(fd, buf.as_mut_ptr(), buf.len() as u32)
+            .build()
+            .user_data(2);
+        unsafe {
+            ring.submission().push(&r).expect("push r");
+        }
+        ring.submit().expect("submit r");
+        let cqe = drain_one(&mut ring).await;
+        assert_eq!(cqe.result(), payload.len() as i32);
+        assert_ne!(buf, payload, "100% corruption should flip a byte");
+        drop(file);
+        Ok(())
+    });
+    sim.run()
+}
+
+#[test]
+fn short_read_probability_truncates() -> Result {
+    let mut builder = Builder::new();
+    builder.fs().short_read_probability(1.0);
+    let mut sim = builder.build();
+    sim.client("c", async {
+        create_dir_all(TEST_DIR)?;
+        let file = open_rw(&format!("{TEST_DIR}/short"))?;
+        let fd = types::Fd(file.as_raw_fd());
+        let mut ring = IoUring::new(4).expect("new ring");
+
+        // Seed file with more than 1 byte so short_read can fire (the
+        // shim only shortens when n > 1).
+        let payload = b"abcdef".to_vec();
+        let w = opcode::Write::new(fd, payload.as_ptr(), payload.len() as u32)
+            .build()
+            .user_data(1);
+        unsafe {
+            ring.submission().push(&w).expect("push w");
+        }
+        ring.submit().expect("submit w");
+        let _ = drain_one(&mut ring).await;
+
+        let mut buf = vec![0u8; payload.len()];
+        let r = opcode::Read::new(fd, buf.as_mut_ptr(), buf.len() as u32)
+            .build()
+            .user_data(2);
+        unsafe {
+            ring.submission().push(&r).expect("push r");
+        }
+        ring.submit().expect("submit r");
+        let cqe = drain_one(&mut ring).await;
+        assert!(
+            cqe.result() > 0 && (cqe.result() as usize) < payload.len(),
+            "expected short read; got {}",
+            cqe.result()
+        );
+        drop(file);
+        Ok(())
+    });
+    sim.run()
+}
+
+#[test]
+fn crash_drops_unsynced_writes_submitted_via_ring() -> Result {
+    use std::sync::atomic::{AtomicBool, Ordering};
+    use std::sync::Arc;
+    use tokio::sync::Notify;
+
+    // Phase 0: write via ring without fsync -> not durable.
+    // Phase 1: after crash + bounce, the file should be gone.
+    let mut sim = Builder::new().build();
+    let phase = Arc::new(AtomicBool::new(false));
+    let notify = Arc::new(Notify::new());
+    let phase_host = phase.clone();
+    let notify_host = notify.clone();
+
+    sim.host("server", move || {
+        let phase = phase_host.clone();
+        let notify = notify_host.clone();
+        async move {
+            if !phase.load(Ordering::SeqCst) {
+                create_dir_all(TEST_DIR)?;
+                turmoil::fs::shim::std::fs::sync_dir("/")?;
+                let file = open_rw(&format!("{TEST_DIR}/lost"))?;
+                let fd = types::Fd(file.as_raw_fd());
+                let mut ring = IoUring::new(4).expect("new ring");
+
+                let payload = b"unsynced via ring".to_vec();
+                let w = opcode::Write::new(fd, payload.as_ptr(), payload.len() as u32)
+                    .build()
+                    .user_data(1);
+                unsafe {
+                    ring.submission().push(&w).expect("push w");
+                }
+                ring.submit().expect("submit w");
+                // Drain so the write side effect actually lands in the
+                // pending op queue (without fsync, it's still
+                // unsynced and will be lost on crash).
+                let _ = drain_one(&mut ring).await;
+                // Deliberately NO fsync.
+                std::mem::forget(file); // keep fd alive across crash test
+            } else {
+                // Phase 1: file should not exist (open without create).
+                let exists = OpenOptions::new()
+                    .read(true)
+                    .open(format!("{TEST_DIR}/lost"))
+                    .is_ok();
+                assert!(!exists, "unsynced ring write should not survive crash");
+            }
+            notify.notify_one();
+            std::future::pending::<()>().await;
+            Ok(())
+        }
+    });
+
+    let n = notify.clone();
+    sim.client("phase0", async move {
+        n.notified().await;
+        Ok(())
+    });
+    sim.run()?;
+    sim.crash("server");
+    phase.store(true, Ordering::SeqCst);
+    sim.bounce("server");
+    let n = notify.clone();
+    sim.client("phase1", async move {
+        n.notified().await;
+        Ok(())
+    });
+    sim.run()
+}
+
+#[test]
+fn crash_drops_inflight_ops_so_no_cqes() -> Result {
+    use std::sync::atomic::{AtomicBool, Ordering};
+    use std::sync::Arc;
+    use tokio::sync::Notify;
+
+    // Submit an op with non-zero latency so it stays in-flight; crash;
+    // verify the post-bounce host can't observe a CQE for it.
+    let mut builder = Builder::new();
+    builder
+        .fs()
+        .io_latency()
+        .min_latency(std::time::Duration::from_secs(1))
+        .max_latency(std::time::Duration::from_secs(1));
+    let mut sim = builder.build();
+    let phase = Arc::new(AtomicBool::new(false));
+    let notify = Arc::new(Notify::new());
+    let phase_host = phase.clone();
+    let notify_host = notify.clone();
+
+    sim.host("server", move || {
+        let phase = phase_host.clone();
+        let notify = notify_host.clone();
+        async move {
+            if !phase.load(Ordering::SeqCst) {
+                create_dir_all(TEST_DIR)?;
+                turmoil::fs::shim::std::fs::sync_dir("/")?;
+                let file = open_rw(&format!("{TEST_DIR}/inflight"))?;
+                let fd = types::Fd(file.as_raw_fd());
+                let mut ring = IoUring::new(4).expect("new ring");
+
+                // Stage a 1-second-latency read.
+                let mut buf = vec![0u8; 8];
+                let r = opcode::Read::new(fd, buf.as_mut_ptr(), buf.len() as u32)
+                    .build()
+                    .user_data(99);
+                unsafe {
+                    ring.submission().push(&r).expect("push r");
+                }
+                ring.submit().expect("submit r");
+                // Don't wait for completion — let it stay in-flight.
+                std::mem::forget(file);
+            } else {
+                // Phase 1: a fresh ring observes no stale CQEs even
+                // after a sync — there's nothing in the ring to expose.
+                let mut ring = IoUring::new(4).expect("new ring after bounce");
+                let mut cq = ring.completion();
+                cq.sync();
+                assert!(
+                    cq.next().is_none(),
+                    "fresh ring after bounce should be empty"
+                );
+            }
+            notify.notify_one();
+            std::future::pending::<()>().await;
+            Ok(())
+        }
+    });
+
+    let n = notify.clone();
+    sim.client("phase0", async move {
+        n.notified().await;
+        Ok(())
+    });
+    sim.run()?;
+    sim.crash("server");
+    phase.store(true, Ordering::SeqCst);
+    sim.bounce("server");
+    let n = notify.clone();
+    sim.client("phase1", async move {
+        n.notified().await;
+        Ok(())
+    });
+    sim.run()
+}
+
+#[test]
+fn async_fd_readable_resolves_when_cqe_matures() -> Result {
+    // Submit a Read with non-zero latency, then await AsyncFd::readable.
+    // It must resolve at simulated time = configured latency, without
+    // spinning.
+    let mut builder = Builder::new();
+    builder
+        .fs()
+        .io_latency()
+        .min_latency(std::time::Duration::from_millis(50))
+        .max_latency(std::time::Duration::from_millis(50));
+    let mut sim = builder.build();
+    sim.client("c", async {
+        create_dir_all(TEST_DIR)?;
+        let file = open_rw(&format!("{TEST_DIR}/asyncfd"))?;
+        let fd = types::Fd(file.as_raw_fd());
+        let mut ring = IoUring::new(4).expect("new ring");
+        let async_fd = AsyncFd::new(RingFdHandle(<IoUring as std::os::fd::AsRawFd>::as_raw_fd(
+            &ring,
+        )))
+        .expect("AsyncFd");
+
+        // Seed via the same ring (drained before the AsyncFd test so
+        // the AsyncFd round only sees the latency-bearing read).
+        let payload = b"async ready".to_vec();
+        let w = opcode::Write::new(fd, payload.as_ptr(), payload.len() as u32)
+            .build()
+            .user_data(1);
+        unsafe {
+            ring.submission().push(&w).expect("push w");
+        }
+        ring.submit().expect("submit w");
+        let _ = drain_one(&mut ring).await;
+
+        // Stage a read with 50ms latency.
+        let mut buf = vec![0u8; 11];
+        let r = opcode::Read::new(fd, buf.as_mut_ptr(), buf.len() as u32)
+            .build()
+            .user_data(2);
+        unsafe {
+            ring.submission().push(&r).expect("push r");
+        }
+        ring.submit().expect("submit r");
+
+        let start = tokio::time::Instant::now();
+        let _guard = async_fd.readable().await.expect("readable");
+        let elapsed = start.elapsed();
+        assert!(
+            elapsed >= std::time::Duration::from_millis(50),
+            "AsyncFd::readable resolved before latency: {:?}",
+            elapsed
+        );
+
+        let mut cq = ring.completion();
+        cq.sync();
+        let cqe = cq.next().expect("CQE ready");
+        assert_eq!(cqe.user_data(), 2);
+        assert_eq!(cqe.result(), 11);
+        drop(file);
+        Ok(())
+    });
+    sim.run()
+}
+
+// --- Cross-path integration with the regular fs shim ----------------
+//
+// io_uring does not maintain a parallel filesystem. Reads and writes
+// submitted via a ring land in the same per-host `Fs` state the
+// shim::std::fs and shim::tokio::fs surfaces use. These tests pin the
+// contract: writes from one path are visible to reads on the other,
+// either fsync route flushes either kind of pending write, and a
+// crash drops everything that wasn't synced regardless of which API
+// produced it.
+
+#[test]
+fn mix_shim_write_then_ring_read() -> Result {
+    let mut sim = Builder::new().build();
+    sim.client("c", async {
+        create_dir_all(TEST_DIR)?;
+        let file = open_rw(&format!("{TEST_DIR}/mix1"))?;
+        let fd = types::Fd(file.as_raw_fd());
+        file.write_all_at(b"shim wrote this", 0)?;
+
+        let mut ring = IoUring::new(4).expect("ring");
+        let mut buf = vec![0u8; 15];
+        let r = opcode::Read::new(fd, buf.as_mut_ptr(), buf.len() as u32)
+            .build()
+            .user_data(1);
+        unsafe {
+            ring.submission().push(&r).expect("push");
+        }
+        ring.submit().expect("submit");
+        let cqe = drain_one(&mut ring).await;
+        assert_eq!(cqe.result(), 15);
+        assert_eq!(buf, b"shim wrote this");
+        drop(file);
+        Ok(())
+    });
+    sim.run()
+}
+
+#[test]
+fn mix_ring_write_then_shim_read() -> Result {
+    let mut sim = Builder::new().build();
+    sim.client("c", async {
+        create_dir_all(TEST_DIR)?;
+        let file = open_rw(&format!("{TEST_DIR}/mix2"))?;
+        let fd = types::Fd(file.as_raw_fd());
+
+        let mut ring = IoUring::new(4).expect("ring");
+        let payload = b"ring wrote this".to_vec();
+        let w = opcode::Write::new(fd, payload.as_ptr(), payload.len() as u32)
+            .build()
+            .user_data(1);
+        unsafe {
+            ring.submission().push(&w).expect("push");
+        }
+        ring.submit().expect("submit");
+        let cqe = drain_one(&mut ring).await;
+        assert_eq!(cqe.result(), payload.len() as i32);
+
+        let mut buf = [0u8; 15];
+        let n = file.read_at(&mut buf, 0)?;
+        assert_eq!(n, payload.len());
+        assert_eq!(&buf, payload.as_slice());
+        drop(file);
+        Ok(())
+    });
+    sim.run()
+}
+
+#[test]
+fn mix_interleaved_writes_show_latest() -> Result {
+    let mut sim = Builder::new().build();
+    sim.client("c", async {
+        create_dir_all(TEST_DIR)?;
+        let file = open_rw(&format!("{TEST_DIR}/mix3"))?;
+        let fd = types::Fd(file.as_raw_fd());
+        file.write_all_at(b"AAAAAAAAAA", 0)?;
+
+        let mut ring = IoUring::new(4).expect("ring");
+        let payload = b"BBBBBB".to_vec();
+        let w = opcode::Write::new(fd, payload.as_ptr(), payload.len() as u32)
+            .offset(2)
+            .build()
+            .user_data(1);
+        unsafe {
+            ring.submission().push(&w).expect("push");
+        }
+        ring.submit().expect("submit");
+        let _ = drain_one(&mut ring).await;
+
+        // Shim overwrites bytes 5..7 with C's. Final layout:
+        //   AA BBB CC BAA   (10 bytes)
+        file.write_all_at(b"CC", 5)?;
+
+        let mut buf = [0u8; 10];
+        let r = opcode::Read::new(fd, buf.as_mut_ptr(), buf.len() as u32)
+            .build()
+            .user_data(2);
+        unsafe {
+            ring.submission().push(&r).expect("push");
+        }
+        ring.submit().expect("submit");
+        let cqe = drain_one(&mut ring).await;
+        assert_eq!(cqe.result(), 10);
+        assert_eq!(&buf, b"AABBBCCBAA");
+        drop(file);
+        Ok(())
+    });
+    sim.run()
+}
+
+#[test]
+fn mix_shim_sync_all_flushes_ring_writes() -> Result {
+    use std::sync::atomic::{AtomicBool, Ordering};
+    use std::sync::Arc;
+    use tokio::sync::Notify;
+
+    let mut sim = Builder::new().build();
+    let phase = Arc::new(AtomicBool::new(false));
+    let notify = Arc::new(Notify::new());
+    let phase_host = phase.clone();
+    let notify_host = notify.clone();
+
+    sim.host("server", move || {
+        let phase = phase_host.clone();
+        let notify = notify_host.clone();
+        async move {
+            if !phase.load(Ordering::SeqCst) {
+                create_dir_all(TEST_DIR)?;
+                turmoil::fs::shim::std::fs::sync_dir("/")?;
+                let file = open_rw(&format!("{TEST_DIR}/mix4"))?;
+                let fd = types::Fd(file.as_raw_fd());
+
+                let mut ring = IoUring::new(4).expect("ring");
+                let payload = b"durable via shim sync".to_vec();
+                let w = opcode::Write::new(fd, payload.as_ptr(), payload.len() as u32)
+                    .build()
+                    .user_data(1);
+                unsafe {
+                    ring.submission().push(&w).expect("push");
+                }
+                ring.submit().expect("submit");
+                let _ = drain_one(&mut ring).await;
+
+                // Sync via the SHIM. Must flush the ring-issued write.
+                file.sync_all()?;
+                turmoil::fs::shim::std::fs::sync_dir(TEST_DIR)?;
+                std::mem::forget(file);
+            } else {
+                let file = OpenOptions::new()
+                    .read(true)
+                    .open(format!("{TEST_DIR}/mix4"))?;
+                let mut buf = [0u8; 21];
+                file.read_at(&mut buf, 0)?;
+                assert_eq!(&buf, b"durable via shim sync");
+            }
+            notify.notify_one();
+            std::future::pending::<()>().await;
+            Ok(())
+        }
+    });
+    let n = notify.clone();
+    sim.client("phase0", async move {
+        n.notified().await;
+        Ok(())
+    });
+    sim.run()?;
+    sim.crash("server");
+    phase.store(true, Ordering::SeqCst);
+    sim.bounce("server");
+    let n = notify.clone();
+    sim.client("phase1", async move {
+        n.notified().await;
+        Ok(())
+    });
+    sim.run()
+}
+
+#[test]
+fn mix_ring_fsync_flushes_shim_writes() -> Result {
+    use std::sync::atomic::{AtomicBool, Ordering};
+    use std::sync::Arc;
+    use tokio::sync::Notify;
+
+    let mut sim = Builder::new().build();
+    let phase = Arc::new(AtomicBool::new(false));
+    let notify = Arc::new(Notify::new());
+    let phase_host = phase.clone();
+    let notify_host = notify.clone();
+
+    sim.host("server", move || {
+        let phase = phase_host.clone();
+        let notify = notify_host.clone();
+        async move {
+            if !phase.load(Ordering::SeqCst) {
+                create_dir_all(TEST_DIR)?;
+                turmoil::fs::shim::std::fs::sync_dir("/")?;
+                let file = open_rw(&format!("{TEST_DIR}/mix5"))?;
+                let fd = types::Fd(file.as_raw_fd());
+
+                file.write_all_at(b"durable via ring fsync", 0)?;
+
+                // Sync via the RING. Must flush the shim-issued write.
+                let mut ring = IoUring::new(4).expect("ring");
+                let f = opcode::Fsync::new(fd).build().user_data(1);
+                unsafe {
+                    ring.submission().push(&f).expect("push");
+                }
+                ring.submit().expect("submit");
+                let cqe = drain_one(&mut ring).await;
+                assert_eq!(cqe.result(), 0);
+                turmoil::fs::shim::std::fs::sync_dir(TEST_DIR)?;
+                std::mem::forget(file);
+            } else {
+                let file = OpenOptions::new()
+                    .read(true)
+                    .open(format!("{TEST_DIR}/mix5"))?;
+                let mut buf = [0u8; 22];
+                file.read_at(&mut buf, 0)?;
+                assert_eq!(&buf, b"durable via ring fsync");
+            }
+            notify.notify_one();
+            std::future::pending::<()>().await;
+            Ok(())
+        }
+    });
+    let n = notify.clone();
+    sim.client("phase0", async move {
+        n.notified().await;
+        Ok(())
+    });
+    sim.run()?;
+    sim.crash("server");
+    phase.store(true, Ordering::SeqCst);
+    sim.bounce("server");
+    let n = notify.clone();
+    sim.client("phase1", async move {
+        n.notified().await;
+        Ok(())
+    });
+    sim.run()
+}
+
+// --- Coverage for previously-missing claims --------------------------
+
+#[test]
+fn async_cancel_of_matured_op_drops_buffer_safely() -> Result {
+    // Pins the UAF fix in RingState::cancel: an op whose `when` has
+    // already elapsed must still be cancelable, with its raw-pointer
+    // payload dropped before we'd dereference it. We submit a Read
+    // with zero latency, advance time so the op matures, then cancel
+    // by user_data. The cancel CQE must come back with result=0
+    // (target found in either inflight or ready) and the target's
+    // CQE must be -ECANCELED.
+    let mut sim = Builder::new().build();
+    sim.client("c", async {
+        create_dir_all(TEST_DIR)?;
+        let file = open_rw(&format!("{TEST_DIR}/cancel-matured"))?;
+        let fd = types::Fd(file.as_raw_fd());
+        let mut ring = IoUring::new(4).expect("ring");
+
+        // Seed file so a read would have content.
+        let payload = b"abcdefgh".to_vec();
+        let w = opcode::Write::new(fd, payload.as_ptr(), payload.len() as u32)
+            .build()
+            .user_data(1);
+        unsafe {
+            ring.submission().push(&w).expect("push w");
+        }
+        ring.submit().expect("submit w");
+        let _ = drain_one(&mut ring).await;
+
+        // Submit the read at zero latency so it matures immediately.
+        let mut buf = vec![0u8; payload.len()];
+        let r = opcode::Read::new(fd, buf.as_mut_ptr(), buf.len() as u32)
+            .build()
+            .user_data(50);
+        unsafe {
+            ring.submission().push(&r).expect("push r");
+        }
+        ring.submit().expect("submit r");
+
+        // Yield once to let the runtime advance simulated time so the
+        // read matures into `inflight`/`ready` before the cancel runs.
+        tokio::task::yield_now().await;
+
+        // Cancel by user_data.
+        let c = opcode::AsyncCancel::new(50).build().user_data(51);
+        unsafe {
+            ring.submission().push(&c).expect("push c");
+        }
+        ring.submit().expect("submit c");
+
+        let mut by_ud = std::collections::HashMap::new();
+        for _ in 0..2 {
+            let cqe = drain_one(&mut ring).await;
+            by_ud.insert(cqe.user_data(), cqe.result());
+        }
+        // Outcome depends on whether the read had time to mature
+        // before the cancel. Both outcomes are acceptable: either the
+        // cancel hit it (result 0, target -ECANCELED) or it raced
+        // past completion (cancel sees -ENOENT, target reports the
+        // real read result). The point of the test is that NEITHER
+        // outcome involves a UAF — the slot was either dropped
+        // before we'd dereference its ptr (the cancel-hit branch) or
+        // executed before the cancel arrived (the race-past branch).
+        let read_res = by_ud.get(&50).copied().expect("target CQE");
+        let cancel_res = by_ud.get(&51).copied().expect("cancel CQE");
+        assert!(
+            (cancel_res == 0 && read_res == -125)
+                || (cancel_res == -2 && read_res == payload.len() as i32),
+            "unexpected pair: cancel={cancel_res} read={read_res}"
+        );
+        drop(file);
+        Ok(())
+    });
+    sim.run()
+}
+
+#[test]
+fn async_cancel_of_unknown_user_data_returns_enoent() -> Result {
+    let mut sim = Builder::new().build();
+    sim.client("c", async {
+        let mut ring = IoUring::new(4).expect("ring");
+        let c = opcode::AsyncCancel::new(9999).build().user_data(1);
+        unsafe {
+            ring.submission().push(&c).expect("push");
+        }
+        ring.submit().expect("submit");
+        let cqe = drain_one(&mut ring).await;
+        assert_eq!(cqe.user_data(), 1);
+        assert_eq!(cqe.result(), -2, "expected -ENOENT for unknown user_data");
+        Ok(())
+    });
+    sim.run()
+}
+
+#[test]
+fn builder_setup_sqpoll_rejected() -> Result {
+    let mut sim = Builder::new().build();
+    sim.client("c", async {
+        let res = IoUring::builder().setup_sqpoll(0).build(4);
+        match res {
+            Ok(_) => panic!("expected InvalidInput, got Ok"),
+            Err(e) if e.kind() == std::io::ErrorKind::InvalidInput => {}
+            Err(e) => panic!("expected InvalidInput, got {e:?}"),
+        }
+        Ok(())
+    });
+    sim.run()
+}
+
+#[test]
+fn builder_setup_iopoll_rejected() -> Result {
+    let mut sim = Builder::new().build();
+    sim.client("c", async {
+        let res = IoUring::builder().setup_iopoll().build(4);
+        match res {
+            Ok(_) => panic!("expected InvalidInput, got Ok"),
+            Err(e) if e.kind() == std::io::ErrorKind::InvalidInput => {}
+            Err(e) => panic!("expected InvalidInput, got {e:?}"),
+        }
+        Ok(())
+    });
+    sim.run()
+}
+
+#[test]
+fn async_fd_on_non_ring_fd_errors() -> Result {
+    let mut sim = Builder::new().build();
+    sim.client("c", async {
+        // Open a regular file; its fd is allocated from SIM_FD_BASE
+        // but is NOT registered in io_uring_rings. AsyncFd::new
+        // should reject it.
+        create_dir_all(TEST_DIR)?;
+        let file = open_rw(&format!("{TEST_DIR}/not-a-ring"))?;
+        let res = AsyncFd::new(RingFdHandle(file.as_raw_fd()));
+        match res {
+            Ok(_) => panic!("expected NotFound, got Ok"),
+            Err(e) if e.kind() == std::io::ErrorKind::NotFound => {}
+            Err(e) => panic!("expected NotFound, got {e:?}"),
+        }
+        drop(file);
+        Ok(())
+    });
+    sim.run()
+}
+
+#[test]
+fn rings_are_isolated_per_host() {
+    use std::sync::atomic::{AtomicI32, Ordering};
+    use std::sync::Arc;
+    use tokio::sync::Notify;
+
+    // Each host opens a ring, records its ring fd, and notifies. fds
+    // must be allocated independently per host (both should land at
+    // SIM_FD_BASE since each host has its own `next_fd` counter).
+    let mut sim = Builder::new().build();
+    let h1_fd = Arc::new(AtomicI32::new(0));
+    let h2_fd = Arc::new(AtomicI32::new(0));
+    let n1 = Arc::new(Notify::new());
+    let n2 = Arc::new(Notify::new());
+
+    let f1 = h1_fd.clone();
+    let s1 = n1.clone();
+    sim.host("h1", move || {
+        let f = f1.clone();
+        let s = s1.clone();
+        async move {
+            let ring = IoUring::new(4).expect("ring");
+            f.store(<IoUring as AsRawFd>::as_raw_fd(&ring), Ordering::SeqCst);
+            s.notify_one();
+            std::future::pending::<()>().await;
+            Ok(())
+        }
+    });
+    let f2 = h2_fd.clone();
+    let s2 = n2.clone();
+    sim.host("h2", move || {
+        let f = f2.clone();
+        let s = s2.clone();
+        async move {
+            let ring = IoUring::new(4).expect("ring");
+            f.store(<IoUring as AsRawFd>::as_raw_fd(&ring), Ordering::SeqCst);
+            s.notify_one();
+            std::future::pending::<()>().await;
+            Ok(())
+        }
+    });
+    sim.client("test", async move {
+        n1.notified().await;
+        n2.notified().await;
+        // Both hosts allocated the same fd integer because they have
+        // separate fd tables. Confirms registries are not globally
+        // shared.
+        assert_eq!(h1_fd.load(Ordering::SeqCst), 1 << 30);
+        assert_eq!(h2_fd.load(Ordering::SeqCst), 1 << 30);
+        Ok(())
+    });
+    sim.run().expect("sim");
+}
+
+#[test]
+fn completion_queue_yields_nothing_without_sync() -> Result {
+    // Real Linux: `next()` reads against the userspace head pointer,
+    // which is only updated by `sync()`. A consumer that submits an
+    // op and iterates `completion()` without calling `sync()` first
+    // will see an empty CQ even though the kernel has posted a CQE.
+    // The simulation enforces the same contract so the bug doesn't
+    // hide under turmoil and bite on Linux.
+    let mut sim = Builder::new().build();
+    sim.client("c", async {
+        create_dir_all(TEST_DIR)?;
+        let file = open_rw(&format!("{TEST_DIR}/no-sync"))?;
+        let fd = types::Fd(file.as_raw_fd());
+        let mut ring = IoUring::new(4).expect("new ring");
+
+        // Submit + drain a write so the CQ has a matured CQE waiting.
+        let payload = b"x".to_vec();
+        let w = opcode::Write::new(fd, payload.as_ptr(), 1)
+            .build()
+            .user_data(1);
+        unsafe {
+            ring.submission().push(&w).expect("push");
+        }
+        ring.submit().expect("submit");
+
+        // Without sync(): next() must return None even though there's
+        // a matured CQE in the ring.
+        {
+            let mut cq = ring.completion();
+            assert!(
+                cq.next().is_none(),
+                "next() without sync() must yield nothing"
+            );
+        }
+
+        // After sync(): next() yields the CQE.
+        let mut cq = ring.completion();
+        cq.sync();
+        let cqe = cq.next().expect("after sync, CQE should appear");
+        assert_eq!(cqe.user_data(), 1);
+
+        // Same handle, no second sync(): next() returns None even if
+        // more matured CQEs exist (we only exposed one with the prior
+        // sync). Submit another op to give the ring a CQE.
+        let w2 = opcode::Write::new(fd, payload.as_ptr(), 1)
+            .offset(1)
+            .build()
+            .user_data(2);
+        unsafe {
+            ring.submission().push(&w2).expect("push 2");
+        }
+        ring.submit().expect("submit 2");
+        let mut cq = ring.completion();
+        // Snapshot is empty before sync.
+        assert_eq!(cq.len(), 0);
+        cq.sync();
+        assert_eq!(cq.len(), 1);
+        let cqe = cq.next().expect("second CQE");
+        assert_eq!(cqe.user_data(), 2);
+        // After draining the snapshot, next() returns None until next sync.
+        assert!(cq.next().is_none());
+        drop(file);
+        Ok(())
+    });
+    sim.run()
+}
+
+#[test]
+fn async_fd_readable_wakes_when_ring_dropped() -> Result {
+    // Drop semantics: an AsyncFd::readable() future awaiting on a
+    // ring whose IoUring is dropped must wake (rather than sleep
+    // until its cached deadline). The subsequent snapshot returns
+    // NotFound.
+    use tokio::time::{timeout, Duration as TD};
+    let mut sim = Builder::new().build();
+    sim.client("c", async {
+        let async_fd = {
+            let ring = IoUring::new(4).expect("ring");
+            let fd = <IoUring as AsRawFd>::as_raw_fd(&ring);
+            let async_fd = AsyncFd::new(RingFdHandle(fd)).expect("AsyncFd");
+            // Drop the ring while async_fd is alive.
+            drop(ring);
+            async_fd
+        };
+        // readable() must return Err(NotFound) promptly. Bound the
+        // wait so a regression that sleeps forever shows up as a
+        // timeout rather than a hang.
+        let res = timeout(TD::from_secs(60), async_fd.readable())
+            .await
+            .expect("readable should not hang past deadline");
+        match res {
+            Ok(_) => panic!("expected NotFound after ring drop, got Ok"),
+            Err(e) if e.kind() == std::io::ErrorKind::NotFound => {}
+            Err(e) => panic!("expected NotFound after ring drop, got {e:?}"),
+        }
+        Ok(())
+    });
+    sim.run()
+}
+
+/// Local newtype: AsyncFd::new is generic over `T: AsRawFd`, and we
+/// want to drive it directly from the ring's fd integer rather than
+/// borrowing the IoUring (which would tie up `&mut ring` while we
+/// also need to push more SQEs).
+struct RingFdHandle(std::os::fd::RawFd);
+impl std::os::fd::AsRawFd for RingFdHandle {
+    fn as_raw_fd(&self) -> std::os::fd::RawFd {
+        self.0
+    }
+}
+
+/// Drain one CQE, advancing simulated time as needed.
+///
+/// Awaits the ring's `AsyncFd::readable` so we don't spin: simulated
+/// time auto-advances to the next scheduled completion deadline.
+async fn drain_one(ring: &mut IoUring) -> cqueue::Entry {
+    let async_fd = AsyncFd::new(RingFdHandle(<IoUring as std::os::fd::AsRawFd>::as_raw_fd(
+        ring,
+    )))
+    .expect("AsyncFd");
+    loop {
+        // Scope the cq handle so its borrow of `ring` ends before we
+        // await on async_fd (the readable future doesn't need the
+        // ring, but the borrow checker won't let us hold both).
+        let cqe = {
+            let mut cq = ring.completion();
+            cq.sync();
+            cq.next()
+        };
+        if let Some(cqe) = cqe {
+            return cqe;
+        }
+        let _ = async_fd.readable().await.expect("readable");
+    }
+}

--- a/crates/turmoil/tests/fs/main.rs
+++ b/crates/turmoil/tests/fs/main.rs
@@ -19,6 +19,8 @@ mod cache;
 mod direct_io;
 mod dirs;
 mod durability;
+#[cfg(feature = "unstable-io_uring")]
+mod io_uring;
 mod links;
 mod metadata;
 mod threads;

--- a/crates/turmoil/tests/io_uring_conformance.rs
+++ b/crates/turmoil/tests/io_uring_conformance.rs
@@ -1,0 +1,20 @@
+//! io_uring conformance suite.
+//!
+//! The same body runs against two backends:
+//!
+//! - `sim`: `turmoil::io_uring`, driven inside a turmoil simulation.
+//!   Runs everywhere turmoil compiles.
+//! - `real`: the real `io-uring` 0.7 crate, with `tokio::io::unix::AsyncFd`
+//!   on the ring fd. Linux-only, gated by `--features real-uring-conformance`.
+//!
+//! If both arms pass, consumers can rely on the sim to predict
+//! real-kernel behavior on macOS and Windows.
+
+#![cfg(feature = "unstable-io_uring")]
+
+#[path = "io_uring_conformance/sim_arm.rs"]
+mod sim_arm;
+
+#[cfg(all(target_os = "linux", feature = "real-uring-conformance"))]
+#[path = "io_uring_conformance/real_arm.rs"]
+mod real_arm;

--- a/crates/turmoil/tests/io_uring_conformance/real_arm.rs
+++ b/crates/turmoil/tests/io_uring_conformance/real_arm.rs
@@ -1,0 +1,187 @@
+//! Conformance tests, real backend (Linux io_uring + tokio AsyncFd).
+//!
+//! Mirror image of `sim_arm.rs`. The bodies are deliberately the same
+//! shape so a future refactor could collapse them into a macro; today
+//! the two backends differ enough at the fixture level (file open,
+//! ring construction, AsyncFd type) that explicit duplication is
+//! easier to read than a heavily cfg'd macro.
+
+use io_uring::{opcode, types, IoUring};
+use std::os::fd::AsRawFd;
+use std::path::PathBuf;
+use tempfile::TempDir;
+use tokio::io::unix::AsyncFd;
+
+fn tmp_file(dir: &TempDir, name: &str) -> std::fs::File {
+    let path: PathBuf = dir.path().join(name);
+    std::fs::OpenOptions::new()
+        .read(true)
+        .write(true)
+        .create(true)
+        .truncate(true)
+        .open(path)
+        .expect("open scratch file")
+}
+
+#[tokio::test(flavor = "current_thread")]
+async fn read_returns_full_buffer() {
+    let dir = TempDir::new().unwrap();
+    let file = tmp_file(&dir, "read_full");
+    let payload = b"abcdefghij".to_vec();
+
+    let mut ring = IoUring::new(4).expect("ring");
+    let fd = types::Fd(file.as_raw_fd());
+
+    let w = opcode::Write::new(fd, payload.as_ptr(), payload.len() as u32)
+        .build()
+        .user_data(1);
+    unsafe {
+        ring.submission().push(&w).unwrap();
+    }
+    ring.submit().unwrap();
+    let _ = drain_one(&mut ring).await;
+
+    let mut buf = vec![0u8; payload.len()];
+    let r = opcode::Read::new(fd, buf.as_mut_ptr(), buf.len() as u32)
+        .build()
+        .user_data(2);
+    unsafe {
+        ring.submission().push(&r).unwrap();
+    }
+    ring.submit().unwrap();
+    let cqe = drain_one(&mut ring).await;
+    assert_eq!(cqe.user_data(), 2);
+    assert_eq!(cqe.result(), payload.len() as i32);
+    assert_eq!(buf, payload);
+}
+
+#[tokio::test(flavor = "current_thread")]
+async fn write_then_fsync_completes() {
+    let dir = TempDir::new().unwrap();
+    let file = tmp_file(&dir, "sync");
+
+    let mut ring = IoUring::new(4).expect("ring");
+    let fd = types::Fd(file.as_raw_fd());
+
+    let payload = b"sync me".to_vec();
+    let w = opcode::Write::new(fd, payload.as_ptr(), payload.len() as u32)
+        .build()
+        .user_data(1);
+    unsafe {
+        ring.submission().push(&w).unwrap();
+    }
+
+    let f = opcode::Fsync::new(fd).build().user_data(2);
+    unsafe {
+        ring.submission().push(&f).unwrap();
+    }
+    ring.submit().unwrap();
+
+    let mut by_ud = std::collections::HashMap::new();
+    for _ in 0..2 {
+        let cqe = drain_one(&mut ring).await;
+        by_ud.insert(cqe.user_data(), cqe.result());
+    }
+    assert_eq!(by_ud.get(&1).copied(), Some(payload.len() as i32));
+    assert_eq!(by_ud.get(&2).copied(), Some(0));
+}
+
+#[tokio::test(flavor = "current_thread")]
+async fn read_with_bad_fd_returns_ebadf() {
+    let mut ring = IoUring::new(4).expect("ring");
+    let mut buf = [0u8; 4];
+    let bogus = types::Fd(-1);
+    let r = opcode::Read::new(bogus, buf.as_mut_ptr(), buf.len() as u32)
+        .build()
+        .user_data(1);
+    unsafe {
+        ring.submission().push(&r).unwrap();
+    }
+    ring.submit().unwrap();
+    let cqe = drain_one(&mut ring).await;
+    assert_eq!(cqe.user_data(), 1);
+    assert_eq!(cqe.result(), -9, "expected -EBADF");
+}
+
+#[tokio::test(flavor = "current_thread")]
+async fn cancel_unknown_user_data_returns_enoent() {
+    let mut ring = IoUring::new(4).expect("ring");
+    let c = opcode::AsyncCancel::new(0xdead_beef).build().user_data(1);
+    unsafe {
+        ring.submission().push(&c).unwrap();
+    }
+    ring.submit().unwrap();
+    let cqe = drain_one(&mut ring).await;
+    assert_eq!(cqe.user_data(), 1);
+    assert_eq!(cqe.result(), -2, "expected -ENOENT");
+}
+
+#[tokio::test(flavor = "current_thread")]
+async fn drain_n_cqes_all_accounted_for() {
+    let dir = TempDir::new().unwrap();
+    let file = tmp_file(&dir, "multi");
+    let fd = types::Fd(file.as_raw_fd());
+    let mut ring = IoUring::new(16).expect("ring");
+
+    // Seed 8 distinct bytes at 8 distinct offsets.
+    let payload: Vec<u8> = (0..8).collect();
+    let w = opcode::Write::new(fd, payload.as_ptr(), payload.len() as u32)
+        .build()
+        .user_data(0);
+    unsafe {
+        ring.submission().push(&w).unwrap();
+    }
+    ring.submit().unwrap();
+    let _ = drain_one(&mut ring).await;
+
+    let mut bufs: Vec<[u8; 1]> = vec![[0u8; 1]; 8];
+    for (i, b) in bufs.iter_mut().enumerate() {
+        let r = opcode::Read::new(fd, b.as_mut_ptr(), 1)
+            .offset(i as u64)
+            .build()
+            .user_data(100 + i as u64);
+        unsafe {
+            ring.submission().push(&r).unwrap();
+        }
+    }
+    ring.submit().unwrap();
+
+    let mut seen_uds: Vec<u64> = Vec::new();
+    for _ in 0..8 {
+        let cqe = drain_one(&mut ring).await;
+        assert_eq!(cqe.result(), 1);
+        seen_uds.push(cqe.user_data());
+    }
+    seen_uds.sort_unstable();
+    assert_eq!(seen_uds, (100..108).collect::<Vec<_>>());
+
+    for (i, b) in bufs.iter().enumerate() {
+        assert_eq!(b[0], i as u8, "buf[{i}] = {} expected {i}", b[0]);
+    }
+}
+
+struct RingFdHandle(std::os::fd::RawFd);
+impl std::os::fd::AsRawFd for RingFdHandle {
+    fn as_raw_fd(&self) -> std::os::fd::RawFd {
+        self.0
+    }
+}
+
+async fn drain_one(ring: &mut IoUring) -> io_uring::cqueue::Entry {
+    let async_fd = AsyncFd::with_interest(
+        RingFdHandle(ring.as_raw_fd()),
+        tokio::io::Interest::READABLE,
+    )
+    .expect("AsyncFd");
+    loop {
+        // SAFETY: single consumer of CQ.
+        let mut cq = unsafe { ring.completion_shared() };
+        cq.sync();
+        if let Some(cqe) = cq.next() {
+            return cqe;
+        }
+        drop(cq);
+        let mut guard = async_fd.readable().await.expect("readable");
+        guard.clear_ready();
+    }
+}

--- a/crates/turmoil/tests/io_uring_conformance/sim_arm.rs
+++ b/crates/turmoil/tests/io_uring_conformance/sim_arm.rs
@@ -1,0 +1,219 @@
+//! Conformance tests, sim backend (turmoil::io_uring).
+//!
+//! These exercise read / write / fsync against the simulated ring
+//! and AsyncFd. The same test bodies are mirrored byte-for-byte by
+//! `real_arm.rs`, except for the per-backend fixture (file open and
+//! ring construction).
+
+use std::os::fd::AsRawFd;
+use turmoil::fs::shim::std::fs::{create_dir_all, OpenOptions};
+use turmoil::io_uring::{opcode, types, AsyncFd, IoUring};
+use turmoil::{Builder, Result};
+
+#[test]
+fn read_returns_full_buffer() -> Result {
+    let mut sim = Builder::new().build();
+    sim.client("c", async {
+        create_dir_all("/conformance")?;
+        let file = OpenOptions::new()
+            .read(true)
+            .write(true)
+            .create(true)
+            .open("/conformance/read_full")?;
+        let payload = b"abcdefghij".to_vec();
+
+        let mut ring = IoUring::new(4).expect("ring");
+        let fd = types::Fd(file.as_raw_fd());
+
+        // Seed.
+        let w = opcode::Write::new(fd, payload.as_ptr(), payload.len() as u32)
+            .build()
+            .user_data(1);
+        unsafe {
+            ring.submission().push(&w).unwrap();
+        }
+        ring.submit().unwrap();
+        let _ = drain_one(&mut ring).await;
+
+        // Read full buffer.
+        let mut buf = vec![0u8; payload.len()];
+        let r = opcode::Read::new(fd, buf.as_mut_ptr(), buf.len() as u32)
+            .build()
+            .user_data(2);
+        unsafe {
+            ring.submission().push(&r).unwrap();
+        }
+        ring.submit().unwrap();
+        let cqe = drain_one(&mut ring).await;
+        assert_eq!(cqe.user_data(), 2);
+        assert_eq!(cqe.result(), payload.len() as i32);
+        assert_eq!(buf, payload);
+        Ok(())
+    });
+    sim.run()
+}
+
+#[test]
+fn write_then_fsync_completes() -> Result {
+    let mut sim = Builder::new().build();
+    sim.client("c", async {
+        create_dir_all("/conformance")?;
+        let file = OpenOptions::new()
+            .read(true)
+            .write(true)
+            .create(true)
+            .open("/conformance/sync")?;
+        let mut ring = IoUring::new(4).expect("ring");
+        let fd = types::Fd(file.as_raw_fd());
+
+        let payload = b"sync me".to_vec();
+        let w = opcode::Write::new(fd, payload.as_ptr(), payload.len() as u32)
+            .build()
+            .user_data(1);
+        unsafe {
+            ring.submission().push(&w).unwrap();
+        }
+
+        let f = opcode::Fsync::new(fd).build().user_data(2);
+        unsafe {
+            ring.submission().push(&f).unwrap();
+        }
+        ring.submit().unwrap();
+
+        let mut by_ud = std::collections::HashMap::new();
+        for _ in 0..2 {
+            let cqe = drain_one(&mut ring).await;
+            by_ud.insert(cqe.user_data(), cqe.result());
+        }
+        assert_eq!(by_ud.get(&1).copied(), Some(payload.len() as i32));
+        assert_eq!(by_ud.get(&2).copied(), Some(0));
+        Ok(())
+    });
+    sim.run()
+}
+
+#[test]
+fn read_with_bad_fd_returns_ebadf() -> Result {
+    // Both backends must surface a closed/invalid fd as -EBADF on the
+    // CQE result.
+    let mut sim = Builder::new().build();
+    sim.client("c", async {
+        let mut ring = IoUring::new(4).expect("ring");
+        let mut buf = [0u8; 4];
+        let bogus = types::Fd(-1);
+        let r = opcode::Read::new(bogus, buf.as_mut_ptr(), buf.len() as u32)
+            .build()
+            .user_data(1);
+        unsafe {
+            ring.submission().push(&r).unwrap();
+        }
+        ring.submit().unwrap();
+        let cqe = drain_one(&mut ring).await;
+        assert_eq!(cqe.user_data(), 1);
+        assert_eq!(cqe.result(), -9, "expected -EBADF");
+        Ok(())
+    });
+    sim.run()
+}
+
+#[test]
+fn cancel_unknown_user_data_returns_enoent() -> Result {
+    // Both backends report -ENOENT for a cancel against a user_data
+    // that has no in-flight match.
+    let mut sim = Builder::new().build();
+    sim.client("c", async {
+        let mut ring = IoUring::new(4).expect("ring");
+        let c = opcode::AsyncCancel::new(0xdead_beef).build().user_data(1);
+        unsafe {
+            ring.submission().push(&c).unwrap();
+        }
+        ring.submit().unwrap();
+        let cqe = drain_one(&mut ring).await;
+        assert_eq!(cqe.user_data(), 1);
+        assert_eq!(cqe.result(), -2, "expected -ENOENT");
+        Ok(())
+    });
+    sim.run()
+}
+
+#[test]
+fn drain_n_cqes_all_accounted_for() -> Result {
+    // Both backends must deliver exactly N CQEs for N submitted ops,
+    // each with the correct user_data and (here) result. Order is
+    // not asserted — kernels may shuffle, sim does shuffle.
+    let mut sim = Builder::new().build();
+    sim.client("c", async {
+        create_dir_all("/conformance")?;
+        let file = OpenOptions::new()
+            .read(true)
+            .write(true)
+            .create(true)
+            .open("/conformance/multi")?;
+        let fd = types::Fd(file.as_raw_fd());
+        let mut ring = IoUring::new(16).expect("ring");
+
+        // Seed 8 distinct bytes at 8 distinct offsets.
+        let payload: Vec<u8> = (0..8).collect();
+        let w = opcode::Write::new(fd, payload.as_ptr(), payload.len() as u32)
+            .build()
+            .user_data(0);
+        unsafe {
+            ring.submission().push(&w).unwrap();
+        }
+        ring.submit().unwrap();
+        let _ = drain_one(&mut ring).await;
+
+        // Submit 8 reads, each for a single byte.
+        let mut bufs: Vec<[u8; 1]> = vec![[0u8; 1]; 8];
+        for (i, b) in bufs.iter_mut().enumerate() {
+            let r = opcode::Read::new(fd, b.as_mut_ptr(), 1)
+                .offset(i as u64)
+                .build()
+                .user_data(100 + i as u64);
+            unsafe {
+                ring.submission().push(&r).unwrap();
+            }
+        }
+        ring.submit().unwrap();
+
+        // Drain all 8 and verify each one's result + buffer.
+        let mut seen_uds: Vec<u64> = Vec::new();
+        for _ in 0..8 {
+            let cqe = drain_one(&mut ring).await;
+            assert_eq!(cqe.result(), 1, "each read should report 1 byte");
+            seen_uds.push(cqe.user_data());
+        }
+        seen_uds.sort_unstable();
+        assert_eq!(seen_uds, (100..108).collect::<Vec<_>>());
+
+        // Each buffer should contain its index byte.
+        for (i, b) in bufs.iter().enumerate() {
+            assert_eq!(b[0], i as u8, "buf[{i}] = {} expected {i}", b[0]);
+        }
+        Ok(())
+    });
+    sim.run()
+}
+
+struct RingFdHandle(std::os::fd::RawFd);
+impl std::os::fd::AsRawFd for RingFdHandle {
+    fn as_raw_fd(&self) -> std::os::fd::RawFd {
+        self.0
+    }
+}
+
+async fn drain_one(ring: &mut IoUring) -> turmoil::io_uring::cqueue::Entry {
+    let async_fd =
+        AsyncFd::new(RingFdHandle(<IoUring as AsRawFd>::as_raw_fd(ring))).expect("AsyncFd");
+    loop {
+        let cqe = {
+            let mut cq = ring.completion();
+            cq.sync();
+            cq.next()
+        };
+        if let Some(cqe) = cqe {
+            return cqe;
+        }
+        let _ = async_fd.readable().await.expect("readable");
+    }
+}

--- a/crates/turmoil/tests/io_uring_parity.rs
+++ b/crates/turmoil/tests/io_uring_parity.rs
@@ -1,0 +1,114 @@
+//! Compile-only parity check between our shim and the real
+//! `io-uring` 0.7 crate.
+//!
+//! Run `RUSTFLAGS=--cfg parity_io_uring cargo check -p turmoil
+//! --features unstable-io_uring --tests` on Linux to verify the
+//! shim's API surface matches the real crate's. Any drift — a
+//! method that gained an argument, a constructor that changed its
+//! return type, a missing builder — fails one build and succeeds
+//! the other.
+//!
+//! The test body does no runtime work; it encodes the contract at
+//! the type level via function-pointer coercions and trait-bound
+//! calls. To pin a new guarantee, add another line.
+//!
+//! Linux-only because the real `io-uring` crate is Linux-only;
+//! parity checking on macOS/Windows is meaningless.
+
+#![cfg(all(target_os = "linux", feature = "unstable-io_uring"))]
+#![allow(dead_code, unused_imports)]
+
+#[cfg(parity_io_uring)]
+use io_uring::{cqueue, opcode, squeue, types, Builder, IoUring, Submitter};
+#[cfg(not(parity_io_uring))]
+use turmoil::io_uring::{cqueue, opcode, squeue, types, Builder, IoUring, Submitter};
+
+use std::fmt::Debug;
+use std::io;
+use std::os::fd::{AsRawFd, RawFd};
+
+fn debug<T: Debug>() {}
+fn as_raw_fd<T: AsRawFd>() {}
+
+#[test]
+fn type_surface() {
+    // Core types implement Debug. Builder does NOT — real crate
+    // derives only Clone+Default, so we pin that here by absence.
+    debug::<types::Fd>();
+    debug::<squeue::Entry>();
+    debug::<cqueue::Entry>();
+
+    // The ring exposes its readiness fd via AsRawFd so AsyncFd can
+    // be built on it.
+    as_raw_fd::<IoUring>();
+}
+
+#[test]
+fn ioring_constructors() {
+    // `IoUring::new(entries) -> io::Result<IoUring>`.
+    let _: fn(u32) -> io::Result<IoUring> = IoUring::new;
+
+    // `IoUring::builder() -> Builder`.
+    let _: fn() -> Builder = IoUring::builder;
+}
+
+#[test]
+fn submitter_methods() {
+    // Note: real Submitter::submit takes &self; we accept either
+    // shape via type ascription on the result.
+    fn check(s: &Submitter<'_>) {
+        let _: io::Result<usize> = s.submit();
+        let _: io::Result<usize> = s.submit_and_wait(0);
+    }
+    let _ = check;
+}
+
+#[test]
+fn opcode_builders() {
+    // Read::new(fd, ptr, len) -> Read; .offset(u64) -> Read;
+    // .build() -> squeue::Entry.
+    fn check_read() {
+        let mut buf = [0u8; 0];
+        let r = opcode::Read::new(types::Fd(0), buf.as_mut_ptr(), 0).offset(0);
+        let _: squeue::Entry = r.build();
+    }
+    fn check_write() {
+        let buf = [0u8; 0];
+        let w = opcode::Write::new(types::Fd(0), buf.as_ptr(), 0).offset(0);
+        let _: squeue::Entry = w.build();
+    }
+    fn check_fsync() {
+        let f = opcode::Fsync::new(types::Fd(0));
+        let _: squeue::Entry = f.build();
+    }
+    fn check_cancel() {
+        let c = opcode::AsyncCancel::new(0);
+        let _: squeue::Entry = c.build();
+    }
+    let _ = (check_read, check_write, check_fsync, check_cancel);
+}
+
+#[test]
+fn squeue_entry_builders() {
+    // Entry chains: .user_data(u64) -> Entry, .flags(Flags) -> Entry.
+    fn check(e: squeue::Entry) -> squeue::Entry {
+        e.user_data(0).flags(squeue::Flags::empty())
+    }
+    let _ = check;
+}
+
+#[test]
+fn cqueue_entry_accessors() {
+    fn check(e: &cqueue::Entry) {
+        let _: u64 = e.user_data();
+        let _: i32 = e.result();
+        let _: u32 = e.flags();
+    }
+    let _ = check;
+}
+
+#[test]
+fn types_fd_wraps_rawfd() {
+    // types::Fd is a tuple struct over RawFd in both crates.
+    let _: types::Fd = types::Fd(0 as RawFd);
+}


### PR DESCRIPTION
## Summary

- Adds `turmoil::io_uring`, a Rust-API-shape mirror of the [`io-uring = "0.7"`](https://docs.rs/io-uring/0.7) crate, gated by the new `unstable-io_uring` feature (depends on `unstable-fs`).
- Lets consumers swap their `use io_uring::*` imports behind a feature flag and run their full test suite under turmoil on macOS/Windows. The simulation samples completion latency from the existing fs distribution, RNG-shuffles CQE order, and shares state with `Fs` so ring writes participate in the same `pending`/`sync`/`crash` model as shim writes.
- Three-layer validation mirroring `turmoil-net`'s pattern: sim-only behavior tests, runtime conformance against the real Linux kernel io_uring, and `--cfg parity_io_uring` compile-time signature parity.

## Scope

Implemented:
- `IoUring`, `Builder` (`setup_sqpoll`/`setup_iopoll` rejected with `EINVAL`).
- SQ/CQ types: `submission()`, `submission_shared()`, `completion()`, `completion_shared()`. `CompletionQueue::next()` requires `sync()` first, matching real Linux semantics.
- Opcodes: `Read`, `Write`, `Fsync`, `AsyncCancel`. Anything else is unreachable through the builders.
- `Submitter::{submit, submit_and_wait, submit_with_args}`. `submit_with_args` validates `timespec` shape but does not bound waits (sync API; see doc).
- `AsyncFd<T: AsRawFd>` mirroring `tokio::io::unix::AsyncFd`, driven by per-ring `Notify` + `tokio::time::sleep_until` race in simulated time.
- `as_raw_fd()` on shim std and tokio `File`s, allocating from a `SIM_FD_BASE = 1<<30` range to avoid colliding with real fds.

Out of scope (rejected with `EINVAL` at submit, or simply not exposed):
- SQPOLL, IOPOLL, registered files/buffers, multishot, linked SQEs, BufRing, ReadFixed/WriteFixed.

Behavioral divergences from real Linux that are *documented at the call site*:
- `File::drop` between submit and completion turns the in-flight op's CQE into `-EBADF` (real kernel keeps an `f_count` ref).
- Page cache: two reads at the same offset in one batch — second sees a hit because we insert at submit time. Matches the existing tokio shim model.
- `CompletionQueue::next()` runs the side effect inside the iterator (real kernel pre-materializes).

## Validation

| | macOS | Linux |
|---|---|---|
| `cargo test --features unstable-io_uring` | 271/271 ✓ | 276/276 ✓ |
| `cargo test --features unstable-io_uring,real-uring-conformance` | (real arm cfg-hidden) | 283/283 ✓ |
| `RUSTFLAGS=--cfg=parity_io_uring cargo check --tests` | (parity cfg-hidden) | ✓ |
| `cargo clippy --all-targets -- --deny warnings` | ✓ | ✓ |
| `cargo fmt --check` | ✓ | ✓ |

The conformance suite runs five test bodies (read, write+fsync, EBADF, ENOENT cancel, multi-CQE batch) against both the sim and the real Linux kernel io_uring. All five behaviors agree across backends.

The parity check caught one drift on first run (a `Builder` that derived `Debug` where the real crate doesn't) — fixed pre-merge.

## Test plan

- [x] Sim-only tests pass on macOS.
- [x] Sim-only tests pass on Linux.
- [x] Real-arm conformance compiles and runs against actual Linux kernel io_uring (10/10 conformance tests).
- [x] `RUSTFLAGS=--cfg=parity_io_uring` build resolves shim against real `io-uring` crate without errors.
- [x] All four feature configs build cleanly: `<none>`, `unstable-fs`, `unstable-io_uring`, `unstable-io_uring,real-uring-conformance`.
- [x] `cargo clippy -- --deny warnings` clean across all configs.
- [x] No regressions in existing turmoil-net or fs tests.