### PR TITLE
refactor(fs)!: simplify setup — Fs is now a handle, enter takes no context

### DIFF
--- a/crates/turmoil-fs/README.md
+++ b/crates/turmoil-fs/README.md
@@ -23,7 +23,7 @@ A mocked `File` returns the bytes you prime it with; it doesn't distinguish "in 
 
 ## Structure
 
-- The crate root holds the authoritative filesystem (`Fs`, `FsConfig`, `FsContext`, `FsHandle`): per-host namespace, inode/file table, pending-vs-synced durability state, crash recovery, O_DIRECT alignment rules.
+- The crate root holds the authoritative filesystem (`Fs`, `FsConfig`, `FsContext`): per-host namespace, inode/file table, pending-vs-synced durability state, crash recovery, O_DIRECT alignment rules.
 - `shim::std` / `shim::tokio` — drop-in replacements for the corresponding standard-library and tokio APIs. Every type, method, and error kind mirrors the upstream signature exactly.
 
 ## Embedding
@@ -35,6 +35,8 @@ A mocked `File` returns the bytes you prime it with; it doesn't distinguish "in 
 turmoil = { version = "0.7", features = ["unstable-fs"] }
 ```
 
-If you are building a custom harness, call `install_host_accessor` once per simulation to plug a callback that hands `FsContext::current` (and `FsContext::current_if_set`) the current host's `Arc<Mutex<Fs>>`, simulated time, and RNG.
+If you are building a custom harness, create an `Fs` for each host. Before each
+tick, call `Fs::set_now` and enter the filesystem with `Fs::enter`; filesystem
+shim operations on that thread then use the entered host.
 
 See the [`turmoil` README](../turmoil/README.md) for crash-consistency examples.

--- a/crates/turmoil-fs/src/lib.rs
+++ b/crates/turmoil-fs/src/lib.rs
@@ -26,26 +26,32 @@
 //!   - Pending writes to synced files are lost; durable data survives
 //! - Each host has its own isolated filesystem namespace
 //!
-//! # Embedding
+//! # Setup
 //!
-//! `turmoil-fs` is normally consumed via `turmoil`, which wires it into
-//! the per-host simulation state. If you are building a custom harness,
-//! call [`install_host_accessor`] once per simulation to plug a callback
-//! that hands [`FsContext::current`] (and [`FsContext::current_if_set`])
-//! the current host's filesystem `Arc<Mutex<Fs>>`, simulated time, and
-//! RNG.
+//! ```ignore
+//! let fs = Fs::builder().seed(42).sync_probability(0.1).build();
+//! let _guard = fs.enter();
+//! // shim operations now route through this Fs
+//! ```
+//!
+//! For embedding into a multi-host harness (e.g. `turmoil`), store each
+//! host's `Fs` behind an `Arc<Mutex<Fs>>` and call [`enter`] with a
+//! reference to it each tick.
 
 pub mod shim;
 
 use indexmap::{IndexMap, IndexSet};
 use rand::{Rng, RngCore};
 use rand_distr::{Distribution, Exp};
-use std::cell::{Cell, RefCell};
+use std::cell::RefCell;
 use std::ops::Range;
 use std::os::fd::RawFd;
 use std::path::{Path, PathBuf};
 use std::sync::{Arc, Mutex};
 use std::time::Duration;
+
+/// Type alias for the optional corruption hook stored on [`FsState`].
+pub type CorruptionHook = Option<Arc<dyn Fn(&FsCorruption) + Send + Sync>>;
 
 /// Base value for sim-allocated file descriptors.
 ///
@@ -57,44 +63,23 @@ pub const SIM_FD_BASE: RawFd = 1 << 30;
 
 // ─── Enter pattern ──────────────────────────────────────────────────
 //
-// `Fs::enter(EnterCtx { now, rng })` pushes the current `Fs` plus its
-// per-tick context into a thread-local. While the returned guard is
-// alive, `FsContext::current` reads from that thread-local — no
-// globals, no installed function pointers, just lexically-scoped
-// access. The embedder (`turmoil`) calls `enter` once per host tick.
+// `enter(&arc)` stores the `Arc<Mutex<Fs>>` in a thread-local.
+// While the returned guard is alive, `FsContext::current` reads from
+// that thread-local — no globals, no installed function pointers,
+// just lexically-scoped access. The embedder (`turmoil`) calls
+// `enter` once per host tick.
 //
 // Same shape `turmoil-net` uses for its CURRENT thread-local: the
 // state lives in the entered struct, not in a global registry.
-
-/// Per-tick context handed to [`enter`]. The borrows are valid for
-/// the duration of the returned [`FsEnterGuard`]; dropping the guard
-/// releases them.
-pub struct EnterCtx<'a> {
-    /// Simulated time elapsed since unix epoch on the current host.
-    pub now: Duration,
-    /// Optional hook fired on every silent-corruption event. Used by
-    /// `turmoil`'s `unstable-barriers` integration; `None` for
-    /// embedders that don't observe corruption.
-    pub on_corruption: Option<&'a dyn Fn(&FsCorruption)>,
-}
-
-// Thread-local state set by `enter`, cleared on guard drop.
 //
-// We do NOT hold the `Fs` mutex for the duration of the guard:
-// `FsContext::current` locks it on each call and releases between
-// calls. This avoids deadlocks with `FsHandle`-spawned worker
-// threads that synchronously block the main sim thread (e.g.
-// `std::thread::spawn` + `join`) — the worker locks while the main
-// thread is parked, and the lock is contended only at sub-call
-// granularity.
-type CorruptionPtr = Option<*const dyn Fn(&FsCorruption)>;
+// Simulated time and the corruption hook live on `Fs` directly — no
+// external per-tick injection. The embedder advances `fs.now` before
+// each tick; the hook is set at build time.
 
 thread_local! {
     /// `Arc<Mutex<Fs>>` of the entered fs. Locked on each
     /// `FsContext::current` call, also cloned by `FsHandle::current`.
-    static CURRENT_FS_ARC: RefCell<Option<Arc<Mutex<Fs>>>> = const { RefCell::new(None) };
-    static CURRENT_NOW: Cell<Duration> = const { Cell::new(Duration::ZERO) };
-    static CURRENT_CORRUPTION: Cell<CorruptionPtr> = const { Cell::new(None) };
+    static CURRENT_FS_ARC: RefCell<Option<Arc<Mutex<FsState>>>> = const { RefCell::new(None) };
 }
 
 /// Guard returned by [`enter`]. While alive, the entered `Fs` is the
@@ -104,26 +89,21 @@ thread_local! {
 /// see the docstring on [`enter`] for why. The mutex is locked on
 /// each `FsContext::current` call.
 ///
-/// `enter` calls nest, mirroring `tracing::span`.
+/// `enter` calls nest. Dropping the guard restores the previous
+/// current `Fs` (if any).
 #[must_use = "the entered Fs is only current while the guard is held"]
-pub struct FsEnterGuard<'a> {
-    prev_arc: Option<Arc<Mutex<Fs>>>,
-    prev_now: Duration,
-    prev_corruption: CorruptionPtr,
-    _marker: std::marker::PhantomData<&'a ()>,
+pub struct FsEnterGuard {
+    prev_arc: Option<Arc<Mutex<FsState>>>,
 }
 
-impl<'a> Drop for FsEnterGuard<'a> {
+impl Drop for FsEnterGuard {
     fn drop(&mut self) {
         CURRENT_FS_ARC.with(|c| *c.borrow_mut() = self.prev_arc.take());
-        CURRENT_NOW.with(|c| c.set(self.prev_now));
-        CURRENT_CORRUPTION.with(|c| c.set(self.prev_corruption));
     }
 }
 
 /// Mark `arc`'s `Fs` as the current one for [`FsContext::current`] on
-/// this thread, with the supplied per-tick context (sim time, optional
-/// corruption hook).
+/// this thread.
 ///
 /// While the guard is alive, shim operations on this thread
 /// (`turmoil_fs::shim::std::fs::*` etc.) route through this `Fs`. The
@@ -137,40 +117,14 @@ impl<'a> Drop for FsEnterGuard<'a> {
 ///
 /// `enter` calls nest. Dropping the guard restores the previous
 /// current `Fs` (if any).
-pub fn enter<'a>(arc: &'a Arc<Mutex<Fs>>, ctx: EnterCtx<'a>) -> FsEnterGuard<'a> {
-    // SAFETY of the lifetime erasure: the returned `FsEnterGuard<'a>`
-    // borrows the corruption hook in `ctx` for `'a`. On drop we
-    // restore the previous pointer, so the erased pointer never
-    // outlives `'a`.
-    let corruption_ptr: Option<*const dyn Fn(&FsCorruption)> =
-        ctx.on_corruption.map(|f| {
-            let f_ptr: *const (dyn Fn(&FsCorruption) + 'a) = f;
-            unsafe {
-                std::mem::transmute::<
-                    *const (dyn Fn(&FsCorruption) + 'a),
-                    *const dyn Fn(&FsCorruption),
-                >(f_ptr)
-            }
-        });
-
+pub fn enter(arc: &Arc<Mutex<FsState>>) -> FsEnterGuard {
     let prev_arc = CURRENT_FS_ARC.with(|c| c.borrow_mut().replace(Arc::clone(arc)));
-    let prev_now = CURRENT_NOW.with(|c| c.replace(ctx.now));
-    let prev_corruption = CURRENT_CORRUPTION.with(|c| c.replace(corruption_ptr));
-
-    FsEnterGuard {
-        prev_arc,
-        prev_now,
-        prev_corruption,
-        _marker: std::marker::PhantomData,
-    }
+    FsEnterGuard { prev_arc }
 }
 
-fn fire_corruption(event: &FsCorruption) {
-    if let Some(hook) = CURRENT_CORRUPTION.with(|c| c.get()) {
-        // SAFETY: pointer is valid while the guard that installed it
-        // is alive (single-threaded; we only read on the same thread).
-        let f = unsafe { &*hook };
-        f(event);
+fn fire_corruption(fs: &FsState, event: &FsCorruption) {
+    if let Some(hook) = &fs.on_corruption {
+        hook(event);
     }
 }
 
@@ -182,15 +136,9 @@ thread_local! {
 }
 
 /// Context stored in thread-local for worker threads.
-///
-/// `rng` is not held here — fs owns its own per-host rng on the `Fs`
-/// struct, so a worker thread that locks the `Arc<Mutex<Fs>>` can read
-/// `fs.rng` directly.
 struct WorkerContext {
     /// Shared reference to the filesystem
-    fs: Arc<Mutex<Fs>>,
-    /// Captured simulated time
-    time: Duration,
+    fs: Arc<Mutex<FsState>>,
 }
 
 /// A handle to the current host's filesystem that can be sent to worker threads.
@@ -235,9 +183,7 @@ struct WorkerContext {
 /// may lead to non-deterministic behavior in tests.
 pub struct FsHandle {
     /// Shared reference to the host's filesystem
-    fs: Arc<Mutex<Fs>>,
-    /// Simulated time when the handle was captured
-    time: Duration,
+    fs: Arc<Mutex<FsState>>,
 }
 
 impl FsHandle {
@@ -255,8 +201,7 @@ impl FsHandle {
                 .map(Arc::clone)
                 .expect("turmoil-fs: no Fs is current (call Fs::enter first)")
         });
-        let time = CURRENT_NOW.with(|c| c.get());
-        FsHandle { fs, time }
+        FsHandle { fs }
     }
 
     /// Enter the filesystem context for this thread.
@@ -277,7 +222,6 @@ impl FsHandle {
         WORKER_FS_CONTEXT.with(|ctx| {
             *ctx.borrow_mut() = Some(WorkerContext {
                 fs: Arc::clone(&self.fs),
-                time: self.time,
             });
         });
         FsHandleGuard { _private: () }
@@ -301,23 +245,18 @@ impl Drop for FsHandleGuard {
     }
 }
 
-/// Context for filesystem operations, bundling Fs state with RNG and time.
+/// Context for filesystem operations, bundling Fs state with time.
 ///
-/// This abstracts how the filesystem is accessed, allowing future support
-/// for worker threads that aren't running in the main simulation context.
-/// Borrowed handle to the current host's filesystem state plus the
-/// ambient sim time. Made `pub` so sister crates (notably
-/// `turmoil-io-uring`) can call [`FsContext::current`] when they need
-/// `&mut Fs`. Published-but-unstable surface — not stable for end
-/// users.
+/// Borrowed handle to the current host's filesystem state. Made `pub`
+/// so sister crates (notably `turmoil-io-uring`) can call
+/// [`FsContext::current`] when they need `&mut Fs`.
+/// Published-but-unstable surface — not stable for end users.
 ///
-/// RNG is not in the context — fs owns its own per-host rng on the
-/// `Fs` struct (see [`Fs::rng`]). Call `ctx.fs.rng.random_bool(...)`
-/// etc. directly.
+/// `now` is read from `fs.now` at the time the context is acquired.
 pub struct FsContext<'a> {
     /// The filesystem state
-    pub fs: &'a mut Fs,
-    /// Current simulated time
+    pub fs: &'a mut FsState,
+    /// Current simulated time (snapshot of `fs.now` when context was acquired)
     pub now: Duration,
 }
 
@@ -331,7 +270,7 @@ impl FsContext<'_> {
     ///
     /// Two sources are checked, in order:
     /// 1. The worker thread-local set by [`FsHandle::enter`].
-    /// 2. The thread-local set by [`Fs::enter`] (the main sim thread).
+    /// 2. The thread-local set by [`enter`] (the main sim thread).
     ///
     /// # Panics
     ///
@@ -343,7 +282,7 @@ impl FsContext<'_> {
                 let borrowed = ctx.borrow();
                 let worker_ctx = borrowed.as_ref().unwrap();
                 let mut fs_guard = worker_ctx.fs.lock().unwrap();
-                let now = worker_ctx.time;
+                let now = fs_guard.now;
                 f(FsContext {
                     fs: &mut fs_guard,
                     now,
@@ -353,9 +292,9 @@ impl FsContext<'_> {
 
         let arc = CURRENT_FS_ARC
             .with(|c| c.borrow().as_ref().map(Arc::clone))
-            .expect("turmoil-fs: no Fs is current (call enter first)");
-        let mut lock = arc.lock().expect("Fs mutex poisoned");
-        let now = CURRENT_NOW.with(|c| c.get());
+            .expect("turmoil-fs: no Fs is current (call Fs::enter first)");
+        let mut lock = arc.lock().expect("FsState mutex poisoned");
+        let now = lock.now;
         f(FsContext { fs: &mut lock, now })
     }
 
@@ -367,7 +306,7 @@ impl FsContext<'_> {
                 let borrowed = ctx.borrow();
                 let worker_ctx = borrowed.as_ref().unwrap();
                 let mut fs_guard = worker_ctx.fs.lock().unwrap();
-                let now = worker_ctx.time;
+                let now = fs_guard.now;
                 f(FsContext {
                     fs: &mut fs_guard,
                     now,
@@ -379,8 +318,8 @@ impl FsContext<'_> {
         let Some(arc) = CURRENT_FS_ARC.with(|c| c.borrow().as_ref().map(Arc::clone)) else {
             return;
         };
-        let mut lock = arc.lock().expect("Fs mutex poisoned");
-        let now = CURRENT_NOW.with(|c| c.get());
+        let mut lock = arc.lock().expect("FsState mutex poisoned");
+        let now = lock.now;
         f(FsContext { fs: &mut lock, now });
     }
 
@@ -1093,7 +1032,21 @@ impl PageCache {
 ///
 /// On crash, orphaned files (in `persisted_files` but not `synced_entries`) are removed
 /// since they have no directory entry pointing to them.
-pub struct Fs {
+// TODO: narrow the public surface. turmoil-io-uring currently reaches
+// into individual fields (open_handles, direct_io_fds, page_cache,
+// probability knobs) because its async completion path can't delegate
+// to the synchronous shim.
+pub struct FsState {
+    /// Simulated time elapsed since unix epoch on this host. The
+    /// embedder advances this before each tick (e.g. turmoil sets it
+    /// to `host.timer.since_epoch()` before entering).
+    pub now: Duration,
+
+    /// Optional hook fired on every silent-corruption event. Set at
+    /// build time or mutated on the locked `Fs`. Used by `turmoil`'s
+    /// `unstable-barriers` integration.
+    pub on_corruption: CorruptionHook,
+
     /// Per-host RNG, seeded from the world rng once at `Fs::new` time.
     /// Used for all probabilistic faults (sync_probability,
     /// io_error_probability, corruption_probability, short_read,
@@ -1152,9 +1105,9 @@ pub struct Fs {
     pub page_cache: Option<PageCache>,
 }
 
-impl Fs {
-    /// Create a new empty filesystem with a fresh per-host RNG seeded
-    /// from `seed`. Embedders typically derive `seed` by calling
+impl FsState {
+    /// Create a new empty filesystem state with a fresh per-host RNG
+    /// seeded from `seed`. Embedders typically derive `seed` by calling
     /// `world_rng.next_u64()` at host construction time.
     pub fn new(config: FsConfig, seed: u64) -> Self {
         let mut persisted_dirs = IndexMap::new();
@@ -1167,6 +1120,8 @@ impl Fs {
         let rng: Box<dyn RngCore + Send> = Box::new(rand::rngs::SmallRng::seed_from_u64(seed));
 
         Self {
+            now: Duration::ZERO,
+            on_corruption: None,
             rng,
             persisted_files: IndexMap::new(),
             persisted_dirs,
@@ -2473,8 +2428,146 @@ impl Fs {
     }
 }
 
-impl Default for Fs {
+impl Default for FsState {
     fn default() -> Self {
         Self::new(FsConfig::default(), 0)
+    }
+}
+
+/// Builder for constructing an [`Fs`] with custom configuration.
+///
+/// ```ignore
+/// let fs = Fs::builder()
+///     .seed(42)
+///     .sync_probability(0.1)
+///     .capacity(1024 * 1024)
+///     .build();
+/// ```
+#[derive(Default)]
+pub struct FsBuilder {
+    config: FsConfig,
+    seed: u64,
+    on_corruption: CorruptionHook,
+}
+
+impl FsBuilder {
+    /// Set the RNG seed (default: 0).
+    pub fn seed(mut self, seed: u64) -> Self {
+        self.seed = seed;
+        self
+    }
+
+    /// Set the probability that writes are randomly synced (0.0–1.0).
+    pub fn sync_probability(mut self, value: f64) -> Self {
+        self.config.sync_probability(value);
+        self
+    }
+
+    /// Set disk capacity in bytes per host.
+    pub fn capacity(mut self, bytes: u64) -> Self {
+        self.config.capacity(bytes);
+        self
+    }
+
+    /// Set the probability of I/O errors (0.0–1.0).
+    pub fn io_error_probability(mut self, value: f64) -> Self {
+        self.config.io_error_probability(value);
+        self
+    }
+
+    /// Set the probability of silent data corruption on reads (0.0–1.0).
+    pub fn corruption_probability(mut self, value: f64) -> Self {
+        self.config.corruption_probability(value);
+        self
+    }
+
+    /// Set the probability of short reads (0.0–1.0).
+    pub fn short_read_probability(mut self, value: f64) -> Self {
+        self.config.short_read_probability(value);
+        self
+    }
+
+    /// Set the alignment required for O_DIRECT I/O.
+    pub fn direct_io_alignment(mut self, bytes: u64) -> Self {
+        self.config.direct_io_alignment(bytes);
+        self
+    }
+
+    /// Set the block size for torn-write simulation.
+    pub fn block_size(mut self, bytes: u64) -> Self {
+        self.config.block_size(bytes);
+        self
+    }
+
+    /// Install a corruption hook fired on every silent-corruption event.
+    pub fn on_corruption(mut self, hook: impl Fn(&FsCorruption) + Send + Sync + 'static) -> Self {
+        self.on_corruption = Some(Arc::new(hook));
+        self
+    }
+
+    /// Build the `Fs` from the configured values.
+    pub fn build(self) -> Fs {
+        let mut state = FsState::new(self.config, self.seed);
+        state.on_corruption = self.on_corruption;
+        Fs(Arc::new(Mutex::new(state)))
+    }
+}
+
+/// A simulated filesystem handle.
+///
+/// `Fs` wraps the internal state behind an `Arc<Mutex<...>>`, making
+/// it cheaply cloneable and sendable to worker threads. Construct via
+/// [`Fs::builder`], then call [`Fs::enter`] to install it as the
+/// current filesystem on the calling thread.
+///
+/// ```ignore
+/// let fs = Fs::builder().seed(42).sync_probability(0.1).build();
+/// let _guard = fs.enter();
+/// // shim operations now route through this Fs
+/// ```
+///
+/// For worker threads, clone the handle and call `enter` on the clone:
+///
+/// ```ignore
+/// let fs2 = fs.clone();
+/// std::thread::spawn(move || {
+///     let _guard = fs2.enter();
+///     // filesystem operations work here
+/// });
+/// ```
+#[derive(Clone)]
+pub struct Fs(Arc<Mutex<FsState>>);
+
+impl Fs {
+    /// Returns a builder for constructing an `Fs` with custom
+    /// configuration.
+    pub fn builder() -> FsBuilder {
+        FsBuilder::default()
+    }
+
+    /// Construct from a pre-built `FsState`. Used by embedders (like
+    /// turmoil) that create state with [`FsState::new`] directly.
+    pub fn from_state(state: FsState) -> Self {
+        Fs(Arc::new(Mutex::new(state)))
+    }
+
+    /// Install this `Fs` as the current filesystem on the calling
+    /// thread. While the guard is held, shim operations route through
+    /// this `Fs`.
+    pub fn enter(&self) -> FsEnterGuard {
+        enter(&self.0)
+    }
+
+    /// Lock the inner state for direct mutation. Embedders use this to
+    /// advance simulated time (`fs.lock().now = ...`) or call methods
+    /// like `crash()`.
+    pub fn lock(&self) -> std::sync::MutexGuard<'_, FsState> {
+        self.0.lock().expect("FsState mutex poisoned")
+    }
+}
+
+impl Default for Fs {
+    fn default() -> Self {
+        Fs(Arc::new(Mutex::new(FsState::default())))
     }
 }

--- a/crates/turmoil-fs/src/lib.rs
+++ b/crates/turmoil-fs/src/lib.rs
@@ -34,9 +34,9 @@
 //! // shim operations now route through this Fs
 //! ```
 //!
-//! For embedding into a multi-host harness (e.g. `turmoil`), store each
-//! host's `Fs` behind an `Arc<Mutex<Fs>>` and call [`enter`] with a
-//! reference to it each tick.
+//! For embedding into a multi-host harness (e.g. `turmoil`), store an
+//! `Fs` per host. Before each tick, advance time via `fs.lock().now`
+//! and call `fs.enter()`. Cloning an `Fs` is cheap (shared state).
 
 pub mod shim;
 
@@ -63,7 +63,7 @@ pub const SIM_FD_BASE: RawFd = 1 << 30;
 
 // ─── Enter pattern ──────────────────────────────────────────────────
 //
-// `enter(&arc)` stores the `Arc<Mutex<Fs>>` in a thread-local.
+// `enter(&arc)` stores the `Arc<Mutex<FsState>>` in a thread-local.
 // While the returned guard is alive, `FsContext::current` reads from
 // that thread-local — no globals, no installed function pointers,
 // just lexically-scoped access. The embedder (`turmoil`) calls
@@ -72,13 +72,13 @@ pub const SIM_FD_BASE: RawFd = 1 << 30;
 // Same shape `turmoil-net` uses for its CURRENT thread-local: the
 // state lives in the entered struct, not in a global registry.
 //
-// Simulated time and the corruption hook live on `Fs` directly — no
-// external per-tick injection. The embedder advances `fs.now` before
-// each tick; the hook is set at build time.
+// Simulated time and the corruption hook live on `FsState` directly —
+// no external per-tick injection. The embedder advances
+// `fs.lock().now` before each tick; the hook is set at build time.
 
 thread_local! {
-    /// `Arc<Mutex<Fs>>` of the entered fs. Locked on each
-    /// `FsContext::current` call, also cloned by `FsHandle::current`.
+    /// `Arc<Mutex<FsState>>` of the entered fs. Locked on each
+    /// `FsContext::current` call.
     static CURRENT_FS_ARC: RefCell<Option<Arc<Mutex<FsState>>>> = const { RefCell::new(None) };
 }
 
@@ -102,8 +102,8 @@ impl Drop for FsEnterGuard {
     }
 }
 
-/// Mark `arc`'s `Fs` as the current one for [`FsContext::current`] on
-/// this thread.
+/// Mark `arc`'s `FsState` as the current one for [`FsContext::current`]
+/// on this thread.
 ///
 /// While the guard is alive, shim operations on this thread
 /// (`turmoil_fs::shim::std::fs::*` etc.) route through this `Fs`. The
@@ -177,7 +177,7 @@ struct WorkerContext {
 ///
 /// # Thread Safety
 ///
-/// The handle holds an `Arc<Mutex<Fs>>`, so it is safe to send to other threads.
+/// The handle clones the inner `Arc`, so it is safe to send to other threads.
 /// The mutex ensures exclusive access to the filesystem during operations.
 /// However, users should be aware that concurrent access from multiple threads
 /// may lead to non-deterministic behavior in tests.

--- a/crates/turmoil-fs/src/lib.rs
+++ b/crates/turmoil-fs/src/lib.rs
@@ -35,7 +35,7 @@
 //! ```
 //!
 //! For embedding into a multi-host harness (e.g. `turmoil`), store an
-//! `Fs` per host. Before each tick, advance time via `fs.lock().now`
+//! `Fs` per host. Before each tick, advance time via [`Fs::set_now`]
 //! and call `fs.enter()`. Cloning an `Fs` is cheap (shared state).
 
 pub mod shim;
@@ -74,7 +74,7 @@ pub const SIM_FD_BASE: RawFd = 1 << 30;
 //
 // Simulated time and the corruption hook live on `FsState` directly —
 // no external per-tick injection. The embedder advances
-// `fs.lock().now` before each tick; the hook is set at build time.
+// time with `Fs::set_now` before each tick; the hook is set at build time.
 
 thread_local! {
     /// `Arc<Mutex<FsState>>` of the entered fs. Locked on each
@@ -112,7 +112,7 @@ impl Drop for FsEnterGuard {
 /// **Lock-on-demand:** `enter` does not hold the mutex on `arc`. Each
 /// `FsContext::current` call inside the guard locks the mutex for the
 /// duration of the closure body, then releases it. This sidesteps a
-/// deadlock with [`FsHandle`]-spawned OS threads that synchronously
+/// deadlock with OS threads using cloned [`Fs`] values that synchronously
 /// block the main sim thread (e.g. `std::thread::spawn` + `join`).
 ///
 /// `enter` calls nest. Dropping the guard restores the previous
@@ -128,128 +128,11 @@ fn fire_corruption(fs: &FsState, event: &FsCorruption) {
     }
 }
 
-// Thread-local storage for worker thread filesystem context.
-// When a worker thread calls `FsHandle::enter()`, this stores the context
-// so that `FsContext::current()` can find it.
-thread_local! {
-    static WORKER_FS_CONTEXT: RefCell<Option<WorkerContext>> = const { RefCell::new(None) };
-}
-
-/// Context stored in thread-local for worker threads.
-struct WorkerContext {
-    /// Shared reference to the filesystem
-    fs: Arc<Mutex<FsState>>,
-}
-
-/// A handle to the current host's filesystem that can be sent to worker threads.
-///
-/// Use this to perform filesystem operations from threads spawned outside
-/// the turmoil simulation context (e.g., via `std::thread::spawn` or
-/// `tokio::task::spawn_blocking`).
-///
-/// # Example
-///
-/// ```ignore
-/// use turmoil::fs::FsHandle;
-/// use turmoil::fs::shim::std::fs::{create_dir, write, read};
-///
-/// // In turmoil simulation:
-/// create_dir("/data")?;
-///
-/// // Capture handle to current host's filesystem
-/// let handle = FsHandle::current();
-///
-/// // Spawn worker thread
-/// let worker = std::thread::spawn(move || {
-///     // Enter the filesystem context
-///     let _guard = handle.enter();
-///
-///     // Now filesystem operations work
-///     write("/data/from_worker.txt", b"hello")?;
-///     Ok::<_, std::io::Error>(())
-/// });
-///
-/// worker.join().unwrap()?;
-///
-/// // Data is visible from main thread
-/// assert_eq!(read("/data/from_worker.txt")?, b"hello");
-/// ```
-///
-/// # Thread Safety
-///
-/// The handle clones the inner `Arc`, so it is safe to send to other threads.
-/// The mutex ensures exclusive access to the filesystem during operations.
-/// However, users should be aware that concurrent access from multiple threads
-/// may lead to non-deterministic behavior in tests.
-pub struct FsHandle {
-    /// Shared reference to the host's filesystem
-    fs: Arc<Mutex<FsState>>,
-}
-
-impl FsHandle {
-    /// Capture a handle to the current host's filesystem.
-    ///
-    /// Must be called from within a turmoil simulation context.
-    ///
-    /// # Panics
-    ///
-    /// Panics if called outside a turmoil simulation.
-    pub fn current() -> Self {
-        let fs = CURRENT_FS_ARC.with(|c| {
-            c.borrow()
-                .as_ref()
-                .map(Arc::clone)
-                .expect("turmoil-fs: no Fs is current (call Fs::enter first)")
-        });
-        FsHandle { fs }
-    }
-
-    /// Enter the filesystem context for this thread.
-    ///
-    /// Returns a guard that must be held while performing filesystem operations.
-    /// When the guard is dropped, the context is cleared.
-    ///
-    /// # Example
-    ///
-    /// ```ignore
-    /// let handle = FsHandle::current();
-    /// std::thread::spawn(move || {
-    ///     let _guard = handle.enter();
-    ///     // filesystem operations work here
-    /// });
-    /// ```
-    pub fn enter(&self) -> FsHandleGuard {
-        WORKER_FS_CONTEXT.with(|ctx| {
-            *ctx.borrow_mut() = Some(WorkerContext {
-                fs: Arc::clone(&self.fs),
-            });
-        });
-        FsHandleGuard { _private: () }
-    }
-}
-
-/// Guard that maintains the filesystem context for a worker thread.
-///
-/// When dropped, clears the thread-local context.
-#[must_use = "the filesystem context is only active while this guard is held"]
-pub struct FsHandleGuard {
-    /// Prevent external construction for forward compatibility.
-    _private: (),
-}
-
-impl Drop for FsHandleGuard {
-    fn drop(&mut self) {
-        WORKER_FS_CONTEXT.with(|ctx| {
-            *ctx.borrow_mut() = None;
-        });
-    }
-}
-
 /// Context for filesystem operations, bundling Fs state with time.
 ///
 /// Borrowed handle to the current host's filesystem state. Made `pub`
 /// so sister crates (notably `turmoil-io-uring`) can call
-/// [`FsContext::current`] when they need `&mut Fs`.
+/// [`FsContext::current`] when they need `&mut FsState`.
 /// Published-but-unstable surface — not stable for end users.
 ///
 /// `now` is read from `fs.now` at the time the context is acquired.
@@ -261,35 +144,15 @@ pub struct FsContext<'a> {
 }
 
 impl FsContext<'_> {
-    /// Check if we're in a worker thread context.
-    fn in_worker_context() -> bool {
-        WORKER_FS_CONTEXT.with(|ctx| ctx.borrow().is_some())
-    }
-
     /// Run `f` with the current host's filesystem context.
     ///
-    /// Two sources are checked, in order:
-    /// 1. The worker thread-local set by [`FsHandle::enter`].
-    /// 2. The thread-local set by [`enter`] (the main sim thread).
+    /// The current filesystem is thread-local, so each worker thread
+    /// must call [`Fs::enter`] before using filesystem shims.
     ///
     /// # Panics
     ///
-    /// Panics if called outside both a turmoil simulation and a worker
-    /// thread context.
+    /// Panics if called without an entered [`Fs`] on this thread.
     pub fn current<R>(f: impl FnOnce(FsContext<'_>) -> R) -> R {
-        if Self::in_worker_context() {
-            return WORKER_FS_CONTEXT.with(|ctx| {
-                let borrowed = ctx.borrow();
-                let worker_ctx = borrowed.as_ref().unwrap();
-                let mut fs_guard = worker_ctx.fs.lock().unwrap();
-                let now = fs_guard.now;
-                f(FsContext {
-                    fs: &mut fs_guard,
-                    now,
-                })
-            });
-        }
-
         let arc = CURRENT_FS_ARC
             .with(|c| c.borrow().as_ref().map(Arc::clone))
             .expect("turmoil-fs: no Fs is current (call Fs::enter first)");
@@ -301,20 +164,6 @@ impl FsContext<'_> {
     /// Run `f` if we're in a simulation context, otherwise no-op.
     /// Used in drop paths where the simulation may be shutting down.
     pub fn current_if_set(f: impl FnOnce(FsContext<'_>)) {
-        if Self::in_worker_context() {
-            WORKER_FS_CONTEXT.with(|ctx| {
-                let borrowed = ctx.borrow();
-                let worker_ctx = borrowed.as_ref().unwrap();
-                let mut fs_guard = worker_ctx.fs.lock().unwrap();
-                let now = fs_guard.now;
-                f(FsContext {
-                    fs: &mut fs_guard,
-                    now,
-                });
-            });
-            return;
-        }
-
         let Some(arc) = CURRENT_FS_ARC.with(|c| c.borrow().as_ref().map(Arc::clone)) else {
             return;
         };
@@ -2551,6 +2400,26 @@ impl Fs {
     /// configuration.
     pub fn builder() -> FsBuilder {
         FsBuilder::default()
+    }
+
+    /// Clone the current host's filesystem.
+    ///
+    /// Use this from an entered simulation context to move the current
+    /// filesystem into a worker thread. The worker must call
+    /// [`Fs::enter`] before using filesystem shims.
+    ///
+    /// # Panics
+    ///
+    /// Panics if called without an entered `Fs` on this thread.
+    pub fn current() -> Self {
+        let state = CURRENT_FS_ARC.with(|current| {
+            current
+                .borrow()
+                .as_ref()
+                .map(Arc::clone)
+                .expect("turmoil-fs: no Fs is current (call Fs::enter first)")
+        });
+        Self(state)
     }
 
     /// Install this `Fs` as the current filesystem on the calling

--- a/crates/turmoil-fs/src/lib.rs
+++ b/crates/turmoil-fs/src/lib.rs
@@ -2451,6 +2451,14 @@ pub struct FsBuilder {
 }
 
 impl FsBuilder {
+    /// Replace the entire config at once. Individual builder methods
+    /// (e.g. [`Self::sync_probability`]) override fields within this
+    /// config, so call this first if combining both styles.
+    pub fn config(mut self, config: FsConfig) -> Self {
+        self.config = config;
+        self
+    }
+
     /// Set the RNG seed (default: 0).
     pub fn seed(mut self, seed: u64) -> Self {
         self.seed = seed;

--- a/crates/turmoil-fs/src/lib.rs
+++ b/crates/turmoil-fs/src/lib.rs
@@ -2553,12 +2553,6 @@ impl Fs {
         FsBuilder::default()
     }
 
-    /// Construct from a pre-built `FsState`. Used by embedders (like
-    /// turmoil) that create state with [`FsState::new`] directly.
-    pub fn from_state(state: FsState) -> Self {
-        Fs(Arc::new(Mutex::new(state)))
-    }
-
     /// Install this `Fs` as the current filesystem on the calling
     /// thread. While the guard is held, shim operations route through
     /// this `Fs`.
@@ -2566,11 +2560,18 @@ impl Fs {
         enter(&self.0)
     }
 
-    /// Lock the inner state for direct mutation. Embedders use this to
-    /// advance simulated time (`fs.lock().now = ...`) or call methods
-    /// like `crash()`.
-    pub fn lock(&self) -> std::sync::MutexGuard<'_, FsState> {
-        self.0.lock().expect("FsState mutex poisoned")
+    /// Advance simulated time. The embedder calls this before each
+    /// tick so that timestamps on newly created files reflect the
+    /// simulation clock.
+    pub fn set_now(&self, now: Duration) {
+        self.0.lock().expect("FsState mutex poisoned").now = now;
+    }
+
+    /// Crash this host's filesystem, discarding pending (unsynced)
+    /// writes and orphaning files whose directory entries were never
+    /// synced. See [`FsState::crash`] for the full semantics.
+    pub fn crash(&self) {
+        self.0.lock().expect("FsState mutex poisoned").crash();
     }
 }
 

--- a/crates/turmoil-fs/src/shim/std/fs/mod.rs
+++ b/crates/turmoil-fs/src/shim/std/fs/mod.rs
@@ -795,11 +795,14 @@ impl File {
                 // Fire the installed corruption hook (turmoil's
                 // `unstable-barriers` integration installs this; if
                 // not installed, the call is a no-op).
-                crate::fire_corruption(&crate::FsCorruption {
-                    path: path.clone(),
-                    offset: offset + corrupt_offset as u64,
-                    len: 1,
-                });
+                crate::fire_corruption(
+                    ctx.fs,
+                    &crate::FsCorruption {
+                        path: path.clone(),
+                        offset: offset + corrupt_offset as u64,
+                        len: 1,
+                    },
+                );
             }
 
             Ok(n)
@@ -1748,7 +1751,7 @@ pub fn remove_dir_all<P: AsRef<Path>>(path: P) -> Result<()> {
 }
 
 /// Helper function to recursively remove directory contents.
-fn remove_dir_contents_recursive(fs: &mut crate::Fs, path: &Path) -> Result<()> {
+fn remove_dir_contents_recursive(fs: &mut crate::FsState, path: &Path) -> Result<()> {
     // Get all entries in this directory
     let entries = fs.dir_entries(path);
 

--- a/crates/turmoil-io-uring/src/host.rs
+++ b/crates/turmoil-io-uring/src/host.rs
@@ -184,7 +184,12 @@ impl IoUringContext<'_> {
 
 #[cfg(feature = "fs")]
 pub(crate) fn with_fs_and_io_uring<R>(
-    f: impl FnOnce(&mut turmoil_fs::Fs, &mut IoUringHostState, &mut dyn rand::RngCore, Duration) -> R,
+    f: impl FnOnce(
+        &mut turmoil_fs::FsState,
+        &mut IoUringHostState,
+        &mut dyn rand::RngCore,
+        Duration,
+    ) -> R,
 ) -> R {
     // Lock fs first (matches lock order documented elsewhere in this
     // crate). FsContext::current handles the fs lock; we lock

--- a/crates/turmoil-io-uring/src/sim.rs
+++ b/crates/turmoil-io-uring/src/sim.rs
@@ -8,7 +8,7 @@ use std::os::fd::RawFd;
 use std::sync::Arc;
 use std::time::Duration;
 use tokio::sync::Notify;
-use turmoil_fs::Fs;
+use turmoil_fs::FsState;
 
 /// State for one [`crate::IoUring`] instance, hung off
 /// [`crate::host::IoUringHostState::rings`].
@@ -167,7 +167,7 @@ pub(crate) struct ScheduledCqe {
     pub(crate) apply: PendingApply,
 }
 
-/// What runs against [`Fs`] at completion time.
+/// What runs against [`FsState`] at completion time.
 ///
 /// Held until the [`super::cqueue::CompletionQueue`] iterator yields
 /// the corresponding CQE; only then does the read/write/fsync take
@@ -202,7 +202,7 @@ unsafe impl Sync for PendingApply {}
 
 impl PendingApply {
     /// Execute the op against `fs`, returning the CQE result.
-    pub(crate) fn execute(self, fs: &mut Fs, rng: &mut dyn RngCore, now: Duration) -> i32 {
+    pub(crate) fn execute(self, fs: &mut FsState, rng: &mut dyn RngCore, now: Duration) -> i32 {
         match self {
             PendingApply::ImmediateError(err) => err,
             PendingApply::Read {
@@ -224,7 +224,7 @@ impl PendingApply {
 
 // --- fs effect execution ---------------------------------------------
 //
-// These touch the existing `Fs` API surface (open_handles, read_file,
+// These touch the existing `FsState` API surface (open_handles, read_file,
 // write_file, sync_file) and apply the same probabilistic fault knobs
 // the [`turmoil_fs::shim`] surface does. There is one source of truth
 // for fs behavior: ops submitted via io_uring observe the same
@@ -236,13 +236,13 @@ impl PendingApply {
 // On real Linux, a file submitted via SQE has its open-file struct
 // reference-counted by the kernel; closing the fd does NOT cancel an
 // in-flight op. The simulation resolves the fd at completion time by
-// looking it up in `Fs::open_handles`, so closing the file (dropping
+// looking it up in `FsState::open_handles`, so closing the file (dropping
 // the `shim::std::fs::File`) between submit and completion turns the
 // CQE into `-EBADF` instead of completing normally. Consumers must
 // keep the file alive until they've drained the corresponding CQE.
 
 fn exec_read(
-    fs: &mut Fs,
+    fs: &mut FsState,
     rng: &mut dyn RngCore,
     fd: RawFd,
     ptr: *mut u8,
@@ -295,7 +295,7 @@ fn exec_read(
 }
 
 fn exec_write(
-    fs: &mut Fs,
+    fs: &mut FsState,
     rng: &mut dyn RngCore,
     fd: RawFd,
     ptr: *const u8,
@@ -337,7 +337,7 @@ fn exec_write(
     len as i32
 }
 
-fn exec_fsync(fs: &mut Fs, rng: &mut dyn RngCore, fd: RawFd) -> i32 {
+fn exec_fsync(fs: &mut FsState, rng: &mut dyn RngCore, fd: RawFd) -> i32 {
     let Some(path) = fs.open_handles.get(&fd).cloned() else {
         return -EBADF;
     };
@@ -370,9 +370,9 @@ fn sample_range(rng: &mut dyn RngCore, range: std::ops::Range<usize>) -> usize {
 }
 
 /// O_DIRECT alignment check: pointer, offset, and length must each be
-/// multiples of `Fs::direct_io_alignment`. Mirrors the same check in
+/// multiples of `FsState::direct_io_alignment`. Mirrors the same check in
 /// the sync and tokio shims; real Linux returns `EINVAL` for these.
-fn direct_io_aligned(fs: &Fs, ptr: usize, offset: u64, len: u32) -> bool {
+fn direct_io_aligned(fs: &FsState, ptr: usize, offset: u64, len: u32) -> bool {
     let alignment = fs.direct_io_alignment;
     if alignment == 0 {
         return true;

--- a/crates/turmoil-io-uring/src/submit.rs
+++ b/crates/turmoil-io-uring/src/submit.rs
@@ -78,7 +78,7 @@ impl<'a> Submitter<'a> {
 /// schedule a future CQE or post an immediate `EINVAL` CQE for
 /// unsupported ops.
 fn schedule_pending(
-    fs: &mut turmoil_fs::Fs,
+    fs: &mut turmoil_fs::FsState,
     iou: &mut IoUringHostState,
     rng: &mut dyn rand::RngCore,
     now: Duration,

--- a/crates/turmoil-io-uring/src/types.rs
+++ b/crates/turmoil-io-uring/src/types.rs
@@ -7,7 +7,7 @@ use std::time::Duration;
 ///
 /// Holds the same kind of integer the real crate accepts. In the
 /// simulation the integer is one allocated by
-/// [`turmoil_fs::Fs::alloc_fd`] (file fds) or
+/// [`turmoil_fs::FsState::alloc_fd`] (file fds) or
 /// [`crate::host::IoUringHostState::alloc_ring_fd`] (ring fds),
 /// each from a distinct subrange above `SIM_FD_BASE`. Resolved back to
 /// per-host state at completion time.

--- a/crates/turmoil/src/envelope.rs
+++ b/crates/turmoil/src/envelope.rs
@@ -74,9 +74,9 @@ pub(crate) fn hex(
 
     for (i, &b) in bytes.iter().enumerate() {
         if i < bytes.len() - 1 {
-            write!(f, "{b:#2X}, ")?;
+            write!(f, "{b:#04X}, ")?;
         } else {
-            write!(f, "{b:#2X}")?;
+            write!(f, "{b:#04X}")?;
         }
     }
 

--- a/crates/turmoil/src/host.rs
+++ b/crates/turmoil/src/host.rs
@@ -1,6 +1,6 @@
 use crate::envelope::{hex, Datagram, Protocol, Segment, Syn};
 #[cfg(feature = "unstable-fs")]
-use crate::fs::{Fs, FsConfig, FsState};
+use crate::fs::{Fs, FsConfig};
 #[cfg(feature = "unstable-io_uring")]
 use crate::io_uring::host::IoUringHostState;
 use crate::net::tcp::stream::BidiFlowControl;
@@ -69,19 +69,19 @@ impl Host {
         fs_config: FsConfig,
         fs_seed: u64,
     ) -> Host {
-        let state = FsState::new(fs_config, fs_seed);
+        #[cfg(not(feature = "unstable-barriers"))]
+        let builder = Fs::builder().config(fs_config).seed(fs_seed);
         #[cfg(feature = "unstable-barriers")]
-        let state = {
-            let mut s = state;
-            s.on_corruption = Some(std::sync::Arc::new(crate::fs_corruption_hook));
-            s
-        };
+        let builder = Fs::builder()
+            .config(fs_config)
+            .seed(fs_seed)
+            .on_corruption(crate::fs_corruption_hook);
         Host {
             nodename: nodename.into(),
             addr,
             udp: Udp::new(udp_capacity),
             tcp: Tcp::new(tcp_capacity),
-            fs: Fs::from_state(state),
+            fs: builder.build(),
             #[cfg(feature = "unstable-io_uring")]
             io_uring: Arc::new(Mutex::new(IoUringHostState::new())),
             timer,

--- a/crates/turmoil/src/host.rs
+++ b/crates/turmoil/src/host.rs
@@ -1,6 +1,6 @@
 use crate::envelope::{hex, Datagram, Protocol, Segment, Syn};
 #[cfg(feature = "unstable-fs")]
-use crate::fs::{Fs, FsConfig};
+use crate::fs::{Fs, FsConfig, FsState};
 #[cfg(feature = "unstable-io_uring")]
 use crate::io_uring::host::IoUringHostState;
 use crate::net::tcp::stream::BidiFlowControl;
@@ -15,7 +15,7 @@ use std::io;
 use std::net::{IpAddr, SocketAddr};
 use std::ops::RangeInclusive;
 use std::sync::Arc;
-#[cfg(any(feature = "unstable-fs", feature = "unstable-io_uring"))]
+#[cfg(feature = "unstable-io_uring")]
 use std::sync::Mutex;
 use tokio::sync::{mpsc, Notify};
 use tokio::time::{Duration, Instant};
@@ -46,7 +46,7 @@ pub(crate) struct Host {
 
     /// Simulated filesystem.
     #[cfg(feature = "unstable-fs")]
-    pub(crate) fs: Arc<Mutex<Fs>>,
+    pub(crate) fs: Fs,
 
     /// Per-host io_uring registry: active rings + ring-fd allocator.
     #[cfg(feature = "unstable-io_uring")]
@@ -69,12 +69,19 @@ impl Host {
         fs_config: FsConfig,
         fs_seed: u64,
     ) -> Host {
+        let state = FsState::new(fs_config, fs_seed);
+        #[cfg(feature = "unstable-barriers")]
+        let state = {
+            let mut s = state;
+            s.on_corruption = Some(std::sync::Arc::new(crate::fs_corruption_hook));
+            s
+        };
         Host {
             nodename: nodename.into(),
             addr,
             udp: Udp::new(udp_capacity),
             tcp: Tcp::new(tcp_capacity),
-            fs: Arc::new(Mutex::new(Fs::new(fs_config, fs_seed))),
+            fs: Fs::from_state(state),
             #[cfg(feature = "unstable-io_uring")]
             io_uring: Arc::new(Mutex::new(IoUringHostState::new())),
             timer,

--- a/crates/turmoil/src/lib.rs
+++ b/crates/turmoil/src/lib.rs
@@ -208,7 +208,8 @@ pub use turmoil_fs::FsConfig;
 pub use turmoil_io_uring as io_uring;
 
 /// Hook fired by `turmoil-fs` on every silent-corruption event when
-/// `unstable-barriers` is on. Stored in `EnterCtx::on_corruption`.
+/// `unstable-barriers` is on. Installed on `FsState::on_corruption`
+/// at host construction time.
 #[cfg(all(feature = "unstable-fs", feature = "unstable-barriers"))]
 fn fs_corruption_hook(event: &turmoil_fs::FsCorruption) {
     crate::barriers::trigger_noop(event.clone());

--- a/crates/turmoil/src/sim.rs
+++ b/crates/turmoil/src/sim.rs
@@ -179,7 +179,7 @@ impl<'a> Sim<'a> {
                 World::current(|world| {
                     let addr = world.current.expect("current host missing");
                     let host = world.hosts.get_mut(&addr).unwrap();
-                    host.fs.lock().crash();
+                    host.fs.crash();
                     #[cfg(feature = "unstable-io_uring")]
                     host.io_uring.lock().unwrap().crash();
                 });
@@ -479,7 +479,7 @@ impl<'a> Sim<'a> {
             let is_software_finished = World::enter(&self.world, || {
                 #[cfg(feature = "unstable-fs")]
                 {
-                    fs_handle.lock().now = now;
+                    fs_handle.set_now(now);
                 }
                 #[cfg(feature = "unstable-fs")]
                 let _fs_guard = fs_handle.enter();

--- a/crates/turmoil/src/sim.rs
+++ b/crates/turmoil/src/sim.rs
@@ -513,7 +513,7 @@ impl<'a> Sim<'a> {
         self.steps += 1;
 
         if self.elapsed > self.config.duration && !is_finished {
-            return Err(format!(
+            Err(format!(
                 "Ran for duration: {:?} steps: {} without completing",
                 self.config.duration, self.steps,
             ))?;

--- a/crates/turmoil/src/sim.rs
+++ b/crates/turmoil/src/sim.rs
@@ -179,7 +179,7 @@ impl<'a> Sim<'a> {
                 World::current(|world| {
                     let addr = world.current.expect("current host missing");
                     let host = world.hosts.get_mut(&addr).unwrap();
-                    host.fs.lock().unwrap().crash();
+                    host.fs.lock().crash();
                     #[cfg(feature = "unstable-io_uring")]
                     host.io_uring.lock().unwrap().crash();
                 });
@@ -464,10 +464,10 @@ impl<'a> Sim<'a> {
             // for the whole tick; rt.tick's own World::current calls
             // re-borrow only what they need (rng for net, etc.).
             #[cfg(feature = "unstable-fs")]
-            let (fs_arc, now) = {
+            let (fs_handle, now) = {
                 let world = self.world.borrow();
                 let host = world.hosts.get(&addr).expect("missing host");
-                (Arc::clone(&host.fs), host.timer.since_epoch())
+                (host.fs.clone(), host.timer.since_epoch())
             };
             #[cfg(feature = "unstable-io_uring")]
             let iou_arc = {
@@ -478,16 +478,11 @@ impl<'a> Sim<'a> {
 
             let is_software_finished = World::enter(&self.world, || {
                 #[cfg(feature = "unstable-fs")]
-                let _fs_guard = turmoil_fs::enter(
-                    &fs_arc,
-                    turmoil_fs::EnterCtx {
-                        now,
-                        #[cfg(feature = "unstable-barriers")]
-                        on_corruption: Some(&crate::fs_corruption_hook),
-                        #[cfg(not(feature = "unstable-barriers"))]
-                        on_corruption: None,
-                    },
-                );
+                {
+                    fs_handle.lock().now = now;
+                }
+                #[cfg(feature = "unstable-fs")]
+                let _fs_guard = fs_handle.enter();
                 #[cfg(feature = "unstable-io_uring")]
                 let _iou_guard = turmoil_io_uring::host::enter(
                     &iou_arc,

--- a/crates/turmoil/tests/fs/threads.rs
+++ b/crates/turmoil/tests/fs/threads.rs
@@ -1,12 +1,12 @@
 //! Worker thread filesystem access tests.
 //!
-//! These tests demonstrate using `FsHandle` to perform filesystem
+//! These tests demonstrate using `Fs` to perform filesystem
 //! operations from worker threads spawned outside the turmoil
 //! simulation context.
 
 use std::os::unix::fs::FileExt;
 use turmoil::fs::shim::std::fs::{create_dir, read, write, OpenOptions};
-use turmoil::fs::FsHandle;
+use turmoil::fs::Fs;
 use turmoil::{Builder, Result};
 
 #[test]
@@ -15,13 +15,13 @@ fn worker_thread_basic_io() -> Result {
     sim.client("test", async {
         create_dir("/data")?;
 
-        // Capture handle to current host's filesystem
-        let handle = FsHandle::current();
+        // Capture the current host's filesystem
+        let fs = Fs::current();
 
         // Spawn worker thread
         let worker = std::thread::spawn(move || {
             // Enter the filesystem context
-            let _guard = handle.enter();
+            let _guard = fs.enter();
 
             // Now filesystem operations work
             write("/data/from_worker.txt", b"hello from worker")?;
@@ -43,10 +43,10 @@ fn worker_thread_file_handle() -> Result {
     sim.client("test", async {
         create_dir("/data")?;
 
-        let handle = FsHandle::current();
+        let fs = Fs::current();
 
         let worker = std::thread::spawn(move || {
-            let _guard = handle.enter();
+            let _guard = fs.enter();
 
             // Use OpenOptions and FileExt trait
             let file = OpenOptions::new()
@@ -82,10 +82,10 @@ fn worker_thread_multiple_operations() -> Result {
         create_dir("/data")?;
         write("/data/initial.txt", b"initial data")?;
 
-        let handle = FsHandle::current();
+        let fs = Fs::current();
 
         let worker = std::thread::spawn(move || {
-            let _guard = handle.enter();
+            let _guard = fs.enter();
 
             // Read existing data
             let initial = read("/data/initial.txt")?;
@@ -116,18 +116,18 @@ fn worker_thread_guard_scoping() -> Result {
     sim.client("test", async {
         create_dir("/data")?;
 
-        let handle = FsHandle::current();
+        let fs = Fs::current();
 
         let worker = std::thread::spawn(move || {
             // First scope
             {
-                let _guard = handle.enter();
+                let _guard = fs.enter();
                 write("/data/scoped1.txt", b"scope 1")?;
             }
 
             // Re-enter with new guard
             {
-                let _guard = handle.enter();
+                let _guard = fs.enter();
                 write("/data/scoped2.txt", b"scope 2")?;
             }
 
@@ -152,10 +152,10 @@ fn worker_thread_with_sync() -> Result {
         create_dir("/data")?;
         sync_dir("/")?;
 
-        let handle = FsHandle::current();
+        let fs = Fs::current();
 
         let worker = std::thread::spawn(move || {
-            let _guard = handle.enter();
+            let _guard = fs.enter();
 
             let file = OpenOptions::new()
                 .read(true)


### PR DESCRIPTION
## Summary

- `Fs` is now a thin `Clone` handle wrapping `Arc<Mutex<FsState>>` — the mutex is hidden from callers.
- Setup is just `let fs = Fs::builder().seed(42).build(); let _guard = fs.enter();`
- Removed `EnterCtx` — simulated time and corruption hook live on `FsState` directly. Three thread-locals collapsed to one.
- `FsState` (formerly `Fs`) is the internal state struct, still pub for turmoil-io-uring's async completion path.

## Test plan

- [x] `cargo test --workspace` — all pass
- [x] `cargo test -p turmoil --features unstable-io_uring,unstable-barriers --test fs --test io_uring_conformance` — 137 tests pass
- [x] `cargo clippy` clean across all four crates
- [x] `cargo fmt --check` clean